### PR TITLE
Feat/real estate multi source

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -42,5 +42,15 @@ MCP_SSE_PORT=8090
 # ─────────────────────────────────────────────
 
 # ── 부동산 (국토교통부) ──
-# 아파트 매매 실거래가 — 엔드포인트: RTMSDataSvcAptTradeDev/getRTMSDataSvcAptTradeDev
-MOLIT_TRADE_API_KEY=
+# 활용 신청은 자료유형 단위로 승인되므로 변수도 자료유형별로 분리.
+# 실제 발급 키가 동일해도 변수는 나눠두면 추후 권한·키 교체 운영이 쉬움.
+# 아파트 매매 실거래가 — RTMSDataSvcAptTradeDev/getRTMSDataSvcAptTradeDev
+MOLIT_APT_TRADE_API_KEY=
+# 아파트 전월세 실거래가 — RTMSDataSvcAptRent/getRTMSDataSvcAptRent
+MOLIT_APT_RENT_API_KEY=
+# 오피스텔 매매 실거래가 — RTMSDataSvcOffiTrade/getRTMSDataSvcOffiTrade
+MOLIT_OFFI_TRADE_API_KEY=
+# 오피스텔 전월세 실거래가 — RTMSDataSvcOffiRent/getRTMSDataSvcOffiRent
+MOLIT_OFFI_RENT_API_KEY=
+# 연립다세대 전월세 실거래가 — RTMSDataSvcRHRent/getRTMSDataSvcRHRent
+MOLIT_RH_RENT_API_KEY=

--- a/mcp-server/scripts/export_tool_schema.py
+++ b/mcp-server/scripts/export_tool_schema.py
@@ -17,10 +17,15 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from mcp_server.tools.real_estate import SearchHousePriceInput
+from mcp_server.tools.real_estate import MolitRealEstateInput
 
+# 부동산 5종 모두 region + deal_ymd 공통 입력 모델을 공유.
 _TOOL_INPUT_MODELS: dict[str, type[BaseModel]] = {
-    "search_house_price": SearchHousePriceInput,
+    "search_house_price": MolitRealEstateInput,
+    "search_apt_rent": MolitRealEstateInput,
+    "search_offi_trade": MolitRealEstateInput,
+    "search_offi_rent": MolitRealEstateInput,
+    "search_rh_rent": MolitRealEstateInput,
 }
 
 

--- a/mcp-server/scripts/seed_real_estate_source.py
+++ b/mcp-server/scripts/seed_real_estate_source.py
@@ -1,10 +1,11 @@
 """부동산 도메인 api_source row 등록.
 
-국토교통부 아파트 매매 실거래가 메타데이터를 mcp 내부 DB 의 api_source 테이블에 시드한다.
-멱등: tool_name='search_house_price' row 가 이미 있으면 update, 없으면 insert.
+국토교통부 부동산 실거래가 5종 자료유형 메타데이터를 mcp 내부 DB 의
+api_source 테이블에 시드한다.
+멱등: 각 row 는 tool_name 기준으로 존재하면 update, 없으면 insert.
 
 서비스 키(serviceKey) 는 param_schema 에 포함하지 않는다.
-도구 레이어가 settings.molit_apt_trade_api_key 를 로드해 호출 시점에 합성하는 책임.
+도구 레이어가 settings.molit_*_api_key 를 로드해 호출 시점에 합성하는 책임.
 
 사용법:
     cd mcp-server
@@ -19,12 +20,9 @@ from sqlalchemy import select
 from mcp_server.db.models import ApiSource
 from mcp_server.db.session import get_session, reset_engine
 
-TOOL_NAME = "search_house_price"
-SOURCE_NAME = "국토교통부 아파트 매매 실거래가"
-URL_TEMPLATE = (
-    "https://apis.data.go.kr/1613000/RTMSDataSvcAptTradeDev/getRTMSDataSvcAptTradeDev"
-)
-PARAM_SCHEMA: dict = {
+# 5종 모두 동일한 호출 파라미터 스키마 (LAWD_CD + DEAL_YMD + 페이지네이션).
+# 자료유형마다 응답 XML 필드는 다르지만, 요청 인자는 MOLIT 공통.
+_COMMON_PARAM_SCHEMA: dict = {
     "type": "object",
     "required": ["LAWD_CD", "DEAL_YMD"],
     "properties": {
@@ -48,36 +46,82 @@ PARAM_SCHEMA: dict = {
     },
 }
 
+_BASE_URL = "https://apis.data.go.kr/1613000"
 
-async def seed() -> None:
+# tool_name 은 추후 추가될 MCP 도구 함수명과 1:1 매핑.
+# (현재는 search_house_price 만 도구로 등록돼 있음 — 나머지는 도구 추가와 함께 활성화)
+SOURCES: list[dict] = [
+    {
+        "tool_name": "search_house_price",
+        "name": "국토교통부 아파트 매매 실거래가",
+        "url_template": f"{_BASE_URL}/RTMSDataSvcAptTradeDev/getRTMSDataSvcAptTradeDev",
+        "param_schema": _COMMON_PARAM_SCHEMA,
+    },
+    {
+        "tool_name": "search_apt_rent",
+        "name": "국토교통부 아파트 전월세 실거래가",
+        "url_template": f"{_BASE_URL}/RTMSDataSvcAptRent/getRTMSDataSvcAptRent",
+        "param_schema": _COMMON_PARAM_SCHEMA,
+    },
+    {
+        "tool_name": "search_offi_trade",
+        "name": "국토교통부 오피스텔 매매 실거래가",
+        "url_template": f"{_BASE_URL}/RTMSDataSvcOffiTrade/getRTMSDataSvcOffiTrade",
+        "param_schema": _COMMON_PARAM_SCHEMA,
+    },
+    {
+        "tool_name": "search_offi_rent",
+        "name": "국토교통부 오피스텔 전월세 실거래가",
+        "url_template": f"{_BASE_URL}/RTMSDataSvcOffiRent/getRTMSDataSvcOffiRent",
+        "param_schema": _COMMON_PARAM_SCHEMA,
+    },
+    {
+        "tool_name": "search_rh_rent",
+        "name": "국토교통부 연립다세대 전월세 실거래가",
+        "url_template": f"{_BASE_URL}/RTMSDataSvcRHRent/getRTMSDataSvcRHRent",
+        "param_schema": _COMMON_PARAM_SCHEMA,
+    },
+]
+
+
+async def _upsert_source(spec: dict) -> None:
+    """단일 자료유형 upsert. tool_name 기준 멱등."""
     async with get_session() as session:
         existing = await session.execute(
-            select(ApiSource).where(ApiSource.tool_name == TOOL_NAME)
+            select(ApiSource).where(ApiSource.tool_name == spec["tool_name"])
         )
         row = existing.scalar_one_or_none()
 
         if row is None:
             row = ApiSource(
-                tool_name=TOOL_NAME,
-                name=SOURCE_NAME,
-                url_template=URL_TEMPLATE,
-                param_schema=PARAM_SCHEMA,
+                tool_name=spec["tool_name"],
+                name=spec["name"],
+                url_template=spec["url_template"],
+                param_schema=spec["param_schema"],
             )
             session.add(row)
-            print(f"[+] api_source insert: tool_name={TOOL_NAME}", file=sys.stderr)
-        else:
-            row.name = SOURCE_NAME
-            row.url_template = URL_TEMPLATE
-            row.param_schema = PARAM_SCHEMA
+            await session.commit()
+            await session.refresh(row)
             print(
-                f"[~] api_source update: id={row.id}, tool_name={TOOL_NAME}",
+                f"[+] api_source insert: id={row.id}, tool_name={spec['tool_name']}",
+                file=sys.stderr,
+            )
+        else:
+            row.name = spec["name"]
+            row.url_template = spec["url_template"]
+            row.param_schema = spec["param_schema"]
+            await session.commit()
+            await session.refresh(row)
+            print(
+                f"[~] api_source update: id={row.id}, tool_name={spec['tool_name']}",
                 file=sys.stderr,
             )
 
-        await session.commit()
-        await session.refresh(row)
-        print(f"[OK] api_source.id={row.id}", file=sys.stderr)
 
+async def seed() -> None:
+    for spec in SOURCES:
+        await _upsert_source(spec)
+    print(f"[OK] seeded {len(SOURCES)} api_source row(s)", file=sys.stderr)
     await reset_engine()
 
 

--- a/mcp-server/scripts/seed_real_estate_source.py
+++ b/mcp-server/scripts/seed_real_estate_source.py
@@ -4,7 +4,7 @@
 멱등: tool_name='search_house_price' row 가 이미 있으면 update, 없으면 insert.
 
 서비스 키(serviceKey) 는 param_schema 에 포함하지 않는다.
-도구 레이어가 settings.molit_trade_api_key 를 로드해 호출 시점에 합성하는 책임.
+도구 레이어가 settings.molit_apt_trade_api_key 를 로드해 호출 시점에 합성하는 책임.
 
 사용법:
     cd mcp-server

--- a/mcp-server/src/mcp_server/config.py
+++ b/mcp-server/src/mcp_server/config.py
@@ -42,9 +42,27 @@ class Settings(BaseSettings):
     # 도메인별 외부 API 키 — 도메인 추가 시 여기 누적.
     # default="" 유지: 키 미발급 상태에서도 import/단위 테스트는 가능해야 함.
     # 실제 호출 직전 도구 레이어에서 빈 값이면 거부하는 책임.
-    molit_trade_api_key: str = Field(
+    # data.go.kr 활용 신청은 자료유형 단위로 승인되므로 자료유형마다 변수 분리.
+    # 실신청은 동일 서비스키여도 변수를 나눠두면 추후 키 교체·권한 분리에 유리.
+    molit_apt_trade_api_key: str = Field(
         default="",
         description="국토교통부 아파트 매매 실거래가 (RTMSDataSvcAptTradeDev) 서비스 키.",
+    )
+    molit_apt_rent_api_key: str = Field(
+        default="",
+        description="국토교통부 아파트 전월세 실거래가 (RTMSDataSvcAptRent) 서비스 키.",
+    )
+    molit_offi_trade_api_key: str = Field(
+        default="",
+        description="국토교통부 오피스텔 매매 실거래가 (RTMSDataSvcOffiTrade) 서비스 키.",
+    )
+    molit_offi_rent_api_key: str = Field(
+        default="",
+        description="국토교통부 오피스텔 전월세 실거래가 (RTMSDataSvcOffiRent) 서비스 키.",
+    )
+    molit_rh_rent_api_key: str = Field(
+        default="",
+        description="국토교통부 연립다세대 전월세 실거래가 (RTMSDataSvcRHRent) 서비스 키.",
     )
 
 

--- a/mcp-server/src/mcp_server/domains/real_estate/normalizer.py
+++ b/mcp-server/src/mcp_server/domains/real_estate/normalizer.py
@@ -1,7 +1,15 @@
-"""국토교통부 아파트 매매 실거래가 응답 정규화.
+"""국토교통부 부동산 실거래가 응답 정규화.
 
-api_source_service.fetch() 가 돌려준 XML 본문을 도메인 모델 list[AptTrade] 로 변환.
-정규화는 도메인 책임이라 sources 계층 예외(SourceError) 와 분리된 RealEstateNormalizationError 사용.
+api_source_service.fetch() 가 돌려준 XML 본문을 자료유형별 도메인 모델 list 로 변환.
+정규화는 도메인 책임이라 sources 계층 예외(SourceError) 와 분리된
+RealEstateNormalizationError 사용.
+
+지원 자료유형 (5종):
+- 아파트 매매 (AptTrade) — dealAmount
+- 아파트 전월세 (AptRent) — deposit + monthlyRent
+- 오피스텔 매매 (OffiTrade) — dealAmount, 단지명 offiNm
+- 오피스텔 전월세 (OffiRent) — deposit + monthlyRent, 단지명 offiNm
+- 연립다세대 전월세 (RHRent) — deposit + monthlyRent, 단지명 mhouseNm, houseType 보존
 """
 
 from datetime import date
