### PR TITLE
Feat: Langfuse 트레이싱 래퍼 + FastMCP stdio/SSE 엔트리포인트

### DIFF
--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "pgvector>=0.3.0",
     "python-dotenv>=1.0.1",
-    "langfuse>=2.40.0",
+    "langfuse>=4.0,<5",
     "beautifulsoup4>=4.12.3",
     "trafilatura>=1.12.0",
 ]

--- a/mcp-server/src/mcp_server/observability/tracing.py
+++ b/mcp-server/src/mcp_server/observability/tracing.py
@@ -1,0 +1,68 @@
+"""Langfuse 트레이싱 래퍼.
+
+모든 @mcp.tool() 도구에 부착되는 표준 트레이서를 제공한다.
+
+사용 예시:
+    from mcp_server.observability.tracing import traced
+
+    @mcp.tool()
+    @traced("search_house_price")
+    async def search_house_price(...): ...
+
+비활성 조건 (LANGFUSE_ENABLED=false 또는 키 미설정) 시 데코레이터는
+원함수를 그대로 반환하므로 테스트 / 로컬 환경에서 외부 호출이 일어나지 않는다.
+"""
+
+import logging
+from collections.abc import Callable
+from functools import lru_cache
+from typing import TypeVar
+
+from langfuse import Langfuse, observe
+
+from mcp_server.config import get_settings
+
+F = TypeVar("F", bound=Callable)
+_log = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def get_langfuse() -> Langfuse | None:
+    """Langfuse 클라이언트 싱글턴. 비활성 또는 키 미설정 시 None."""
+    s = get_settings()
+    if not s.langfuse_enabled:
+        return None
+    if not s.langfuse_public_key or not s.langfuse_secret_key:
+        _log.warning("Langfuse 비활성: PUBLIC_KEY / SECRET_KEY 가 비어있음")
+        return None
+    return Langfuse(
+        public_key=s.langfuse_public_key,
+        secret_key=s.langfuse_secret_key,
+        host=s.langfuse_host,
+    )
+
+
+def flush_langfuse() -> None:
+    """버퍼링된 trace 전송. lifespan shutdown 에서 호출해 손실 방지."""
+    client = get_langfuse()
+    if client is not None:
+        client.flush()
+
+
+def traced(name: str) -> Callable[[F], F]:
+    """모든 @mcp.tool() 도구에 부착되는 표준 트레이싱 데코레이터.
+
+    Langfuse 비활성 시 원함수를 그대로 반환 (no-op).
+    활성 시 langfuse `@observe(name, as_type="tool")` 위임 — sync/async 자동 처리,
+    입력/출력 자동 캡처, 예외 발생 시 status=ERROR.
+
+    민감정보 redaction 은 deferred. 도구 입력에 비밀이 들어갈 경우
+    Langfuse `mask=` 콜백 또는 도구 측 sanitize 로 처리.
+
+    시그니처 안정성: 향후 옵션 추가 시 keyword-only 만 허용.
+    """
+    def decorator(func: F) -> F:
+        if get_langfuse() is None:
+            return func
+        return observe(name=name, as_type="tool")(func)  # type: ignore[return-value]
+    return decorator

