### PR TITLE
feat: 연립다세대 매매 MCP 도구 추가 + Spring AI ↔ MCP 끝-끝 연결 정상화

### DIFF
--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
     # 마이그레이션은 환경 무관해야 하므로 ${...} 치환 비활성화.
     placeholder-replacement: false
 
+  ai:
     mcp:
       client:
         sse:

--- a/infra/docker/dev/docker-compose.yml
+++ b/infra/docker/dev/docker-compose.yml
@@ -41,6 +41,22 @@ services:
       "
     restart: "no"
 
+  postgres-mcp-init:
+    image: pgvector/pgvector:pg16
+    environment:
+      PGPASSWORD: ${PG_PASSWORD:-devpass}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    entrypoint: >
+      bash -c "
+      psql -h postgres -U ${PG_USER:-devuser} -d postgres
+      -tc \"SELECT 1 FROM pg_database WHERE datname='mcp_dev'\"
+      | grep -q 1
+      || psql -h postgres -U ${PG_USER:-devuser} -d postgres -c 'CREATE DATABASE mcp_dev;'
+      "
+    restart: "no"
+
   # ── Langfuse V3 ───────────────────────────────────────────
   # 기동 순서: clickhouse → minio → minio-init → langfuse-web + langfuse-worker
   # 대시보드: http://localhost:3001

--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -54,3 +54,5 @@ MOLIT_OFFI_TRADE_API_KEY=
 MOLIT_OFFI_RENT_API_KEY=
 # 연립다세대 전월세 실거래가 — RTMSDataSvcRHRent/getRTMSDataSvcRHRent
 MOLIT_RH_RENT_API_KEY=
+# 연립다세대 매매 실거래가 — RTMSDataSvcRHTrade/getRTMSDataSvcRHTrade
+MOLIT_RH_TRADE_API_KEY=

--- a/mcp-server/scripts/seed_real_estate_source.py
+++ b/mcp-server/scripts/seed_real_estate_source.py
@@ -1,6 +1,6 @@
 """부동산 도메인 api_source row 등록.
 
-국토교통부 부동산 실거래가 5종 자료유형 메타데이터를 mcp 내부 DB 의
+국토교통부 부동산 실거래가 6종 자료유형 메타데이터를 mcp 내부 DB 의
 api_source 테이블에 시드한다.
 멱등: 각 row 는 tool_name 기준으로 존재하면 update, 없으면 insert.
 
@@ -79,6 +79,12 @@ SOURCES: list[dict] = [
         "tool_name": "search_rh_rent",
         "name": "국토교통부 연립다세대 전월세 실거래가",
         "url_template": f"{_BASE_URL}/RTMSDataSvcRHRent/getRTMSDataSvcRHRent",
+        "param_schema": _COMMON_PARAM_SCHEMA,
+    },
+    {
+        "tool_name": "search_rh_trade",
+        "name": "국토교통부 연립다세대 매매 실거래가",
+        "url_template": f"{_BASE_URL}/RTMSDataSvcRHTrade/getRTMSDataSvcRHTrade",
         "param_schema": _COMMON_PARAM_SCHEMA,
     },
 ]

--- a/mcp-server/src/mcp_server/config.py
+++ b/mcp-server/src/mcp_server/config.py
@@ -64,6 +64,10 @@ class Settings(BaseSettings):
         default="",
         description="국토교통부 연립다세대 전월세 실거래가 (RTMSDataSvcRHRent) 서비스 키.",
     )
+    molit_rh_trade_api_key: str = Field(
+        default="",
+        description="국토교통부 연립다세대 매매 실거래가 (RTMSDataSvcRHTrade) 서비스 키.",
+    )
 
 
 @lru_cache

--- a/mcp-server/src/mcp_server/domains/real_estate/normalizer.py
+++ b/mcp-server/src/mcp_server/domains/real_estate/normalizer.py
@@ -4,12 +4,13 @@ api_source_service.fetch() 가 돌려준 XML 본문을 자료유형별 도메인
 정규화는 도메인 책임이라 sources 계층 예외(SourceError) 와 분리된
 RealEstateNormalizationError 사용.
 
-지원 자료유형 (5종):
+지원 자료유형 (6종):
 - 아파트 매매 (AptTrade) — dealAmount
 - 아파트 전월세 (AptRent) — deposit + monthlyRent
 - 오피스텔 매매 (OffiTrade) — dealAmount, 단지명 offiNm
 - 오피스텔 전월세 (OffiRent) — deposit + monthlyRent, 단지명 offiNm
 - 연립다세대 전월세 (RHRent) — deposit + monthlyRent, 단지명 mhouseNm, houseType 보존
+- 연립다세대 매매 (RHTrade) — dealAmount, 단지명 mhouseNm, houseType 보존
 """
 
 from datetime import date