@@ -11,6 +19,10 @@ from pydantic import BaseModel, Field
 
 from mcp_server.domains.real_estate.errors import RealEstateNormalizationError
 
+
+# ─────────────────────────────────────────────
+# 모델
+# ─────────────────────────────────────────────
 
 class AptTrade(BaseModel):
     """아파트 매매 실거래 1건."""
@@ -26,19 +38,129 @@ class AptTrade(BaseModel):
     build_year: int | None = Field(default=None, description="건축년도")
 
 
+class AptRent(BaseModel):
+    """아파트 전월세 실거래 1건. monthlyRent=0 이면 순수 전세."""
+
+    apt_name: str = Field(description="단지명")
+    deposit: int = Field(description="보증금 (만원, 콤마 제거)")
+    monthly_rent: int = Field(description="월세 (만원). 0 이면 전세.")
+    deal_date: date = Field(description="계약 일자")
+    area: float = Field(description="전용면적 m²")
+    floor: int = Field(description="층")
+    lawd_cd: str = Field(description="법정동 코드 5자리")
+    dong: str = Field(description="법정동명")
+    jibun: str | None = Field(default=None, description="지번")
+    build_year: int | None = Field(default=None, description="건축년도")
+
+
+class OffiTrade(BaseModel):
+    """오피스텔 매매 실거래 1건."""
+
+    offi_name: str = Field(description="단지명")
+    deal_amount: int = Field(description="거래 금액 (만원, 콤마 제거)")
+    deal_date: date = Field(description="계약 일자")
+    area: float = Field(description="전용면적 m²")
+    floor: int = Field(description="층")
+    lawd_cd: str = Field(description="법정동 코드 5자리")
+    dong: str = Field(description="법정동명")
+    jibun: str | None = Field(default=None, description="지번")
+    build_year: int | None = Field(default=None, description="건축년도")
+
+
+class OffiRent(BaseModel):
+    """오피스텔 전월세 실거래 1건. monthlyRent=0 이면 순수 전세."""
+
+    offi_name: str = Field(description="단지명")
+    deposit: int = Field(description="보증금 (만원, 콤마 제거)")
+    monthly_rent: int = Field(description="월세 (만원). 0 이면 전세.")
+    deal_date: date = Field(description="계약 일자")
+    area: float = Field(description="전용면적 m²")
+    floor: int = Field(description="층")
+    lawd_cd: str = Field(description="법정동 코드 5자리")
+    dong: str = Field(description="법정동명")
+    jibun: str | None = Field(default=None, description="지번")
+    build_year: int | None = Field(default=None, description="건축년도")
+
+
+class RHRent(BaseModel):
+    """연립다세대 전월세 실거래 1건. monthlyRent=0 이면 순수 전세."""
+
+    mhouse_name: str = Field(description="단지명 (mhouseNm)")
+    house_type: str | None = Field(default=None, description="주택 유형 (예: '다세대', '연립')")
+    deposit: int = Field(description="보증금 (만원, 콤마 제거)")
+    monthly_rent: int = Field(description="월세 (만원). 0 이면 전세.")
+    deal_date: date = Field(description="계약 일자")
+    area: float = Field(description="전용면적 m²")
+    floor: int = Field(description="층")
+    lawd_cd: str = Field(description="법정동 코드 5자리")
+    dong: str = Field(description="법정동명")
+    jibun: str | None = Field(default=None, description="지번")
+    build_year: int | None = Field(default=None, description="건축년도")
+
+
+# ─────────────────────────────────────────────
+# 정규화 함수
+# ─────────────────────────────────────────────
+
 _SUCCESS_CODE = "000"
 
 
 def normalize_apt_trade(xml_text: str, *, lawd_cd: str) -> list[AptTrade]:
     """MOLIT 아파트 매매 실거래가 XML → list[AptTrade].
 
-    Args:
-        xml_text: api_source_service.fetch() 의 RawResult.content (XML 텍스트).
-        lawd_cd: 호출 시 사용한 법정동 코드 5자리. 응답 자체엔 직접 안 들어있어 호출자가 보존.
+    Raises:
+        RealEstateNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    items = _parse_items(xml_text)
+    return [_build_apt_trade(item, lawd_cd=lawd_cd) for item in items]
+
+
+def normalize_apt_rent(xml_text: str, *, lawd_cd: str) -> list[AptRent]:
+    """MOLIT 아파트 전월세 실거래가 XML → list[AptRent].
 
     Raises:
         RealEstateNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
     """
+    items = _parse_items(xml_text)
+    return [_build_apt_rent(item, lawd_cd=lawd_cd) for item in items]
+
+
+def normalize_offi_trade(xml_text: str, *, lawd_cd: str) -> list[OffiTrade]:
+    """MOLIT 오피스텔 매매 실거래가 XML → list[OffiTrade].
+
+    Raises:
+        RealEstateNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    items = _parse_items(xml_text)
+    return [_build_offi_trade(item, lawd_cd=lawd_cd) for item in items]
+
+
+def normalize_offi_rent(xml_text: str, *, lawd_cd: str) -> list[OffiRent]:
+    """MOLIT 오피스텔 전월세 실거래가 XML → list[OffiRent].
+
+    Raises:
+        RealEstateNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    items = _parse_items(xml_text)
+    return [_build_offi_rent(item, lawd_cd=lawd_cd) for item in items]
+
+
+def normalize_rh_rent(xml_text: str, *, lawd_cd: str) -> list[RHRent]:
+    """MOLIT 연립다세대 전월세 실거래가 XML → list[RHRent].
+
+    Raises:
+        RealEstateNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    items = _parse_items(xml_text)
+    return [_build_rh_rent(item, lawd_cd=lawd_cd) for item in items]
+
+
+# ─────────────────────────────────────────────
+# 공통 파서: 응답 검증 + items 추출
+# ─────────────────────────────────────────────
+
+def _parse_items(xml_text: str) -> list[ET.Element]:
+    """XML 파싱 + resultCode 검증 + items 반환. items 가 비어있으면 빈 리스트."""
     try:
         root = ET.fromstring(xml_text)
     except ET.ParseError as exc:
@@ -51,37 +173,138 @@ def normalize_apt_trade(xml_text: str, *, lawd_cd: str) -> list[AptTrade]:
             f"MOLIT API 비정상 응답: code={result_code}, msg={result_msg}"
         )
 
-    items = root.findall("body/items/item")
-    if not items:
-        return []
+    return root.findall("body/items/item")
 
-    return [_build_apt_trade(item, lawd_cd=lawd_cd) for item in items]
 
+# ─────────────────────────────────────────────
+# 자료유형별 builder
+# ─────────────────────────────────────────────
 
 def _build_apt_trade(item: ET.Element, *, lawd_cd: str) -> AptTrade:
     try:
-        deal_year = int(_required(item, "dealYear"))
-        deal_month = int(_required(item, "dealMonth"))
-        deal_day = int(_required(item, "dealDay"))
+        common = _build_common(item, lawd_cd=lawd_cd, name_tag="aptNm")
         deal_amount = _parse_amount(_required(item, "dealAmount"))
-        area = float(_required(item, "excluUseAr"))
-        floor = int(_required(item, "floor"))
-        apt_name = _required(item, "aptNm")
-        dong = _required(item, "umdNm")
     except (KeyError, ValueError) as exc:
         raise RealEstateNormalizationError(f"item 필수 필드 파싱 실패: {exc}") from exc