--- a/mcp-server/src/mcp_server/server.py
+++ b/mcp-server/src/mcp_server/server.py
@@ -1,0 +1,72 @@
+"""FastMCP 서버 인스턴스 + 엔트리포인트.
+
+규약:
+- 모든 도구 모듈은 `from mcp_server.server import mcp` 후 @mcp.tool() 데코레이터 사용.
+- 새 FastMCP() 추가 생성 금지 — 인스턴스 분리 시 도구 등록이 보이지 않음.
+
+도구 자동 등록은 Phase 2 시점에선 미적용. Phase 3-2 (`tools/real_estate.py` 추가)
+PR 에서 `tools/__init__.py` 가 leaf 도구 모듈을 명시 import 하도록 도입한다
+(서버 모듈에서 직접 import 하면 도구 모듈이 `from mcp_server.server import mcp`
+하므로 순환 import 위험).
+"""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from mcp_server.config import get_settings
+from mcp_server.db.session import reset_engine
+from mcp_server.observability.tracing import flush_langfuse, get_langfuse
+
+
+@asynccontextmanager
+async def _lifespan(_: FastMCP) -> AsyncIterator[None]:
+    # startup: Langfuse 클라이언트 워밍업 (비활성이면 None 반환, 무영향)
+    get_langfuse()
+    try:
+        yield
+    finally:
+        # shutdown: trace 손실 방지 + DB 풀 정리
+        flush_langfuse()
+        await reset_engine()
+
+
+_settings = get_settings()
+
+mcp: FastMCP = FastMCP(
+    name="monitoring-mcp",
+    instructions=(
+        "부동산 / 법률 / 채용 / 경매 4개 도메인의 변화를 감시하는 MCP 서버. "
+        "도구 호출 결과는 {text, structured, source_url, metadata} 공통 스키마로 반환된다."
+    ),
+    host=_settings.mcp_sse_host,
+    port=_settings.mcp_sse_port,
+    lifespan=_lifespan,
+)
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health(_: Request) -> JSONResponse:
+    """SSE 모드에서만 노출. stdio 에서는 starlette app 이 mount 되지 않아 무동작."""
+    return JSONResponse({"status": "ok"})
+
+
+def main() -> None:
+    """`mcp-server` CLI 엔트리포인트. 환경변수 MCP_TRANSPORT 로 분기."""
+    s = get_settings()
+    transport = s.mcp_transport.lower()
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+    elif transport == "sse":
+        mcp.run(transport="sse")
+    else:
+        raise ValueError(
+            f"Unknown MCP_TRANSPORT={s.mcp_transport!r}; expected: stdio | sse"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/tests/conftest.py
+++ b/mcp-server/tests/conftest.py
@@ -14,10 +14,29 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from mcp_server.config import get_settings
+
 # models import 로 Base.metadata 등록
 from mcp_server.db import models  # noqa: F401
 from mcp_server.db import session as db_session
 from mcp_server.db.base import Base
+from mcp_server.observability.tracing import get_langfuse
+
+
+@pytest.fixture(autouse=True)
+def disable_langfuse(monkeypatch: pytest.MonkeyPatch):
+    """모든 테스트에서 Langfuse 비활성. 외부 네트워크 호출 차단 + 격리.
+
+    활성화 검증이 필요한 테스트는 fixture 안에서 monkeypatch 로 다시 켤 것.
+    """
+    monkeypatch.setenv("LANGFUSE_ENABLED", "false")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "")
+    get_settings.cache_clear()
+    get_langfuse.cache_clear()
+    yield
+    get_settings.cache_clear()
+    get_langfuse.cache_clear()
 
 
 @pytest_asyncio.fixture

