### PR TITLE
FEAT: AI 파싱 결과 Typed Schema 검증 및 MCP 입력 검증 강화

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/ai/AiParsedTaskSchema.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/AiParsedTaskSchema.java
@@ -1,0 +1,103 @@
+package com.back.domain.adapter.out.ai;
+
+import com.back.domain.model.notification.NotificationChannel;
+import com.back.global.error.ApiException;
+import com.back.global.error.ErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Locale;
+import java.util.Set;
+
+final class AiParsedTaskSchema {
+    private static final Set<String> INTENTS = Set.of("create", "delete", "modify", "reject");
+    private static final Set<String> DOMAINS = Set.of(
+            "부동산", "real-estate",
+            "법률", "법률/규제", "law-regulation",
+            "채용", "recruitment",
+            "경매", "경매/희소매물", "auction"
+    );
+    private static final Set<String> API_TYPES = Set.of("api", "crawl", "rss", "search");
+
+    private AiParsedTaskSchema() {
+    }
+
+    static void validate(JsonNode node) {
+        JsonNode meta = node.path("metadata");
+        if (!node.isObject() || !meta.isObject()) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+
+        String intent = requiredText(node, "intent");
+        validateIntent(intent);
+        String domainName = optionalText(node, "domain_name");
+        validateDomainForIntent(intent, domainName);
+        String channel = optionalText(node, "channel");
+        validateChannel(channel);
+        String apiType = optionalText(node, "api_type");
+        validateApiType(apiType);
+
+        double confidence = meta.path("confidence").asDouble(Double.NaN);
+        if (Double.isNaN(confidence) || confidence < 0.0 || confidence > 1.0) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+    }
+
+    private static String requiredText(JsonNode node, String fieldName) {
+        String value = optionalText(node, fieldName);
+        if (value.isBlank()) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+        return value;
+    }
+
+    private static String optionalText(JsonNode node, String fieldName) {
+        JsonNode value = node.path(fieldName);
+        return value.isMissingNode() || value.isNull() ? "" : value.asText("").trim();
+    }
+
+    private static void validateIntent(String value) {
+        if (!INTENTS.contains(value)) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+    }
+
+    private static void validateDomainForIntent(String intent, String domainName) {
+        if ("create".equals(intent)) {
+            if (domainName.isBlank()) {
+                throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+            }
+            validateDomain(domainName);
+        } else if (!domainName.isBlank() && !"reject".equals(intent)) {
+            validateDomain(domainName);
+        }
+    }
+
+    private static void validateDomain(String value) {
+        if (!DOMAINS.contains(value)) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+    }
+
+    private static void validateApiType(String value) {
+        if (!value.isBlank() && !API_TYPES.contains(value)) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+    }
+
+    private static void validateChannel(String value) {
+        if (value.isBlank()) {
+            return;
+        }
+        String normalized = value.toUpperCase(Locale.ROOT);
+        if ("TELEGRAM".equals(normalized)) {
+            normalized = "TELEGRAM_DM";
+        }
+        if ("DISCORD".equals(normalized)) {
+            normalized = "DISCORD_DM";
+        }
+        try {
+            NotificationChannel.valueOf(normalized);
+        } catch (IllegalArgumentException exception) {
+            throw new ApiException(ErrorCode.AI_PARSE_FAILED);
+        }
+    }
+}