-
     return AptTrade(
-        apt_name=apt_name,
+        apt_name=common["name"],
         deal_amount=deal_amount,
-        deal_date=date(deal_year, deal_month, deal_day),
-        area=area,
-        floor=floor,
-        lawd_cd=lawd_cd,
-        dong=dong,
-        jibun=_find_text(item, "jibun"),
-        build_year=_optional_int(item, "buildYear"),
+        deal_date=common["deal_date"],
+        area=common["area"],
+        floor=common["floor"],
+        lawd_cd=common["lawd_cd"],
+        dong=common["dong"],
+        jibun=common["jibun"],
+        build_year=common["build_year"],
     )
+
+
+def _build_apt_rent(item: ET.Element, *, lawd_cd: str) -> AptRent:
+    try:
+        common = _build_common(item, lawd_cd=lawd_cd, name_tag="aptNm")
+        deposit, monthly_rent = _parse_rent(item)
+    except (KeyError, ValueError) as exc:
+        raise RealEstateNormalizationError(f"item 필수 필드 파싱 실패: {exc}") from exc
+    return AptRent(
+        apt_name=common["name"],
+        deposit=deposit,
+        monthly_rent=monthly_rent,
+        deal_date=common["deal_date"],
+        area=common["area"],
+        floor=common["floor"],
+        lawd_cd=common["lawd_cd"],
+        dong=common["dong"],
+        jibun=common["jibun"],
+        build_year=common["build_year"],
+    )
+
+
+def _build_offi_trade(item: ET.Element, *, lawd_cd: str) -> OffiTrade:
+    try:
+        common = _build_common(item, lawd_cd=lawd_cd, name_tag="offiNm")
+        deal_amount = _parse_amount(_required(item, "dealAmount"))
+    except (KeyError, ValueError) as exc:
+        raise RealEstateNormalizationError(f"item 필수 필드 파싱 실패: {exc}") from exc
+    return OffiTrade(
+        offi_name=common["name"],
+        deal_amount=deal_amount,
+        deal_date=common["deal_date"],
+        area=common["area"],
+        floor=common["floor"],
+        lawd_cd=common["lawd_cd"],
+        dong=common["dong"],
+        jibun=common["jibun"],
+        build_year=common["build_year"],
+    )
+
+
+def _build_offi_rent(item: ET.Element, *, lawd_cd: str) -> OffiRent:
+    try:
+        common = _build_common(item, lawd_cd=lawd_cd, name_tag="offiNm")
+        deposit, monthly_rent = _parse_rent(item)
+    except (KeyError, ValueError) as exc:
+        raise RealEstateNormalizationError(f"item 필수 필드 파싱 실패: {exc}") from exc
+    return OffiRent(
+        offi_name=common["name"],
+        deposit=deposit,
+        monthly_rent=monthly_rent,
+        deal_date=common["deal_date"],
+        area=common["area"],
+        floor=common["floor"],
+        lawd_cd=common["lawd_cd"],
+        dong=common["dong"],
+        jibun=common["jibun"],
+        build_year=common["build_year"],
+    )
+
+
+def _build_rh_rent(item: ET.Element, *, lawd_cd: str) -> RHRent:
+    try:
+        common = _build_common(item, lawd_cd=lawd_cd, name_tag="mhouseNm")
+        deposit, monthly_rent = _parse_rent(item)
+    except (KeyError, ValueError) as exc:
+        raise RealEstateNormalizationError(f"item 필수 필드 파싱 실패: {exc}") from exc
+    return RHRent(
+        mhouse_name=common["name"],
+        house_type=_find_text(item, "houseType"),
+        deposit=deposit,
+        monthly_rent=monthly_rent,
+        deal_date=common["deal_date"],
+        area=common["area"],
+        floor=common["floor"],
+        lawd_cd=common["lawd_cd"],
+        dong=common["dong"],
+        jibun=common["jibun"],
+        build_year=common["build_year"],
+    )
+
+
+# ─────────────────────────────────────────────
+# 공통 필드/유틸
+# ─────────────────────────────────────────────
+
+def _build_common(item: ET.Element, *, lawd_cd: str, name_tag: str) -> dict:
+    """5종 자료유형 공통 필드 추출. 단지명 태그만 자료유형별로 다름."""
+    deal_year = int(_required(item, "dealYear"))
+    deal_month = int(_required(item, "dealMonth"))
+    deal_day = int(_required(item, "dealDay"))
+    return {
+        "name": _required(item, name_tag),
+        "deal_date": date(deal_year, deal_month, deal_day),
+        "area": float(_required(item, "excluUseAr")),
+        "floor": int(_required(item, "floor")),
+        "lawd_cd": lawd_cd,
+        "dong": _required(item, "umdNm"),
+        "jibun": _find_text(item, "jibun"),
+        "build_year": _optional_int(item, "buildYear"),
+    }
+
+
+def _parse_rent(item: ET.Element) -> tuple[int, int]:
+    """전월세 가격 파싱. monthlyRent 는 보통 정수지만 콤마 가능성 대비."""
+    deposit = _parse_amount(_required(item, "deposit"))
+    monthly_rent = _parse_amount(_required(item, "monthlyRent"))
+    return deposit, monthly_rent
 
 
 def _find_text(parent: ET.Element, path: str) -> str | None:
@@ -113,4 +336,16 @@ def _parse_amount(raw: str) -> int:
     return int(raw.replace(",", "").strip())
 
 
-__all__ = ["AptTrade", "RealEstateNormalizationError", "normalize_apt_trade"]
+__all__ = [
+    "AptRent",
+    "AptTrade",
+    "OffiRent",
+    "OffiTrade",
+    "RHRent",
+    "RealEstateNormalizationError",
+    "normalize_apt_rent",
+    "normalize_apt_trade",
+    "normalize_offi_rent",
+    "normalize_offi_trade",
+    "normalize_rh_rent",
+]

--- a/mcp-server/src/mcp_server/tools/real_estate.py
+++ b/mcp-server/src/mcp_server/tools/real_estate.py
@@ -127,23 +127,23 @@ async def search_house_price(input: SearchHousePriceInput) -> dict[str, Any]:
     빈 응답(거래 0건) 은 정상 동작 — text 가 "0건" 으로 명시된다. 예외 아님.
 
     Raises:
-        RealEstateConfigError: MOLIT_TRADE_API_KEY 미설정.
+        RealEstateConfigError: MOLIT_APT_TRADE_API_KEY 미설정.
         RealEstateRegionNotFoundError: region 매칭 실패 또는 동음이의(자동 선택 거부).
         RealEstateNormalizationError: API 응답이 비정상(코드 != "000") 또는 XML 파싱 실패.
         SourceNotFoundError: api_source 시드 미실행.
         SourceFetchError: API 호출 실패 (네트워크/4xx/5xx).
     """
     settings = get_settings()
-    if not settings.molit_trade_api_key:
+    if not settings.molit_apt_trade_api_key:
         raise RealEstateConfigError(
-            "MOLIT_TRADE_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
+            "MOLIT_APT_TRADE_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
     lawd_cd = resolve_lawd_cd(input.region)
     source_id = await _resolve_source_id()
 
     params: dict[str, Any] = {
-        "serviceKey": settings.molit_trade_api_key,
+        "serviceKey": settings.molit_apt_trade_api_key,
         "LAWD_CD": lawd_cd,
         "DEAL_YMD": input.deal_ymd,
         "numOfRows": _DEFAULT_NUM_OF_ROWS,

--- a/mcp-server/src/mcp_server/tools/real_estate.py
+++ b/mcp-server/src/mcp_server/tools/real_estate.py
@@ -1,13 +1,20 @@
 """부동산 도메인 MCP 도구.
 
-현재 등록 도구:
-- search_house_price: 국토교통부 아파트 매매 실거래가 조회.
+등록 도구 (5종):
+- search_house_price (= 아파트 매매)
+- search_apt_rent          (아파트 전월세)
+- search_offi_trade        (오피스텔 매매)
+- search_offi_rent         (오피스텔 전월세)
+- search_rh_rent           (연립다세대 전월세)
 
 원칙:
 - serviceKey 같은 비밀값은 도구 함수 인자로 받지 않는다 (Langfuse @traced 가 입력을
   자동 캡처하므로 평문 누출 위험). 도구 내부에서 settings 로 직접 합성한다.
 - 외부 호출은 sources.api_source_service.fetch() 만 경유한다.
 - 결과 trades 는 토큰 폭증을 막기 위해 상위 _MAX_TRADES_RETURNED 건으로 절단한다.