@@ -98,6 +99,21 @@ class RHRent(BaseModel):
     build_year: int | None = Field(default=None, description="건축년도")
 
 
+class RHTrade(BaseModel):
+    """연립다세대 매매 실거래 1건."""
+
+    mhouse_name: str = Field(description="단지명 (mhouseNm)")
+    house_type: str | None = Field(default=None, description="주택 유형 (예: '다세대', '연립')")
+    deal_amount: int = Field(description="거래 금액 (만원, 콤마 제거)")
+    deal_date: date = Field(description="계약 일자")
+    area: float = Field(description="전용면적 m²")
+    floor: int = Field(description="층")
+    lawd_cd: str = Field(description="법정동 코드 5자리")
+    dong: str = Field(description="법정동명")
+    jibun: str | None = Field(default=None, description="지번")
+    build_year: int | None = Field(default=None, description="건축년도")
+
+
 # ─────────────────────────────────────────────
 # 정규화 함수
 # ─────────────────────────────────────────────
@@ -153,6 +169,16 @@ def normalize_rh_rent(xml_text: str, *, lawd_cd: str) -> list[RHRent]:
     """
     items = _parse_items(xml_text)
     return [_build_rh_rent(item, lawd_cd=lawd_cd) for item in items]
+
+
+def normalize_rh_trade(xml_text: str, *, lawd_cd: str) -> list[RHTrade]:
+    """MOLIT 연립다세대 매매 실거래가 XML → list[RHTrade].
+
+    Raises:
+        RealEstateNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    items = _parse_items(xml_text)
+    return [_build_rh_trade(item, lawd_cd=lawd_cd) for item in items]
 
 
 # ─────────────────────────────────────────────
@@ -279,6 +305,26 @@ def _build_rh_rent(item: ET.Element, *, lawd_cd: str) -> RHRent:
     )
 
 
+def _build_rh_trade(item: ET.Element, *, lawd_cd: str) -> RHTrade:
+    try:
+        common = _build_common(item, lawd_cd=lawd_cd, name_tag="mhouseNm")
+        deal_amount = _parse_amount(_required(item, "dealAmount"))
+    except (KeyError, ValueError) as exc:
+        raise RealEstateNormalizationError(f"item 필수 필드 파싱 실패: {exc}") from exc
+    return RHTrade(
+        mhouse_name=common["name"],
+        house_type=_find_text(item, "houseType"),
+        deal_amount=deal_amount,
+        deal_date=common["deal_date"],
+        area=common["area"],
+        floor=common["floor"],
+        lawd_cd=common["lawd_cd"],
+        dong=common["dong"],
+        jibun=common["jibun"],
+        build_year=common["build_year"],
+    )
+
+
 # ─────────────────────────────────────────────
 # 공통 필드/유틸
 # ─────────────────────────────────────────────
@@ -342,10 +388,12 @@ __all__ = [
     "OffiRent",
     "OffiTrade",
     "RHRent",
+    "RHTrade",
     "RealEstateNormalizationError",
     "normalize_apt_rent",
     "normalize_apt_trade",
     "normalize_offi_rent",
     "normalize_offi_trade",
     "normalize_rh_rent",
+    "normalize_rh_trade",
 ]