--- a/back/src/main/java/com/back/domain/adapter/out/ai/GlmTaskParserAdapter.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/GlmTaskParserAdapter.java
@@ -123,6 +123,8 @@ public class GlmTaskParserAdapter implements ParseNaturalLanguagePort {
     }
 
     private ParsedTask parseSingleTask(JsonNode node) {
+        AiParsedTaskSchema.validate(node);
+
         JsonNode meta = node.path("metadata");
         return new ParsedTask(
                 node.path("intent").asText(""),

--- a/back/src/main/java/com/back/domain/application/service/ScheduleExecutionService.java
+++ b/back/src/main/java/com/back/domain/application/service/ScheduleExecutionService.java
@@ -25,8 +25,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -44,7 +42,6 @@ public class ScheduleExecutionService implements RunDueSchedulesUseCase {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, Object>> PARAMETER_MAP = new TypeReference<>() {};
-    private static final DateTimeFormatter DEAL_YMD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
     private static final Pattern REGION = Pattern.compile(
             "([가-힣]+(?:특별자치시|특별자치도|특별시|광역시|시|군|구)|서울|부산|대구|인천|광주|대전|울산|세종|제주)"
     );
@@ -144,7 +141,7 @@ public class ScheduleExecutionService implements RunDueSchedulesUseCase {
                 .map(this::parameters)
                 .orElseGet(() -> fallbackParameters(query));
         if (tool.name().startsWith("search_house_price")) {
-            return searchHousePriceArguments(parameters, now);
+            return SearchHousePriceMcpInput.from(parameters, now).toArguments();
         }
         return parameters;
     }
@@ -166,28 +163,6 @@ public class ScheduleExecutionService implements RunDueSchedulesUseCase {
             return Map.of();
         }
         return Map.of("region", region);
-    }
-
-    private Map<String, Object> searchHousePriceArguments(Map<String, Object> parameters, LocalDateTime now) {
-        Map<String, Object> input = new LinkedHashMap<>();
-        String region = stringValue(parameters.get("region"));
-        if (!isBlank(region)) {
-            input.put("region", region);
-        }
-        input.put("deal_ymd", dealYmd(parameters, now));
-        return Map.of("input", input);
-    }
-
-    private String dealYmd(Map<String, Object> parameters, LocalDateTime now) {
-        String dealYmd = stringValue(parameters.get("deal_ymd"));
-        if (!isBlank(dealYmd)) {
-            return dealYmd;
-        }
-        dealYmd = stringValue(parameters.get("dealYmd"));
-        if (!isBlank(dealYmd)) {
-            return dealYmd;
-        }
-        return now.minusMonths(1).format(DEAL_YMD_FORMATTER);
     }
 
     private String extractRegion(String query) {

--- a/back/src/main/java/com/back/domain/application/service/SearchHousePriceMcpInput.java
+++ b/back/src/main/java/com/back/domain/application/service/SearchHousePriceMcpInput.java
@@ -1,0 +1,57 @@
+package com.back.domain.application.service;
+
+import com.back.global.error.ApiException;
+import com.back.global.error.ErrorCode;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+record SearchHousePriceMcpInput(String region, String dealYmd) {
+    private static final Pattern DEAL_YMD = Pattern.compile("^[0-9]{6}$");
+    private static final DateTimeFormatter DEAL_YMD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+
+    SearchHousePriceMcpInput {
+        if (region == null || region.isBlank()) {
+            throw new ApiException(ErrorCode.MCP_REQUEST_FAILED);
+        }
+        if (dealYmd == null || !DEAL_YMD.matcher(dealYmd).matches()) {
+            throw new ApiException(ErrorCode.MCP_REQUEST_FAILED);
+        }
+    }
+
+    static SearchHousePriceMcpInput from(Map<String, Object> parameters, LocalDateTime now) {
+        return new SearchHousePriceMcpInput(
+                stringValue(parameters.get("region")),
+                dealYmd(parameters, now)
+        );
+    }
+
+    Map<String, Object> toArguments() {
+        Map<String, Object> input = new LinkedHashMap<>();
+        input.put("region", region);
+        input.put("deal_ymd", dealYmd);
+        return Map.of("input", input);
+    }
+
+    private static String dealYmd(Map<String, Object> parameters, LocalDateTime now) {
+        String dealYmd = stringValue(parameters.get("deal_ymd"));
+        if (!isBlank(dealYmd)) {
+            return dealYmd;
+        }
+        dealYmd = stringValue(parameters.get("dealYmd"));
+        if (!isBlank(dealYmd)) {
+            return dealYmd;
+        }
+        return now.minusMonths(1).format(DEAL_YMD_FORMATTER);
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/ParsedTaskNormalizer.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/ParsedTaskNormalizer.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -74,12 +75,12 @@ public class ParsedTaskNormalizer {
             params.put("region", region);
         }
 
-        if (!isBlank(task.condition())) {
-            params.put("condition", task.condition());
-        } else if (canReusePrevious && !isBlank(previousDraft.monitoringParams().get("condition"))) {
-            params.put("condition", previousDraft.monitoringParams().get("condition"));
+        Optional<StructuredCondition> condition = StructuredCondition.parse(task.condition());
+        if (condition.isEmpty() && canReusePrevious) {
+            condition = StructuredCondition.fromParameters(previousDraft.monitoringParams());
         }
-        if (isBlank(params.get("condition"))) {
+        condition.ifPresent(structuredCondition -> params.putAll(structuredCondition.toParameterMap()));
+        if (condition.isEmpty()) {
             missing.add("condition");
         }
 

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/StructuredCondition.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/StructuredCondition.java
@@ -1,0 +1,143 @@
+package com.back.domain.application.service.subscriptionconversation;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public record StructuredCondition(
+        Metric metric,
+        Direction direction,
+        Operator operator,
+        BigDecimal threshold,
+        Unit unit
+) {
+    private static final Pattern THRESHOLD = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*(%|퍼센트|프로|만원|억)?");
+
+    public StructuredCondition {
+        if (metric == null || direction == null || operator == null || threshold == null || unit == null) {
+            throw new IllegalArgumentException("condition fields must not be null");
+        }
+    }
+
+    public static Optional<StructuredCondition> parse(String raw) {
+        String text = raw == null ? "" : raw.trim();
+        if (text.isBlank()) {
+            return Optional.empty();
+        }
+
+        Matcher matcher = THRESHOLD.matcher(text);
+        if (!matcher.find()) {
+            return Optional.empty();
+        }
+
+        BigDecimal threshold = new BigDecimal(matcher.group(1)).stripTrailingZeros();
+        Unit unit = Unit.from(matcher.group(2));
+        Direction direction = Direction.from(text);
+        Operator operator = Operator.from(text);
+        return Optional.of(new StructuredCondition(
+                Metric.AVG_PRICE,
+                direction,
+                operator,
+                threshold,
+                unit
+        ));
+    }
+
+    public static Optional<StructuredCondition> fromParameters(Map<String, String> parameters) {
+        if (parameters == null || parameters.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            String metric = parameters.get("conditionMetric");
+            String direction = parameters.get("conditionDirection");
+            String operator = parameters.get("conditionOperator");
+            String threshold = parameters.get("conditionThreshold");
+            String unit = parameters.get("conditionUnit");
+            if (isBlank(metric) || isBlank(direction) || isBlank(operator) || isBlank(threshold) || isBlank(unit)) {
+                return parse(parameters.get("condition"));
+            }
+            return Optional.of(new StructuredCondition(
+                    Metric.valueOf(metric),
+                    Direction.valueOf(direction),
+                    Operator.valueOf(operator),
+                    new BigDecimal(threshold).stripTrailingZeros(),
+                    Unit.valueOf(unit)
+            ));
+        } catch (IllegalArgumentException exception) {
+            return Optional.empty();
+        }
+    }
+
+    public Map<String, String> toParameterMap() {
+        Map<String, String> value = new LinkedHashMap<>();
+        value.put("conditionMetric", metric.name());
+        value.put("conditionDirection", direction.name());
+        value.put("conditionOperator", operator.name());
+        value.put("conditionThreshold", threshold.toPlainString());
+        value.put("conditionUnit", unit.name());
+        return value;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    public enum Metric {
+        AVG_PRICE
+    }
+
+    public enum Direction {
+        UP,
+        DOWN,
+        ANY;
+
+        private static Direction from(String text) {
+            if (text.contains("하락") || text.contains("떨어") || text.contains("내리")) {
+                return DOWN;
+            }
+            if (text.contains("상승") || text.contains("오르") || text.contains("올라")) {
+                return UP;
+            }
+            return ANY;
+        }
+    }
+
+    public enum Operator {
+        GTE,
+        GT,
+        LTE,
+        LT;
+
+        private static Operator from(String text) {
+            if (text.contains("미만")) {
+                return LT;
+            }
+            if (text.contains("이하")) {
+                return LTE;
+            }
+            if (text.contains("초과")) {
+                return GT;
+            }
+            return GTE;
+        }
+    }
+
+    public enum Unit {
+        PERCENT,
+        MANWON,
+        EOK;
+
+        private static Unit from(String raw) {
+            if ("만원".equals(raw)) {
+                return MANWON;
+            }
+            if ("억".equals(raw)) {
+                return EOK;
+            }
+            return PERCENT;
+        }
+    }
+}

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -366,7 +366,7 @@ public class SubscriptionConversationService {
                 && !isBlank(draft.query())
                 && !isBlank(draft.intent())
                 && !isBlank(draft.toolName())
-                && !isBlank(draft.monitoringParams().get("condition"))
+                && StructuredCondition.fromParameters(draft.monitoringParams()).isPresent()
                 && !isBlank(draft.cronExpr())
                 && channel != null
                 && draft.missingFields().isEmpty();
@@ -423,7 +423,9 @@ public class SubscriptionConversationService {
         }
 
         Map<String, String> monitoringParams = new HashMap<>(monitoringParams(conversation.getDraftMonitoringParams()));
-        monitoringParams.put("condition", percentCondition(message, matcher.group(1)));
+        monitoringParams.remove("condition");
+        StructuredCondition.parse(percentCondition(message, matcher.group(1)))
+                .ifPresent(condition -> monitoringParams.putAll(condition.toParameterMap()));
         conversation.updateParsedDraft(
                 conversation.getParseSessionId(),
                 conversation.getDraftQuery(),
@@ -495,7 +497,7 @@ public class SubscriptionConversationService {
                 ).isEmpty()) {
             missing.add("notificationEndpoint");
         }
-        if (isBlank(monitoringParams(conversation.getDraftMonitoringParams()).get("condition"))) {
+        if (StructuredCondition.fromParameters(monitoringParams(conversation.getDraftMonitoringParams())).isEmpty()) {
             missing.add("condition");
         }
         if (conversation.getDraftDomainId() == null

--- a/back/src/test/java/com/back/domain/adapter/out/ai/GlmTaskParserAdapterTest.java
+++ b/back/src/test/java/com/back/domain/adapter/out/ai/GlmTaskParserAdapterTest.java
@@ -1,6 +1,7 @@
 package com.back.domain.adapter.out.ai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
@@ -9,6 +10,8 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.back.domain.application.result.ParsedTask;
+import com.back.global.error.ApiException;
+import com.back.global.error.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -43,7 +46,7 @@ class GlmTaskParserAdapterTest {
                   "choices": [
                     {
                       "message": {
-                        "content": "[{\\"intent\\":\\"create\\",\\"domain_name\\":\\"부동산\\",\\"query\\":\\"안산시 본오동 집값\\",\\"condition\\":\\"\\",\\"cron_expr\\":\\"\\",\\"channel\\":\\"\\",\\"api_type\\":\\"real_estate\\",\\"metadata\\":{\\"target\\":\\"안산시 본오동\\",\\"urls\\":[],\\"confidence\\":0.8,\\"needs_confirmation\\":true,\\"confirmation_question\\":\\"주기를 선택해 주세요.\\"}}]"
+                        "content": "[{\\"intent\\":\\"create\\",\\"domain_name\\":\\"부동산\\",\\"query\\":\\"안산시 본오동 집값\\",\\"condition\\":\\"\\",\\"cron_expr\\":\\"\\",\\"channel\\":\\"\\",\\"api_type\\":\\"crawl\\",\\"metadata\\":{\\"target\\":\\"안산시 본오동\\",\\"urls\\":[],\\"confidence\\":0.8,\\"needs_confirmation\\":true,\\"confirmation_question\\":\\"주기를 선택해 주세요.\\"}}]"
                       }
                     }
                   ]
@@ -56,5 +59,65 @@ class GlmTaskParserAdapterTest {
         assertThat(result.getFirst().domainName()).isEqualTo("부동산");
         assertThat(result.getFirst().target()).isEqualTo("안산시 본오동");
         server.verify();
+    }
+
+    @Test
+    void parseRejectsInvalidEnumValuesFromAiResponse() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        GlmTaskParserAdapter adapter = new GlmTaskParserAdapter(
+                builder,
+                "https://api.z.ai/api/coding/paas/v4",
+                "parser-key",
+                new ObjectMapper()
+        );
+
+        server.expect(requestTo("https://api.z.ai/api/coding/paas/v4/chat/completions"))
+                .andRespond(withSuccess("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "[{\\"intent\\":\\"subscribe\\",\\"domain_name\\":\\"부동산\\",\\"query\\":\\"강남구 집값\\",\\"condition\\":\\"5% 이상 상승\\",\\"cron_expr\\":\\"0 9 * * *\\",\\"channel\\":\\"telegram\\",\\"api_type\\":\\"api\\",\\"metadata\\":{\\"target\\":\\"강남구\\",\\"urls\\":[],\\"confidence\\":0.8,\\"needs_confirmation\\":false,\\"confirmation_question\\":\\"\\"}}]"
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> adapter.parse("강남구 집값"))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_PARSE_FAILED);
+    }
+
+    @Test
+    void parseRejectsMissingMetadataFromAiResponse() {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        GlmTaskParserAdapter adapter = new GlmTaskParserAdapter(
+                builder,
+                "https://api.z.ai/api/coding/paas/v4",
+                "parser-key",
+                new ObjectMapper()
+        );
+
+        server.expect(requestTo("https://api.z.ai/api/coding/paas/v4/chat/completions"))
+                .andRespond(withSuccess("""
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": "[{\\"intent\\":\\"create\\",\\"domain_name\\":\\"부동산\\",\\"query\\":\\"강남구 집값\\",\\"condition\\":\\"5% 이상 상승\\",\\"cron_expr\\":\\"0 9 * * *\\",\\"channel\\":\\"telegram\\",\\"api_type\\":\\"api\\"}]"
+                      }
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> adapter.parse("강남구 집값"))
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AI_PARSE_FAILED);
     }
 }

--- a/back/src/test/java/com/back/domain/application/service/ScheduleExecutionServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/ScheduleExecutionServiceTest.java
@@ -291,6 +291,49 @@ class ScheduleExecutionServiceTest {
                 .containsOnly("TELEGRAM_DM");
     }
 
+    @Test
+    @DisplayName("Application: MCP input validation rejects malformed configured deal_ymd before calling MCP")
+    void rejectsMalformedConfiguredDealYmdBeforeCallingMcp() {
+        User user = new User(1L, "user@example.com", "사용자", LocalDateTime.now(), null);
+        Domain domain = new Domain(10L, "real-estate");
+        Subscription subscription = new Subscription("sub-1", user, domain, "강남구 아파트 실거래가", "create", true, LocalDateTime.now());
+        Schedule schedule = new Schedule("schedule-1", subscription, "0 0 * * * *", null, LocalDateTime.now().minusMinutes(1));
+        McpTool tool = new McpTool(
+                100L,
+                new McpServer(1L, "default-mcp", "server", "http://localhost:8090/tools/execute"),
+                domain,
+                "search_house_price",
+                "부동산 실거래가 조회",
+                "{}"
+        );
+        FakeExecuteMcpToolPort executeMcpToolPort = new FakeExecuteMcpToolPort();
+        LoadSubscriptionMonitoringConfigPort loadConfigPort = subscriptionId -> Optional.of(
+                new SubscriptionMonitoringConfig(
+                        subscriptionId,
+                        "search_house_price",
+                        "apartment_trade_price",
+                        "{\"region\":\"강남구\",\"deal_ymd\":\"2024-03\"}"
+                )
+        );
+        ScheduleExecutionService service = new ScheduleExecutionService(
+                new FakeLoadDueSchedulesPort(schedule),
+                new FakeLoadMcpToolPort(tool),
+                loadConfigPort,
+                subscriptionId -> List.of(),
+                executeMcpToolPort,
+                new FakeSaveAiDataHubPort(),
+                new FakeSaveNotificationPort(),
+                notification -> true,
+                new FakeSaveSchedulePort()
+        );
+
+        assertThatThrownBy(service::runDueSchedules)
+                .isInstanceOf(ApiException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MCP_REQUEST_FAILED);
+        assertThat(executeMcpToolPort.executedToolName).isNull();
+    }
+
     private record FakeLoadDueSchedulesPort(Schedule schedule) implements LoadDueSchedulesPort {
 
         @Override

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/StructuredConditionTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/StructuredConditionTest.java
@@ -1,0 +1,31 @@
+package com.back.domain.application.service.subscriptionconversation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Application: structured monitoring condition")
+class StructuredConditionTest {
+
+    @Test
+    @DisplayName("parses percent rise condition into canonical fields")
+    void parsesPercentRiseCondition() {
+        Optional<StructuredCondition> parsed = StructuredCondition.parse("5% 이상 상승");
+
+        assertThat(parsed).isPresent();
+        assertThat(parsed.get().toParameterMap())
+                .containsEntry("conditionMetric", "AVG_PRICE")
+                .containsEntry("conditionDirection", "UP")
+                .containsEntry("conditionOperator", "GTE")
+                .containsEntry("conditionThreshold", "5")
+                .containsEntry("conditionUnit", "PERCENT");
+    }
+
+    @Test
+    @DisplayName("rejects vague condition without numeric threshold")
+    void rejectsVagueCondition() {
+        assertThat(StructuredCondition.parse("오르면 알려줘")).isEmpty();
+    }
+}

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -173,7 +173,10 @@ class SubscriptionConversationServiceTest {
         assertThat(savedConversation.getDraftDomainName()).isEqualTo("real-estate");
         assertThat(savedConversation.getDraftCronExpr()).isEqualTo("0 0 9 * * *");
         assertThat(savedConversation.getDraftNotificationChannel()).isEqualTo(NotificationChannel.TELEGRAM_DM);
-        assertThat(savedConversation.getDraftMonitoringParams()).contains("\"condition\":\"5% 이상\"");
+        assertThat(savedConversation.getDraftMonitoringParams())
+                .contains("\"conditionThreshold\":\"5\"")
+                .contains("\"conditionDirection\":\"ANY\"")
+                .contains("\"conditionUnit\":\"PERCENT\"");
     }
 
     @Test
@@ -211,7 +214,10 @@ class SubscriptionConversationServiceTest {
         assertThat(response.assistantMessage()).isEqualTo("얼마나 자주 확인할까요?");
         assertThat(response.actions()).extracting(SubscriptionConversationService.ActionOption::type)
                 .containsOnly("SELECT_CADENCE");
-        assertThat(savedConversation.getDraftMonitoringParams()).contains("\"condition\":\"13% 이상 변동\"");
+        assertThat(savedConversation.getDraftMonitoringParams())
+                .contains("\"conditionThreshold\":\"13\"")
+                .contains("\"conditionDirection\":\"ANY\"")
+                .contains("\"conditionUnit\":\"PERCENT\"");
     }
 
     @Test
@@ -265,7 +271,10 @@ class SubscriptionConversationServiceTest {
         assertThat(parseTaskUseCase.continueCallCount).isZero();
         assertThat(response.status()).isEqualTo("NEEDS_INPUT");
         assertThat(response.assistantMessage()).isEqualTo("얼마나 자주 확인할까요?");
-        assertThat(savedConversation.getDraftMonitoringParams()).contains("\"condition\":\"5% 이상 상승\"");
+        assertThat(savedConversation.getDraftMonitoringParams())
+                .contains("\"conditionThreshold\":\"5\"")
+                .contains("\"conditionDirection\":\"UP\"")
+                .contains("\"conditionUnit\":\"PERCENT\"");
     }
 
     @Test


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #73

**🛠 작업 내역**

AI 파싱 응답 검증 로직 추가
- intent, domain_name, channel, api_type, metadata.confidence 값 검증
- 허용되지 않은 enum 값이나 필수 metadata 누락 시 파싱 실패 처리

구독 대화 흐름에 구조화 조건 적용
- 조건 입력 여부 판단을 문자열 존재 여부가 아니라 StructuredCondition 파싱 결과 기준으로 변경
- “5% 이상” 같은 추가 답변도 구조화해서 저장 gt/gte/lt/lte
search_house_price MCP 입력 DTO 검증 추가

region 필수 검증
- deal_ymd는 yyyyMM 형식만 허용
- 잘못된 MCP 입력은 호출 전에 차단

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?