+- 도구 이름·docstring 은 LLM 의 도구 선택 근거. 자료유형(매매/전월세, 아파트/오피스텔
+  /연립다세대)을 명확히 구분되게 작성. (CLAUDE.md "Tool 이름과 Description이 AI의
+  판단 근거" 원칙)
 """
 
 from datetime import datetime
@@ -21,25 +28,36 @@ from mcp_server.domains.real_estate.errors import (
     RealEstateConfigError,
 )
 from mcp_server.domains.real_estate.normalizer import (
+    AptRent,
     AptTrade,
+    OffiRent,
+    OffiTrade,
+    RHRent,
+    normalize_apt_rent,
     normalize_apt_trade,
+    normalize_offi_rent,
+    normalize_offi_trade,
+    normalize_rh_rent,
 )
 from mcp_server.domains.real_estate.region import resolve_lawd_cd
 from mcp_server.observability.tracing import traced
 from mcp_server.server import mcp
 from mcp_server.sources import api_source_service
 
-_TOOL_NAME = "search_house_price"
 _DEFAULT_NUM_OF_ROWS = 100
 _MAX_TRADES_RETURNED = 20
 
-# 첫 호출 시 lookup 후 보존. seed 가 멱등이라 id 는 변하지 않는다.
-# 테스트는 monkeypatch 로 None 으로 되돌린다.
-_cached_source_id: int | None = None
+# tool_name → api_source.id 캐시. seed 가 멱등이라 id 는 변하지 않는다.
+# 테스트는 monkeypatch 로 dict 자체를 비운다.
+_cached_source_ids: dict[str, int] = {}
 
 
-class SearchHousePriceInput(BaseModel):
-    """search_house_price 입력.
+# ─────────────────────────────────────────────
+# 공통 입력 모델 — 5종 모두 region + deal_ymd 시그니처 동일.
+# ─────────────────────────────────────────────
+
+class MolitRealEstateInput(BaseModel):
+    """MOLIT 부동산 실거래가 조회 공통 입력.
 
     region 은 자연어 시군구명("강남구", "서울 중구", "성남시 분당구") 또는 5자리
     법정동코드("11680") 모두 허용. 동·읍·면 단위는 지원하지 않는다.
@@ -59,11 +77,21 @@ class SearchHousePriceInput(BaseModel):
     )
 
 
-async def _resolve_source_id() -> int:
-    global _cached_source_id
-    if _cached_source_id is None:
-        _cached_source_id = await api_source_service.resolve_source_id_by_tool_name(_TOOL_NAME)
-    return _cached_source_id
+# 기존 호출자 호환을 위한 alias.
+SearchHousePriceInput = MolitRealEstateInput
+
+
+# ─────────────────────────────────────────────
+# 공통 헬퍼
+# ─────────────────────────────────────────────
+
+async def _resolve_source_id(tool_name: str) -> int:
+    """tool_name → api_source.id. 첫 호출 시 lookup 후 dict 캐시."""
+    if tool_name not in _cached_source_ids:
+        _cached_source_ids[tool_name] = (
+            await api_source_service.resolve_source_id_by_tool_name(tool_name)
+        )
+    return _cached_source_ids[tool_name]
 
 
 def _mask_query_string(params: dict[str, Any]) -> str:
@@ -75,19 +103,6 @@ def _mask_query_string(params: dict[str, Any]) -> str:
     return urlencode(masked, safe="*")
 
 
-def _summarize(trades: list[AptTrade]) -> dict[str, Any]:
-    """간단한 통계 요약 (만원 단위 정수)."""
-    if not trades:
-        return {"count": 0, "avg_deal_amount": None, "min_deal_amount": None, "max_deal_amount": None}
-    amounts = [t.deal_amount for t in trades]
-    return {
-        "count": len(trades),
-        "avg_deal_amount": round(sum(amounts) / len(amounts)),
-        "min_deal_amount": min(amounts),
-        "max_deal_amount": max(amounts),
-    }
-
-
 def _to_eok(amount_manwon: int | None) -> str:
     """만원 → '12.5억' 표기. None 이면 '-'."""
     if amount_manwon is None:
@@ -95,21 +110,148 @@ def _to_eok(amount_manwon: int | None) -> str:
     return f"{amount_manwon / 10000:.1f}억"
 
 
-def _build_text(region_label: str, deal_ymd: str, summary: dict[str, Any]) -> str:
+def _build_params(api_key: str, lawd_cd: str, deal_ymd: str) -> dict[str, Any]:
+    return {
+        "serviceKey": api_key,
+        "LAWD_CD": lawd_cd,
+        "DEAL_YMD": deal_ymd,
+        "numOfRows": _DEFAULT_NUM_OF_ROWS,
+    }
+
+
+# ─────────────────────────────────────────────
+# 매매 (Trade) 공통: dealAmount 기준 통계
+# ─────────────────────────────────────────────
+
+def _summarize_trade(records: list) -> dict[str, Any]:
+    if not records:
+        return {
+            "count": 0,
+            "avg_deal_amount": None,
+            "min_deal_amount": None,
+            "max_deal_amount": None,
+        }
+    amounts = [r.deal_amount for r in records]
+    return {
+        "count": len(records),
+        "avg_deal_amount": round(sum(amounts) / len(amounts)),
+        "min_deal_amount": min(amounts),
+        "max_deal_amount": max(amounts),
+    }
+
+
+def _trade_text(region_label: str, deal_ymd: str, kind: str, summary: dict[str, Any]) -> str:
+    """매매 자료유형 통계 한 단락. kind 예: '아파트 매매', '오피스텔 매매'."""
     if summary["count"] == 0:
-        return f"{region_label} {deal_ymd} 아파트 매매 실거래 0건."
+        return f"{region_label} {deal_ymd} {kind} 실거래 0건."
     return (
-        f"{region_label} {deal_ymd} 아파트 매매 실거래 {summary['count']}건. "
+        f"{region_label} {deal_ymd} {kind} 실거래 {summary['count']}건. "
         f"평균 {_to_eok(summary['avg_deal_amount'])}, "
         f"최저 {_to_eok(summary['min_deal_amount'])}, "
         f"최고 {_to_eok(summary['max_deal_amount'])} (단위: 만원)."
     )
 
 
+# ─────────────────────────────────────────────
+# 전월세 (Rent) 공통: deposit 기준 통계 + 평균 월세
+# ─────────────────────────────────────────────
+
+def _summarize_rent(records: list) -> dict[str, Any]:
+    if not records:
+        return {
+            "count": 0,
+            "avg_deposit": None,
+            "min_deposit": None,
+            "max_deposit": None,
+            "avg_monthly_rent": None,
+        }
+    deposits = [r.deposit for r in records]
+    monthly = [r.monthly_rent for r in records]
+    return {
+        "count": len(records),
+        "avg_deposit": round(sum(deposits) / len(deposits)),
+        "min_deposit": min(deposits),
+        "max_deposit": max(deposits),
+        "avg_monthly_rent": round(sum(monthly) / len(monthly)),
+    }
+
+
+def _rent_text(region_label: str, deal_ymd: str, kind: str, summary: dict[str, Any]) -> str:
+    """전월세 통계 한 단락. monthly 0 이면 전세, 0 초과면 월세 포함."""
+    if summary["count"] == 0:
+        return f"{region_label} {deal_ymd} {kind} 실거래 0건."
+    return (
+        f"{region_label} {deal_ymd} {kind} 실거래 {summary['count']}건. "
+        f"평균 보증금 {_to_eok(summary['avg_deposit'])}, "
+        f"최저 보증금 {_to_eok(summary['min_deposit'])}, "
+        f"최고 보증금 {_to_eok(summary['max_deposit'])}, "
+        f"평균 월세 {summary['avg_monthly_rent']}만원."
+    )
+
+
+# ─────────────────────────────────────────────
+# 응답 dict 빌더 — fetch + normalize 후 정렬·절단·요약·메타
+# ─────────────────────────────────────────────
+
+def _build_response(
+    *,
+    raw,
+    records: list,
+    sort_key,
+    summary: dict[str, Any],
+    text: str,
+    region: str,
+    lawd_cd: str,
+    deal_ymd: str,
+    params: dict[str, Any],
+    tool_name: str,
+    source_id: int,
+) -> dict[str, Any]:
+    sorted_records = sorted(records, key=sort_key, reverse=True)
+    truncated = len(sorted_records) > _MAX_TRADES_RETURNED
+    returned = sorted_records[:_MAX_TRADES_RETURNED]
+
+    url_template = raw.raw_metadata.get("url_template", "")
+    source_url = f"{url_template}?{_mask_query_string(params)}" if url_template else None
+
+    return {
+        "text": text,
+        "structured": {
+            "summary": summary,
+            "trades": [r.model_dump(mode="json") for r in returned],
+            "trades_truncated": truncated,
+            "query": {
+                "region": region,
+                "lawd_cd": lawd_cd,
+                "deal_ymd": deal_ymd,
+            },
+        },
+        "source_url": source_url,
+        "metadata": {
+            "fetched_at": (
+                raw.fetched_at.isoformat()
+                if isinstance(raw.fetched_at, datetime)
+                else str(raw.fetched_at)
+            ),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": tool_name,
+            "source_id": source_id,
+        },
+    }
+
+
+# ─────────────────────────────────────────────
+# 도구 1: 아파트 매매 (= search_house_price, 기존 호환 유지)
+# ─────────────────────────────────────────────
+
+_TOOL_APT_TRADE = "search_house_price"
+
+
 @mcp.tool()
-@traced(_TOOL_NAME)
-async def search_house_price(input: SearchHousePriceInput) -> dict[str, Any]:
-    """국토교통부 아파트 매매 실거래가 조회.
+@traced(_TOOL_APT_TRADE)
+async def search_house_price(input: MolitRealEstateInput) -> dict[str, Any]:
+    """국토교통부 **아파트 매매** 실거래가 조회.
 
     지정한 시군구(LAWD_CD 5자리) + 거래연월(YYYYMM) 의 아파트 매매 실거래 목록을
     국토교통부 공식 API 에서 조회한다.
@@ -140,48 +282,244 @@ async def search_house_price(input: SearchHousePriceInput) -> dict[str, Any]:
         )
 
     lawd_cd = resolve_lawd_cd(input.region)
-    source_id = await _resolve_source_id()
-
-    params: dict[str, Any] = {
-        "serviceKey": settings.molit_apt_trade_api_key,
-        "LAWD_CD": lawd_cd,
-        "DEAL_YMD": input.deal_ymd,
-        "numOfRows": _DEFAULT_NUM_OF_ROWS,
-    }
+    source_id = await _resolve_source_id(_TOOL_APT_TRADE)
+    params = _build_params(settings.molit_apt_trade_api_key, lawd_cd, input.deal_ymd)
 
     raw = await api_source_service.fetch(source_id=source_id, params=params)
-    trades = normalize_apt_trade(raw.content, lawd_cd=lawd_cd)
+    records: list[AptTrade] = normalize_apt_trade(raw.content, lawd_cd=lawd_cd)
+    summary = _summarize_trade(records)
 
-    sorted_trades = sorted(trades, key=lambda t: t.deal_amount, reverse=True)
-    truncated = len(sorted_trades) > _MAX_TRADES_RETURNED
-    returned = sorted_trades[:_MAX_TRADES_RETURNED]
-    summary = _summarize(trades)
-
-    region_label = f"LAWD_CD {lawd_cd}"
-    url_template = raw.raw_metadata.get("url_template", "")
-    source_url = f"{url_template}?{_mask_query_string(params)}" if url_template else None
-
-    return {
-        "text": _build_text(region_label, input.deal_ymd, summary),
-        "structured": {
-            "summary": summary,
-            "trades": [t.model_dump(mode="json") for t in returned],
-            "trades_truncated": truncated,
-            "query": {
-                "region": input.region,
-                "lawd_cd": lawd_cd,
-                "deal_ymd": input.deal_ymd,
-            },
-        },
-        "source_url": source_url,
-        "metadata": {
-            "fetched_at": raw.fetched_at.isoformat() if isinstance(raw.fetched_at, datetime) else str(raw.fetched_at),
-            "raw_count": len(trades),
-            "returned_count": len(returned),
-            "tool_name": _TOOL_NAME,
-            "source_id": source_id,
-        },
-    }
+    return _build_response(
+        raw=raw,
+        records=records,
+        sort_key=lambda r: r.deal_amount,
+        summary=summary,
+        text=_trade_text(f"LAWD_CD {lawd_cd}", input.deal_ymd, "아파트 매매", summary),
+        region=input.region,
+        lawd_cd=lawd_cd,
+        deal_ymd=input.deal_ymd,
+        params=params,
+        tool_name=_TOOL_APT_TRADE,
+        source_id=source_id,
+    )
 
 
-__all__ = ["SearchHousePriceInput", "search_house_price"]
+# ─────────────────────────────────────────────
+# 도구 2: 아파트 전월세
+# ─────────────────────────────────────────────
+
+_TOOL_APT_RENT = "search_apt_rent"
+
+
+@mcp.tool()
+@traced(_TOOL_APT_RENT)
+async def search_apt_rent(input: MolitRealEstateInput) -> dict[str, Any]:
+    """국토교통부 **아파트 전월세** 실거래가 조회 (전세·월세 모두 포함).
+
+    지정한 시군구(LAWD_CD 5자리) + 거래연월(YYYYMM) 의 아파트 전월세 실거래 목록을
+    국토교통부 공식 API 에서 조회한다. 전세는 monthly_rent=0 으로 표현된다.
+
+    반환 dict:
+      - text: 통계 요약 (보증금 평균/최저/최고 + 평균 월세).
+      - structured.summary: {count, avg_deposit, min_deposit, max_deposit, avg_monthly_rent}
+        (단위: 만원). 거래 0건이면 통계 필드는 None.
+      - structured.trades: AptRent dict 의 상위 20건 (보증금 내림차순).
+      - structured.trades_truncated / query / source_url / metadata: 매매 도구와 동일.
+
+    Raises:
+        RealEstateConfigError: MOLIT_APT_RENT_API_KEY 미설정.
+        (그 외 매매 도구와 동일.)
+    """
+    settings = get_settings()
+    if not settings.molit_apt_rent_api_key:
+        raise RealEstateConfigError(
+            "MOLIT_APT_RENT_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
+        )
+
+    lawd_cd = resolve_lawd_cd(input.region)
+    source_id = await _resolve_source_id(_TOOL_APT_RENT)
+    params = _build_params(settings.molit_apt_rent_api_key, lawd_cd, input.deal_ymd)
+
+    raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[AptRent] = normalize_apt_rent(raw.content, lawd_cd=lawd_cd)
+    summary = _summarize_rent(records)
+
+    return _build_response(
+        raw=raw,
+        records=records,
+        sort_key=lambda r: r.deposit,
+        summary=summary,
+        text=_rent_text(f"LAWD_CD {lawd_cd}", input.deal_ymd, "아파트 전월세", summary),
+        region=input.region,
+        lawd_cd=lawd_cd,
+        deal_ymd=input.deal_ymd,
+        params=params,
+        tool_name=_TOOL_APT_RENT,
+        source_id=source_id,
+    )
+
+
+# ─────────────────────────────────────────────
+# 도구 3: 오피스텔 매매
+# ─────────────────────────────────────────────
+
+_TOOL_OFFI_TRADE = "search_offi_trade"
+
+
+@mcp.tool()
+@traced(_TOOL_OFFI_TRADE)
+async def search_offi_trade(input: MolitRealEstateInput) -> dict[str, Any]:
+    """국토교통부 **오피스텔 매매** 실거래가 조회.
+
+    지정한 시군구(LAWD_CD 5자리) + 거래연월(YYYYMM) 의 오피스텔 매매 실거래 목록을
+    국토교통부 공식 API 에서 조회한다. 아파트가 아닌 오피스텔(officetel) 전용.
+
+    반환 dict 구조는 아파트 매매(search_house_price) 와 동일하나, 단지명 필드는
+    offi_name 으로 노출된다.
+
+    Raises:
+        RealEstateConfigError: MOLIT_OFFI_TRADE_API_KEY 미설정.
+        (그 외 매매 도구와 동일.)
+    """
+    settings = get_settings()
+    if not settings.molit_offi_trade_api_key:
+        raise RealEstateConfigError(
+            "MOLIT_OFFI_TRADE_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
+        )
+
+    lawd_cd = resolve_lawd_cd(input.region)
+    source_id = await _resolve_source_id(_TOOL_OFFI_TRADE)
+    params = _build_params(settings.molit_offi_trade_api_key, lawd_cd, input.deal_ymd)
+
+    raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[OffiTrade] = normalize_offi_trade(raw.content, lawd_cd=lawd_cd)
+    summary = _summarize_trade(records)
+
+    return _build_response(
+        raw=raw,
+        records=records,
+        sort_key=lambda r: r.deal_amount,
+        summary=summary,
+        text=_trade_text(f"LAWD_CD {lawd_cd}", input.deal_ymd, "오피스텔 매매", summary),
+        region=input.region,
+        lawd_cd=lawd_cd,
+        deal_ymd=input.deal_ymd,
+        params=params,
+        tool_name=_TOOL_OFFI_TRADE,
+        source_id=source_id,
+    )
+
+
+# ─────────────────────────────────────────────
+# 도구 4: 오피스텔 전월세
+# ─────────────────────────────────────────────
+
+_TOOL_OFFI_RENT = "search_offi_rent"
+
+
+@mcp.tool()
+@traced(_TOOL_OFFI_RENT)
+async def search_offi_rent(input: MolitRealEstateInput) -> dict[str, Any]:
+    """국토교통부 **오피스텔 전월세** 실거래가 조회 (전세·월세 모두 포함).
+
+    지정한 시군구(LAWD_CD 5자리) + 거래연월(YYYYMM) 의 오피스텔 전월세 실거래 목록을
+    국토교통부 공식 API 에서 조회한다. 아파트가 아닌 오피스텔(officetel) 전용.
+    전세는 monthly_rent=0 으로 표현된다.
+
+    반환 dict 구조는 아파트 전월세(search_apt_rent) 와 동일하나, 단지명 필드는
+    offi_name 으로 노출된다.
+
+    Raises:
+        RealEstateConfigError: MOLIT_OFFI_RENT_API_KEY 미설정.
+        (그 외 동일.)
+    """
+    settings = get_settings()
+    if not settings.molit_offi_rent_api_key:
+        raise RealEstateConfigError(
+            "MOLIT_OFFI_RENT_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
+        )
+
+    lawd_cd = resolve_lawd_cd(input.region)
+    source_id = await _resolve_source_id(_TOOL_OFFI_RENT)
+    params = _build_params(settings.molit_offi_rent_api_key, lawd_cd, input.deal_ymd)
+
+    raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[OffiRent] = normalize_offi_rent(raw.content, lawd_cd=lawd_cd)
+    summary = _summarize_rent(records)
+
+    return _build_response(
+        raw=raw,
+        records=records,
+        sort_key=lambda r: r.deposit,
+        summary=summary,
+        text=_rent_text(f"LAWD_CD {lawd_cd}", input.deal_ymd, "오피스텔 전월세", summary),
+        region=input.region,
+        lawd_cd=lawd_cd,
+        deal_ymd=input.deal_ymd,
+        params=params,
+        tool_name=_TOOL_OFFI_RENT,
+        source_id=source_id,
+    )
+
+
+# ─────────────────────────────────────────────
+# 도구 5: 연립다세대 전월세
+# ─────────────────────────────────────────────
+
+_TOOL_RH_RENT = "search_rh_rent"
+
+
+@mcp.tool()
+@traced(_TOOL_RH_RENT)
+async def search_rh_rent(input: MolitRealEstateInput) -> dict[str, Any]:
+    """국토교통부 **연립다세대(빌라·연립·다세대주택) 전월세** 실거래가 조회.
+
+    지정한 시군구(LAWD_CD 5자리) + 거래연월(YYYYMM) 의 연립·다세대주택 전월세
+    실거래 목록을 국토교통부 공식 API 에서 조회한다. 아파트나 오피스텔이 아닌
+    빌라/연립/다세대주택이 대상. 전세는 monthly_rent=0 으로 표현된다.
+
+    반환 dict 의 trades 항목엔 단지명(mhouse_name) 외에 house_type(예: '연립',
+    '다세대') 필드가 포함된다.
+
+    Raises:
+        RealEstateConfigError: MOLIT_RH_RENT_API_KEY 미설정.
+        (그 외 동일.)
+    """
+    settings = get_settings()
+    if not settings.molit_rh_rent_api_key:
+        raise RealEstateConfigError(
+            "MOLIT_RH_RENT_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
+        )
+
+    lawd_cd = resolve_lawd_cd(input.region)
+    source_id = await _resolve_source_id(_TOOL_RH_RENT)
+    params = _build_params(settings.molit_rh_rent_api_key, lawd_cd, input.deal_ymd)
+
+    raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[RHRent] = normalize_rh_rent(raw.content, lawd_cd=lawd_cd)
+    summary = _summarize_rent(records)
+
+    return _build_response(
+        raw=raw,
+        records=records,
+        sort_key=lambda r: r.deposit,
+        summary=summary,
+        text=_rent_text(f"LAWD_CD {lawd_cd}", input.deal_ymd, "연립다세대 전월세", summary),
+        region=input.region,
+        lawd_cd=lawd_cd,
+        deal_ymd=input.deal_ymd,
+        params=params,
+        tool_name=_TOOL_RH_RENT,
+        source_id=source_id,
+    )
+
+
+__all__ = [
+    "MolitRealEstateInput",
+    "SearchHousePriceInput",  # 호환 alias
+    "search_apt_rent",
+    "search_house_price",
+    "search_offi_rent",
+    "search_offi_trade",
+    "search_rh_rent",
+]

--- a/mcp-server/tests/domains/real_estate/test_normalizer.py
+++ b/mcp-server/tests/domains/real_estate/test_normalizer.py
@@ -1,7 +1,14 @@
 """real_estate.normalizer 단위 테스트.
 
-XML 픽스처 (tests/fixtures/molit_apt_trade_*.xml) 기반.
+XML 픽스처 (tests/fixtures/molit_*_{sample,empty,error}.xml) 기반.
 실제 API 호출 없음 — 정규화 로직만 검증.
+
+자료유형 5종:
+- AptTrade  (아파트 매매)     — dealAmount
+- AptRent   (아파트 전월세)   — deposit + monthlyRent
+- OffiTrade (오피스텔 매매)   — dealAmount, offiNm
+- OffiRent  (오피스텔 전월세) — deposit + monthlyRent, offiNm
+- RHRent    (연립다세대 전월세) — deposit + monthlyRent, mhouseNm + houseType
 """
 
 from datetime import date
@@ -10,9 +17,17 @@ from pathlib import Path
 import pytest
 
 from mcp_server.domains.real_estate.normalizer import (
+    AptRent,
     AptTrade,
+    OffiRent,
+    OffiTrade,
     RealEstateNormalizationError,
+    RHRent,
+    normalize_apt_rent,
     normalize_apt_trade,
+    normalize_offi_rent,
+    normalize_offi_trade,
+    normalize_rh_rent,
 )
 
 FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"
@@ -21,6 +36,10 @@ FIXTURES = Path(__file__).resolve().parents[2] / "fixtures"
 def _load(name: str) -> str:
     return (FIXTURES / name).read_text(encoding="utf-8")
 
+
+# ─────────────────────────────────────────────
+# AptTrade (아파트 매매) — 기존 테스트
+# ─────────────────────────────────────────────
 
 def test_normalize_returns_apt_trades():
     """정상 응답 → AptTrade 리스트, 첫 row 의 핵심 필드 검증."""
@@ -70,3 +89,110 @@ def test_normalize_raises_on_malformed_xml():
     """깨진 XML → ParseError 흡수해 RealEstateNormalizationError."""
     with pytest.raises(RealEstateNormalizationError):
         normalize_apt_trade("<response><header><resultCode>", lawd_cd="11680")
+
+
+# ─────────────────────────────────────────────
+# AptRent (아파트 전월세)
+# ─────────────────────────────────────────────
+
+def test_normalize_apt_rent_returns_rows():
+    """정상 응답 → AptRent 리스트, 보증금/월세/전세 구분 검증."""
+    result = normalize_apt_rent(_load("molit_apt_rent_sample.xml"), lawd_cd="11680")
+
+    assert len(result) == 2
+    assert all(isinstance(row, AptRent) for row in result)
+
+    first = result[0]
+    assert first.apt_name == "래미안"
+    assert first.deposit == 70000
+    assert first.monthly_rent == 0  # 전세
+    assert first.deal_date == date(2024, 3, 20)
+    assert first.area == 76.79
+    assert first.dong == "대치동"
+    assert first.build_year == 1979
+
+    second = result[1]
+    assert second.deposit == 20000
+    assert second.monthly_rent == 120  # 월세
+
+
+def test_normalize_apt_rent_handles_empty_and_error():
+    assert normalize_apt_rent(_load("molit_apt_rent_empty.xml"), lawd_cd="11680") == []
+    with pytest.raises(RealEstateNormalizationError):
+        normalize_apt_rent(_load("molit_apt_rent_error.xml"), lawd_cd="11680")
+
+
+# ─────────────────────────────────────────────
+# OffiTrade (오피스텔 매매)
+# ─────────────────────────────────────────────
+
+def test_normalize_offi_trade_returns_rows():
+    """offiNm 단지명 + dealAmount 가격 검증."""
+    result = normalize_offi_trade(_load("molit_offi_trade_sample.xml"), lawd_cd="11680")
+
+    assert len(result) == 2
+    assert all(isinstance(row, OffiTrade) for row in result)
+
+    first = result[0]
+    assert first.offi_name == "강남 오피스텔"
+    assert first.deal_amount == 27500
+    assert first.deal_date == date(2024, 3, 20)
+    assert first.dong == "청담동"
+
+
+def test_normalize_offi_trade_handles_empty_and_error():
+    assert normalize_offi_trade(_load("molit_offi_trade_empty.xml"), lawd_cd="11680") == []
+    with pytest.raises(RealEstateNormalizationError):
+        normalize_offi_trade(_load("molit_offi_trade_error.xml"), lawd_cd="11680")
+
+
+# ─────────────────────────────────────────────
+# OffiRent (오피스텔 전월세)
+# ─────────────────────────────────────────────
+
+def test_normalize_offi_rent_returns_rows():
+    """offiNm + deposit/monthlyRent 검증."""
+    result = normalize_offi_rent(_load("molit_offi_rent_sample.xml"), lawd_cd="11680")
+
+    assert len(result) == 2
+    assert all(isinstance(row, OffiRent) for row in result)
+
+    first = result[0]
+    assert first.offi_name == "강남 스카이홈"
+    assert first.deposit == 16500
+    assert first.monthly_rent == 10
+    assert first.dong == "도곡동"
+
+
+def test_normalize_offi_rent_handles_empty_and_error():
+    assert normalize_offi_rent(_load("molit_offi_rent_empty.xml"), lawd_cd="11680") == []
+    with pytest.raises(RealEstateNormalizationError):
+        normalize_offi_rent(_load("molit_offi_rent_error.xml"), lawd_cd="11680")
+
+
+# ─────────────────────────────────────────────
+# RHRent (연립다세대 전월세)
+# ─────────────────────────────────────────────
+
+def test_normalize_rh_rent_returns_rows():
+    """mhouseNm + houseType 보존 + deposit/monthlyRent."""
+    result = normalize_rh_rent(_load("molit_rh_rent_sample.xml"), lawd_cd="11680")
+
+    assert len(result) == 2
+    assert all(isinstance(row, RHRent) for row in result)
+
+    first = result[0]
+    assert first.mhouse_name == "역삼삼성빌라"
+    assert first.house_type == "다세대"
+    assert first.deposit == 30500
+    assert first.monthly_rent == 0  # 전세
+
+    second = result[1]
+    assert second.house_type == "연립"
+    assert second.monthly_rent == 50  # 월세
+
+
+def test_normalize_rh_rent_handles_empty_and_error():
+    assert normalize_rh_rent(_load("molit_rh_rent_empty.xml"), lawd_cd="11680") == []
+    with pytest.raises(RealEstateNormalizationError):
+        normalize_rh_rent(_load("molit_rh_rent_error.xml"), lawd_cd="11680")

--- a/mcp-server/tests/fixtures/molit_apt_rent_empty.xml
+++ b/mcp-server/tests/fixtures/molit_apt_rent_empty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items></items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>0</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_apt_rent_error.xml
+++ b/mcp-server/tests/fixtures/molit_apt_rent_error.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>30</resultCode>
+    <resultMsg>SERVICE KEY IS NOT REGISTERED ERROR</resultMsg>
+  </header>
+</response>

--- a/mcp-server/tests/fixtures/molit_apt_rent_sample.xml
+++ b/mcp-server/tests/fixtures/molit_apt_rent_sample.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items>
+      <item>
+        <aptNm>래미안</aptNm>
+        <deposit>  70,000 </deposit>
+        <monthlyRent>0</monthlyRent>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>20</dealDay>
+        <excluUseAr>76.79</excluUseAr>
+        <floor>1</floor>
+        <umdNm>대치동</umdNm>
+        <jibun>316</jibun>
+        <buildYear>1979</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+      <item>
+        <aptNm>자이</aptNm>
+        <deposit>20,000</deposit>
+        <monthlyRent>120</monthlyRent>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>22</dealDay>
+        <excluUseAr>59.98</excluUseAr>
+        <floor>5</floor>
+        <umdNm>역삼동</umdNm>
+        <jibun>510</jibun>
+        <buildYear>2015</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+    </items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>2</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_offi_rent_empty.xml
+++ b/mcp-server/tests/fixtures/molit_offi_rent_empty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items></items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>0</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_offi_rent_error.xml
+++ b/mcp-server/tests/fixtures/molit_offi_rent_error.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>30</resultCode>
+    <resultMsg>SERVICE KEY IS NOT REGISTERED ERROR</resultMsg>
+  </header>
+</response>

--- a/mcp-server/tests/fixtures/molit_offi_rent_sample.xml
+++ b/mcp-server/tests/fixtures/molit_offi_rent_sample.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items>
+      <item>
+        <offiNm>강남 스카이홈</offiNm>
+        <deposit>  16,500 </deposit>
+        <monthlyRent>10</monthlyRent>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>24</dealDay>
+        <excluUseAr>25.16</excluUseAr>
+        <floor>8</floor>
+        <umdNm>도곡동</umdNm>
+        <jibun>662</jibun>
+        <buildYear>2014</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+      <item>
+        <offiNm>역삼 라이프</offiNm>
+        <deposit>5,000</deposit>
+        <monthlyRent>80</monthlyRent>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>27</dealDay>
+        <excluUseAr>22.4</excluUseAr>
+        <floor>4</floor>
+        <umdNm>역삼동</umdNm>
+        <jibun>820</jibun>
+        <buildYear>2018</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+    </items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>2</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_offi_trade_empty.xml
+++ b/mcp-server/tests/fixtures/molit_offi_trade_empty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items></items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>0</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_offi_trade_error.xml
+++ b/mcp-server/tests/fixtures/molit_offi_trade_error.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>30</resultCode>
+    <resultMsg>SERVICE KEY IS NOT REGISTERED ERROR</resultMsg>
+  </header>
+</response>

--- a/mcp-server/tests/fixtures/molit_offi_trade_sample.xml
+++ b/mcp-server/tests/fixtures/molit_offi_trade_sample.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items>
+      <item>
+        <offiNm>강남 오피스텔</offiNm>
+        <dealAmount>  27,500 </dealAmount>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>20</dealDay>
+        <excluUseAr>21.9</excluUseAr>
+        <floor>9</floor>
+        <umdNm>청담동</umdNm>
+        <jibun>130-9</jibun>
+        <buildYear>1991</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+      <item>
+        <offiNm>역삼 시그마</offiNm>
+        <dealAmount>15,000</dealAmount>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>25</dealDay>
+        <excluUseAr>18.5</excluUseAr>
+        <floor>3</floor>
+        <umdNm>역삼동</umdNm>
+        <jibun>702</jibun>
+        <buildYear>2010</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+    </items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>2</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_rh_rent_empty.xml
+++ b/mcp-server/tests/fixtures/molit_rh_rent_empty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items></items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>0</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/fixtures/molit_rh_rent_error.xml
+++ b/mcp-server/tests/fixtures/molit_rh_rent_error.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>30</resultCode>
+    <resultMsg>SERVICE KEY IS NOT REGISTERED ERROR</resultMsg>
+  </header>
+</response>

--- a/mcp-server/tests/fixtures/molit_rh_rent_sample.xml
+++ b/mcp-server/tests/fixtures/molit_rh_rent_sample.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <header>
+    <resultCode>000</resultCode>
+    <resultMsg>OK</resultMsg>
+  </header>
+  <body>
+    <items>
+      <item>
+        <mhouseNm>역삼삼성빌라</mhouseNm>
+        <houseType>다세대</houseType>
+        <deposit>  30,500 </deposit>
+        <monthlyRent>0</monthlyRent>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>23</dealDay>
+        <excluUseAr>26.93</excluUseAr>
+        <floor>2</floor>
+        <umdNm>역삼동</umdNm>
+        <jibun>1206</jibun>
+        <buildYear>2017</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+      <item>
+        <mhouseNm>대치연립</mhouseNm>
+        <houseType>연립</houseType>
+        <deposit>10,000</deposit>
+        <monthlyRent>50</monthlyRent>
+        <dealYear>2024</dealYear>
+        <dealMonth>3</dealMonth>
+        <dealDay>26</dealDay>
+        <excluUseAr>40.5</excluUseAr>
+        <floor>3</floor>
+        <umdNm>대치동</umdNm>
+        <jibun>402</jibun>
+        <buildYear>1995</buildYear>
+        <sggCd>11680</sggCd>
+      </item>
+    </items>
+    <numOfRows>10</numOfRows>
+    <pageNo>1</pageNo>
+    <totalCount>2</totalCount>
+  </body>
+</response>

--- a/mcp-server/tests/tools/test_real_estate.py
+++ b/mcp-server/tests/tools/test_real_estate.py
@@ -42,7 +42,7 @@ def reset_module_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture(autouse=True)
 def set_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """기본 키 주입. 키 미설정 분기 테스트는 자기 안에서 다시 비운다."""
-    monkeypatch.setenv("MOLIT_TRADE_API_KEY", "test-key-12345")
+    monkeypatch.setenv("MOLIT_APT_TRADE_API_KEY", "test-key-12345")
     get_settings.cache_clear()
 
 
@@ -193,9 +193,9 @@ async def test_search_propagates_normalization_error(
 async def test_search_raises_when_api_key_missing(
     patched_session_factory, monkeypatch: pytest.MonkeyPatch
 ):
-    """MOLIT_TRADE_API_KEY 빈 값 → RealEstateConfigError, fetch 호출 X."""
+    """MOLIT_APT_TRADE_API_KEY 빈 값 → RealEstateConfigError, fetch 호출 X."""
     await _seed_source()
-    monkeypatch.setenv("MOLIT_TRADE_API_KEY", "")
+    monkeypatch.setenv("MOLIT_APT_TRADE_API_KEY", "")
     get_settings.cache_clear()
 
     fetch_called = False

--- a/mcp-server/tests/tools/test_real_estate.py
+++ b/mcp-server/tests/tools/test_real_estate.py
@@ -1,7 +1,10 @@
-"""tools.real_estate.search_house_price 단위 테스트.
+"""tools.real_estate.* 단위 테스트.
 
 실제 HTTP 호출 없이 api_source_service.fetch 를 stub 으로 교체해 도구 자체의 책임
 (키 검증 → region 변환 → fetch → 정규화 → 통계 산출 → 공통 스키마 반환) 만 격리한다.
+
+자료유형 5종 (search_house_price / search_apt_rent / search_offi_trade /
+search_offi_rent / search_rh_rent) 모두 같은 fetch stub 패턴 공유.
 """
 
 from datetime import UTC, datetime
@@ -23,8 +26,13 @@ from mcp_server.sources.errors import SourceFetchError, SourceNotFoundError
 from mcp_server.sources.result import RawResult
 from mcp_server.tools import real_estate
 from mcp_server.tools.real_estate import (
+    MolitRealEstateInput,
     SearchHousePriceInput,
+    search_apt_rent,
     search_house_price,
+    search_offi_rent,
+    search_offi_trade,
+    search_rh_rent,
 )
 
 FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
@@ -32,25 +40,39 @@ SAMPLE_XML = (FIXTURES / "molit_apt_trade_sample.xml").read_text(encoding="utf-8
 EMPTY_XML = (FIXTURES / "molit_apt_trade_empty.xml").read_text(encoding="utf-8")
 ERROR_XML = (FIXTURES / "molit_apt_trade_error.xml").read_text(encoding="utf-8")
 
+# 신규 자료유형별 sample 픽스처
+APT_RENT_XML = (FIXTURES / "molit_apt_rent_sample.xml").read_text(encoding="utf-8")
+OFFI_TRADE_XML = (FIXTURES / "molit_offi_trade_sample.xml").read_text(encoding="utf-8")
+OFFI_RENT_XML = (FIXTURES / "molit_offi_rent_sample.xml").read_text(encoding="utf-8")
+RH_RENT_XML = (FIXTURES / "molit_rh_rent_sample.xml").read_text(encoding="utf-8")
+
 
 @pytest.fixture(autouse=True)
 def reset_module_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """도구 모듈 lazy 캐시(_cached_source_id) 를 테스트 간 격리."""
-    monkeypatch.setattr(real_estate, "_cached_source_id", None)
+    """도구 모듈 source_id 캐시(dict) 를 테스트 간 격리."""
+    monkeypatch.setattr(real_estate, "_cached_source_ids", {})
 
 
 @pytest.fixture(autouse=True)
-def set_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """기본 키 주입. 키 미설정 분기 테스트는 자기 안에서 다시 비운다."""
+def set_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """5종 자료유형 키 모두 기본 주입. 키 미설정 분기 테스트는 자기 안에서 다시 비운다."""
     monkeypatch.setenv("MOLIT_APT_TRADE_API_KEY", "test-key-12345")
+    monkeypatch.setenv("MOLIT_APT_RENT_API_KEY", "test-key-12345")
+    monkeypatch.setenv("MOLIT_OFFI_TRADE_API_KEY", "test-key-12345")
+    monkeypatch.setenv("MOLIT_OFFI_RENT_API_KEY", "test-key-12345")
+    monkeypatch.setenv("MOLIT_RH_RENT_API_KEY", "test-key-12345")
     get_settings.cache_clear()
 
 
-async def _seed_source(url_template: str = "https://example.gov/molit/apt-trade") -> ApiSource:
+async def _seed_source(
+    tool_name: str = "search_house_price",
+    url_template: str = "https://example.gov/molit/apt-trade",
+    name: str = "국토교통부 아파트 매매 실거래가 (테스트)",
+) -> ApiSource:
     async with get_session() as session:
         row = ApiSource(
-            tool_name="search_house_price",
-            name="국토교통부 아파트 매매 실거래가 (테스트)",
+            tool_name=tool_name,
+            name=name,
             url_template=url_template,
             param_schema={"type": "object"},
         )
@@ -60,7 +82,13 @@ async def _seed_source(url_template: str = "https://example.gov/molit/apt-trade"
         return row
 
 
-def _make_fake_fetch(content: str, captured: dict[str, Any]):
+def _make_fake_fetch(
+    content: str,
+    captured: dict[str, Any],
+    *,
+    tool_name: str = "search_house_price",
+    url_template: str = "https://example.gov/molit/apt-trade",
+):
     """fetch 호출을 가로채 params 를 captured 에 기록하고 RawResult 를 반환하는 fake."""
 
     async def fake(source_id: int, params: dict | None = None, **_: Any) -> RawResult:
@@ -72,8 +100,8 @@ def _make_fake_fetch(content: str, captured: dict[str, Any]):
             content=content,
             fetched_at=datetime(2026, 4, 24, 12, 0, tzinfo=UTC),
             raw_metadata={
-                "tool_name": "search_house_price",
-                "url_template": "https://example.gov/molit/apt-trade",
+                "tool_name": tool_name,
+                "url_template": url_template,
                 "params": params or {},
             },
         )
@@ -309,3 +337,274 @@ def test_input_validates_deal_ymd_pattern():
         SearchHousePriceInput(region="강남구", deal_ymd="2024-03")
     with pytest.raises(Exception):
         SearchHousePriceInput(region="강남구", deal_ymd="20240")
+
+
+def test_search_house_price_input_alias():
+    """SearchHousePriceInput 은 MolitRealEstateInput 의 호환 alias."""
+    assert SearchHousePriceInput is MolitRealEstateInput
+
+
+# ─────────────────────────────────────────────
+# search_apt_rent (아파트 전월세)
+# ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_search_apt_rent_returns_rent_summary(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """전월세 정상 응답 → summary 에 deposit/monthly_rent 통계, trades 에 apt_name."""
+    await _seed_source(
+        tool_name="search_apt_rent",
+        url_template="https://example.gov/molit/apt-rent",
+        name="국토교통부 아파트 전월세 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            APT_RENT_XML,
+            captured,
+            tool_name="search_apt_rent",
+            url_template="https://example.gov/molit/apt-rent",
+        ),
+    )
+
+    result = await search_apt_rent(MolitRealEstateInput(region="강남구", deal_ymd="202403"))
+
+    summary = result["structured"]["summary"]
+    assert summary["count"] == 2
+    assert summary["avg_deposit"] == 45000  # (70000 + 20000) / 2
+    assert summary["min_deposit"] == 20000
+    assert summary["max_deposit"] == 70000
+    assert summary["avg_monthly_rent"] == 60  # (0 + 120) / 2
+    # 보증금 내림차순
+    deposits = [t["deposit"] for t in result["structured"]["trades"]]
+    assert deposits == sorted(deposits, reverse=True)
+    # apt_name 필드가 그대로 노출
+    assert "apt_name" in result["structured"]["trades"][0]
+    assert result["metadata"]["tool_name"] == "search_apt_rent"
+
+
+@pytest.mark.asyncio
+async def test_search_apt_rent_raises_when_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """MOLIT_APT_RENT_API_KEY 빈 값 → RealEstateConfigError, fetch 미호출."""
+    await _seed_source(tool_name="search_apt_rent")
+    monkeypatch.setenv("MOLIT_APT_RENT_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(RealEstateConfigError):
+        await search_apt_rent(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+
+# ─────────────────────────────────────────────
+# search_offi_trade (오피스텔 매매)
+# ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_search_offi_trade_returns_trade_summary(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """오피스텔 매매 정상 응답 → summary 에 deal_amount 통계, trades 에 offi_name."""
+    await _seed_source(
+        tool_name="search_offi_trade",
+        url_template="https://example.gov/molit/offi-trade",
+        name="국토교통부 오피스텔 매매 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            OFFI_TRADE_XML,
+            captured,
+            tool_name="search_offi_trade",
+            url_template="https://example.gov/molit/offi-trade",
+        ),
+    )
+
+    result = await search_offi_trade(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+    summary = result["structured"]["summary"]
+    assert summary["count"] == 2
+    assert summary["avg_deal_amount"] == 21250  # (27500 + 15000) / 2
+    assert summary["max_deal_amount"] == 27500
+    # offi_name 필드 노출 (apt_name 아님)
+    first = result["structured"]["trades"][0]
+    assert "offi_name" in first
+    assert "apt_name" not in first
+    assert result["metadata"]["tool_name"] == "search_offi_trade"
+
+
+@pytest.mark.asyncio
+async def test_search_offi_trade_raises_when_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    await _seed_source(tool_name="search_offi_trade")
+    monkeypatch.setenv("MOLIT_OFFI_TRADE_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(RealEstateConfigError):
+        await search_offi_trade(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+
+# ─────────────────────────────────────────────
+# search_offi_rent (오피스텔 전월세)
+# ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_search_offi_rent_returns_rent_summary(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    await _seed_source(
+        tool_name="search_offi_rent",
+        url_template="https://example.gov/molit/offi-rent",
+        name="국토교통부 오피스텔 전월세 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            OFFI_RENT_XML,
+            captured,
+            tool_name="search_offi_rent",
+            url_template="https://example.gov/molit/offi-rent",
+        ),
+    )
+
+    result = await search_offi_rent(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+    summary = result["structured"]["summary"]
+    assert summary["count"] == 2
+    assert summary["avg_deposit"] == 10750  # (16500 + 5000) / 2
+    assert summary["avg_monthly_rent"] == 45  # (10 + 80) / 2
+    first = result["structured"]["trades"][0]
+    assert "offi_name" in first
+    assert result["metadata"]["tool_name"] == "search_offi_rent"
+
+
+@pytest.mark.asyncio
+async def test_search_offi_rent_raises_when_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    await _seed_source(tool_name="search_offi_rent")
+    monkeypatch.setenv("MOLIT_OFFI_RENT_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(RealEstateConfigError):
+        await search_offi_rent(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+
+# ─────────────────────────────────────────────
+# search_rh_rent (연립다세대 전월세)
+# ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_search_rh_rent_returns_rent_summary_with_house_type(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """연립다세대 응답 → summary 는 전월세 공통, trades 는 mhouse_name + house_type."""
+    await _seed_source(
+        tool_name="search_rh_rent",
+        url_template="https://example.gov/molit/rh-rent",
+        name="국토교통부 연립다세대 전월세 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            RH_RENT_XML,
+            captured,
+            tool_name="search_rh_rent",
+            url_template="https://example.gov/molit/rh-rent",
+        ),
+    )
+
+    result = await search_rh_rent(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+    summary = result["structured"]["summary"]
+    assert summary["count"] == 2
+    assert summary["avg_deposit"] == 20250  # (30500 + 10000) / 2
+    first = result["structured"]["trades"][0]
+    assert "mhouse_name" in first
+    assert "house_type" in first
+    assert first["house_type"] in {"다세대", "연립"}
+    assert result["metadata"]["tool_name"] == "search_rh_rent"
+
+
+@pytest.mark.asyncio
+async def test_search_rh_rent_raises_when_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    await _seed_source(tool_name="search_rh_rent")
+    monkeypatch.setenv("MOLIT_RH_RENT_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(RealEstateConfigError):
+        await search_rh_rent(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+
+# ─────────────────────────────────────────────
+# tool_name 별 source_id 캐시 격리 검증
+# ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_resolve_source_id_caches_per_tool_name(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """5개 도구가 같은 _cached_source_ids dict 를 공유하지만 키 충돌 없이 각자 캐시."""
+    apt_trade_row = await _seed_source(tool_name="search_house_price")
+    offi_trade_row = await _seed_source(
+        tool_name="search_offi_trade",
+        url_template="https://example.gov/molit/offi-trade",
+        name="오피스텔 매매 (테스트)",
+    )
+
+    captured1: dict[str, Any] = {}
+    captured2: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(SAMPLE_XML, captured1),
+    )
+    await search_house_price(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            OFFI_TRADE_XML,
+            captured2,
+            tool_name="search_offi_trade",
+            url_template="https://example.gov/molit/offi-trade",
+        ),
+    )
+    await search_offi_trade(MolitRealEstateInput(region="11680", deal_ymd="202403"))
+
+    # 각 도구별로 자기 source_id 가 캐시됐는지 검증
+    assert real_estate._cached_source_ids["search_house_price"] == apt_trade_row.id
+    assert real_estate._cached_source_ids["search_offi_trade"] == offi_trade_row.id


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #71 

**🛠 작업 내역**

MOLIT 부동산 실거래가 도구를 아파트 매매 1종 → 5종 자료유형으로 확장.

  | # | tool_name | 자료유형 | API 키 |
  |---|---|---|---|
  | 1 | `search_house_price` (기존) | 아파트 매매 | `MOLIT_APT_TRADE_API_KEY` |
  | 2 | `search_apt_rent` | 아파트 전월세 | `MOLIT_APT_RENT_API_KEY` |
  | 3 | `search_offi_trade` | 오피스텔 매매 | `MOLIT_OFFI_TRADE_API_KEY` |
  | 4 | `search_offi_rent` | 오피스텔 전월세 | `MOLIT_OFFI_RENT_API_KEY` |
  | 5 | `search_rh_rent` | 연립다세대 전월세 | `MOLIT_RH_RENT_API_KEY` |

  5종 모두 region + deal_ymd 동일 시그니처 를 공유하고, 자료유형별 정규화/응답 빌더만 분기
 기존 `search_house_price` 호출자는 변경 없이 동작

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?