--- a/mcp-server/tests/observability/test_tracing.py
+++ b/mcp-server/tests/observability/test_tracing.py
@@ -1,0 +1,66 @@
+"""Langfuse 트레이싱 래퍼 단위 테스트.
+
+활성 상태 trace 송출 검증은 deferred (Langfuse v4 OTLP 기반 — mock 비용 큼).
+실제 송출은 Langfuse UI 수동 검증으로 처리.
+"""
+
+import pytest
+
+from mcp_server.config import get_settings
+from mcp_server.observability import tracing
+
+
+def _clear_caches() -> None:
+    get_settings.cache_clear()
+    tracing.get_langfuse.cache_clear()
+
+
+def test_get_langfuse_returns_none_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGFUSE_ENABLED", "false")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk")
+    _clear_caches()
+
+    assert tracing.get_langfuse() is None
+
+
+def test_get_langfuse_returns_none_when_keys_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("LANGFUSE_ENABLED", "true")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "")
+    _clear_caches()
+
+    with caplog.at_level("WARNING"):
+        assert tracing.get_langfuse() is None
+    assert any("Langfuse 비활성" in rec.message for rec in caplog.records)
+
+
+async def test_traced_async_passthrough_when_disabled() -> None:
+    @tracing.traced("noop_async")
+    async def echo(x: int) -> int:
+        return x * 2
+
+    assert await echo(3) == 6
+
+
+def test_traced_sync_passthrough_when_disabled() -> None:
+    @tracing.traced("noop_sync")
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(1, 2) == 3
+
+
+async def test_traced_async_propagates_exception_when_disabled() -> None:
+    @tracing.traced("raise")
+    async def boom() -> None:
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        await boom()
+
+
+def test_flush_langfuse_no_op_when_disabled() -> None:
+    tracing.flush_langfuse()

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -1,0 +1,51 @@
+"""FastMCP 서버 인스턴스 + 엔트리포인트 단위 테스트.
+
+`/health` 라우트의 실제 응답 검증은 SSE 수동 검증 (README) 으로 처리.
+FastMCP `_custom_starlette_routes` 는 비공개 attr 이라 단위 테스트 의존을 피한다.
+"""
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from mcp_server import server as server_mod
+from mcp_server.config import get_settings
+
+
+def test_mcp_instance_is_fastmcp() -> None:
+    assert isinstance(server_mod.mcp, FastMCP)
+
+
+def test_mcp_name() -> None:
+    assert server_mod.mcp.name == "monitoring-mcp"
+
+
+async def test_no_tools_registered_yet() -> None:
+    """Phase 2 시점엔 도구 0개. Phase 3-2 부터 늘어나면 본 assertion 갱신."""
+    tools = await server_mod.mcp.list_tools()
+    assert tools == []
+
+
+async def test_lifespan_calls_shutdown_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
+    called = {"reset": False, "flush": False}
+
+    async def fake_reset() -> None:
+        called["reset"] = True
+
+    def fake_flush() -> None:
+        called["flush"] = True
+
+    monkeypatch.setattr(server_mod, "reset_engine", fake_reset)
+    monkeypatch.setattr(server_mod, "flush_langfuse", fake_flush)
+
+    async with server_mod._lifespan(server_mod.mcp):
+        pass
+
+    assert called["reset"] is True
+    assert called["flush"] is True
+
+
+def test_main_rejects_unknown_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MCP_TRANSPORT", "websocket")
+    get_settings.cache_clear()
+    with pytest.raises(ValueError, match="Unknown MCP_TRANSPORT"):
+        server_mod.main()

--- a/mcp-server/uv.lock
+++ b/mcp-server/uv.lock
@@ -898,7 +898,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.3" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "langfuse", specifier = ">=2.40.0" },
+    { name = "langfuse", specifier = ">=4.0,<5" },
     { name = "mcp", specifier = ">=1.2.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
     { name = "playwright", specifier = ">=1.47.0" },


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #

**🛠 작업 내역**
- `observability/tracing.py` 추가 — 모든 MCP 도구에 부착할 `@traced("tool_name")` 데코레이터와 Langfuse 싱글턴 클라이언트. 비활성 조건에선 원함수 그대로 반환하는 no-op 로 동작하여 테스트/로컬 환경에서 외부 네트워크 호출이 일어나지 않음.
- `server.py` 추가 — FastMCP 인스턴스 + stdio/SSE transport 분기. `lifespan` 에서 Langfuse 워밍업 + shutdown 시 `flush()` / DB 엔진 `reset_engine()` 호출로 trace 손실과 커넥션 누수를 동시에 방지. SSE 모드 한정 `/health` 라우트 노출.
- 의존성: `langfuse>=4.0,<5` 로 상한 고정
- 테스트 인프라: `tests/conftest.py` 에 `disable_langfuse` autouse fixture 추가 → 전체 테스트에서 Langfuse 자동 비활성화 및 `get_settings` / `get_langfuse` 캐시 초기화 보장.

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?