--- a/mcp-server/src/mcp_server/tools/real_estate.py
+++ b/mcp-server/src/mcp_server/tools/real_estate.py
@@ -1,11 +1,12 @@
 """부동산 도메인 MCP 도구.
 
-등록 도구 (5종):
+등록 도구 (6종):
 - search_house_price (= 아파트 매매)
 - search_apt_rent          (아파트 전월세)
 - search_offi_trade        (오피스텔 매매)
 - search_offi_rent         (오피스텔 전월세)
 - search_rh_rent           (연립다세대 전월세)
+- search_rh_trade          (연립다세대 매매)
 
 원칙:
 - serviceKey 같은 비밀값은 도구 함수 인자로 받지 않는다 (Langfuse @traced 가 입력을
@@ -33,11 +34,13 @@ from mcp_server.domains.real_estate.normalizer import (
     OffiRent,
     OffiTrade,
     RHRent,
+    RHTrade,
     normalize_apt_rent,
     normalize_apt_trade,
     normalize_offi_rent,
     normalize_offi_trade,
     normalize_rh_rent,
+    normalize_rh_trade,
 )
 from mcp_server.domains.real_estate.region import resolve_lawd_cd
 from mcp_server.observability.tracing import traced
@@ -514,6 +517,58 @@ async def search_rh_rent(input: MolitRealEstateInput) -> dict[str, Any]:
     )
 
 
+# ─────────────────────────────────────────────
+# 도구 6: 연립다세대 매매
+# ─────────────────────────────────────────────
+
+_TOOL_RH_TRADE = "search_rh_trade"
+
+
+@mcp.tool()
+@traced(_TOOL_RH_TRADE)
+async def search_rh_trade(input: MolitRealEstateInput) -> dict[str, Any]:
+    """국토교통부 **연립다세대(빌라·연립·다세대주택) 매매** 실거래가 조회.
+
+    지정한 시군구(LAWD_CD 5자리) + 거래연월(YYYYMM) 의 연립·다세대주택 매매
+    실거래 목록을 국토교통부 공식 API 에서 조회한다. 아파트나 오피스텔이 아닌
+    빌라/연립/다세대주택이 대상.
+
+    반환 dict 의 trades 항목엔 단지명(mhouse_name) 외에 house_type(예: '연립',
+    '다세대') 필드가 포함된다. 정렬은 거래금액 내림차순.
+
+    Raises:
+        RealEstateConfigError: MOLIT_RH_TRADE_API_KEY 미설정.
+        (그 외 매매 도구와 동일.)
+    """
+    settings = get_settings()
+    if not settings.molit_rh_trade_api_key:
+        raise RealEstateConfigError(
+            "MOLIT_RH_TRADE_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
+        )
+
+    lawd_cd = resolve_lawd_cd(input.region)
+    source_id = await _resolve_source_id(_TOOL_RH_TRADE)
+    params = _build_params(settings.molit_rh_trade_api_key, lawd_cd, input.deal_ymd)
+
+    raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[RHTrade] = normalize_rh_trade(raw.content, lawd_cd=lawd_cd)
+    summary = _summarize_trade(records)
+
+    return _build_response(
+        raw=raw,
+        records=records,
+        sort_key=lambda r: r.deal_amount,
+        summary=summary,
+        text=_trade_text(f"LAWD_CD {lawd_cd}", input.deal_ymd, "연립다세대 매매", summary),
+        region=input.region,
+        lawd_cd=lawd_cd,
+        deal_ymd=input.deal_ymd,
+        params=params,
+        tool_name=_TOOL_RH_TRADE,
+        source_id=source_id,
+    )
+
+
 __all__ = [
     "MolitRealEstateInput",
     "SearchHousePriceInput",  # 호환 alias
@@ -522,4 +577,5 @@ __all__ = [
     "search_offi_rent",
     "search_offi_trade",
     "search_rh_rent",
+    "search_rh_trade",
 ]


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #76 

**🛠 작업 내역**
- 부동산 도메인 6번째 도구 search_rh_trade 추가 — config / normalizer / tool / seed 4계층 매핑
- application.yml 의 mcp: 들여쓰기 버그 수정 (spring.flyway → spring.ai) — Spring AI MCP autoconfig 가 SSE connection 을 인식하도록 함
- dev compose 에 postgres-mcp-init 서비스 추가 — mcp_dev DB 자동 생성

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?