### PR TITLE
feat : api_cache에 저장하는 로직 추가

### DIFF
--- a/mcp-server/src/mcp_server/sources/api_source_service.py
+++ b/mcp-server/src/mcp_server/sources/api_source_service.py
@@ -2,16 +2,21 @@
 
 규약:
 - 도구는 직접 httpx 를 쓰지 말고 이 fetch() 만 호출한다.
-- 캐시 로직 삽입 지점은 # TODO: cache 주석으로 표시. MVP 에서는 통과.
+
+성공: API 호출 후 api_cache 에 upsert, RawResult 반환.
+실패:
+    캐시 있음 → RawResult(fetched_at=cache.cached_at) 반환.
+    캐시 없음 → fetch_error 기록 후 빈 RawResult 반환.
 """
 
 import json
 from datetime import UTC, datetime
+from urllib.parse import urlencode
 
 import httpx
 from sqlalchemy import select
 
-from mcp_server.db.models import ApiSource
+from mcp_server.db.models import ApiCache, ApiSource
 from mcp_server.db.session import get_session
 from mcp_server.sources.errors import SourceFetchError, SourceNotFoundError
 from mcp_server.sources.result import RawResult
@@ -37,16 +42,46 @@ async def fetch(
         SourceFetchError: HTTP 호출 실패 (네트워크 오류 / 4xx-5xx 응답).
     """
     source = await _load_source(source_id)
-    # TODO: cache lookup — site_url(url_template + params) 로 api_cache 조회
-
+    params = params or {}
+    site_url = _build_site_url(source.url_template, params)
     fetched_at = datetime.now(UTC)
-    response_text = await _call_external_api(
-        endpoint=source.url_template,
-        params=params or {},
-        http_client=_test_http_client,
-    )
 
-    # TODO: cache store — api_cache 에 (site_url, content, expired_at) 기록
+    try:
+        response_text = await _call_external_api(
+            endpoint=source.url_template,
+            params=params,
+            http_client=_test_http_client,
+        )
+    except SourceFetchError as exc:
+        cached = await _load_cache(site_url)
+        base_meta = {
+            "tool_name": source.tool_name,
+            "url_template": source.url_template,
+            "params": params,
+        }
+        if cached is not None:
+            return RawResult(
+                source_type="api",
+                source_id=source.id,
+                content=cached.content or "",
+                fetched_at=cached.cached_at,
+                raw_metadata=base_meta,
+            )
+        return RawResult(
+            source_type="api",
+            source_id=source.id,
+            content="",
+            fetched_at=fetched_at,
+            raw_metadata={**base_meta, "fetch_error": str(exc)},
+        )
+
+    await _upsert_cache(
+        source_id=source.id,
+        site_url=site_url,
+        tool_name=source.tool_name,
+        content=response_text,
+        cached_at=fetched_at,
+    )
 
     return RawResult(
         source_type="api",
@@ -61,6 +96,12 @@ async def fetch(
     )
 
 
+def _build_site_url(url_template: str, params: dict) -> str:
+    """캐시 키용 URL. serviceKey 제외 (DB에 API 키 저장 방지)."""
+    cache_params = {k: v for k, v in params.items() if k != "serviceKey"}
+    return f"{url_template}?{urlencode(sorted(cache_params.items()))}"
+
+
 async def _load_source(source_id: int) -> ApiSource:
     async with get_session() as session:
         result = await session.execute(select(ApiSource).where(ApiSource.id == source_id))
@@ -68,6 +109,41 @@ async def _load_source(source_id: int) -> ApiSource:
     if source is None:
         raise SourceNotFoundError(f"api_source.id={source_id} 등록되지 않음")
     return source
+
+
+async def _load_cache(site_url: str) -> ApiCache | None:
+    async with get_session() as session:
+        result = await session.execute(
+            select(ApiCache).where(ApiCache.site_url == site_url)
+        )
+        return result.scalar_one_or_none()
+
+
+async def _upsert_cache(
+    source_id: int,
+    site_url: str,
+    tool_name: str,
+    content: str,
+    cached_at: datetime,
+) -> None:
+    async with get_session() as session:
+        result = await session.execute(
+            select(ApiCache).where(ApiCache.site_url == site_url)
+        )
+        cache = result.scalar_one_or_none()
+        if cache is None:
+            session.add(ApiCache(
+                source_id=source_id,
+                site_url=site_url,
+                api_type=tool_name,
+                content=content,
+                cached_at=cached_at,
+                expired_at=None,
+            ))
+        else:
+            cache.content = content
+            cache.cached_at = cached_at
+        await session.commit()
 
 
 async def resolve_source_id_by_tool_name(tool_name: str) -> int:
@@ -108,7 +184,6 @@ async def _call_external_api(
 
     content_type = response.headers.get("content-type", "")
     if "application/json" in content_type:
-        # JSON 은 정렬해서 hash 일관성 확보 (캐시 도입 시 활용)
         return json.dumps(response.json(), ensure_ascii=False, sort_keys=True)
     return response.text
 

--- a/mcp-server/tests/sources/test_api_source_service.py
+++ b/mcp-server/tests/sources/test_api_source_service.py
@@ -8,10 +8,12 @@ import json
 import httpx
 import pytest
 
-from mcp_server.db.models import ApiSource
+from sqlalchemy import select
+
+from mcp_server.db.models import ApiCache, ApiSource
 from mcp_server.db.session import get_session
 from mcp_server.sources import api_source_service
-from mcp_server.sources.errors import SourceFetchError, SourceNotFoundError
+from mcp_server.sources.errors import SourceNotFoundError
 
 
 async def _create_source(**overrides) -> ApiSource:
@@ -90,8 +92,8 @@ async def test_fetch_raises_source_not_found_for_unknown_id(patched_session_fact
 
 
 @pytest.mark.asyncio
-async def test_fetch_wraps_http_errors_in_source_fetch_error(patched_session_factory):
-    """HTTP 5xx 는 SourceFetchError 로 감싼다."""
+async def test_fetch_returns_empty_result_on_http_error_without_cache(patched_session_factory):
+    """HTTP 5xx + 캐시 없음 → 빈 content + fetch_error 기록."""
     source = await _create_source(
         tool_name="failing_endpoint", url_template="https://example.gov/fail"
     )
@@ -101,5 +103,76 @@ async def test_fetch_wraps_http_errors_in_source_fetch_error(patched_session_fac
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
-        with pytest.raises(SourceFetchError):
-            await api_source_service.fetch(source_id=source.id, params={}, _test_http_client=client)
+        result = await api_source_service.fetch(
+            source_id=source.id, params={}, _test_http_client=client
+        )
+
+    assert result.content == ""
+    assert "fetch_error" in result.raw_metadata
+
+
+@pytest.mark.asyncio
+async def test_fetch_writes_cache_on_success(patched_session_factory):
+    """성공 시 api_cache 에 upsert 된다."""
+    source = await _create_source()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"items": [{"price": 1500}]},
+            headers={"content-type": "application/json"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await api_source_service.fetch(
+            source_id=source.id,
+            params={"region": "강남구"},
+            _test_http_client=client,
+        )
+
+    async with get_session() as session:
+        result = await session.execute(select(ApiCache).where(ApiCache.source_id == source.id))
+        cache = result.scalar_one_or_none()
+
+    assert cache is not None
+    assert cache.api_type == "search_house_price"
+    assert "1500" in cache.content
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_cache_on_http_error(patched_session_factory):
+    """HTTP 5xx + 캐시 있음 → 캐시 반환, fetched_at 은 캐시 시각."""
+    source = await _create_source()
+
+    def ok_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"items": [{"price": 1500}]},
+            headers={"content-type": "application/json"},
+        )
+
+    def fail_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="Service Unavailable")
+
+    # 1차: 성공 → 캐시 저장
+    transport = httpx.MockTransport(ok_handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        first = await api_source_service.fetch(
+            source_id=source.id,
+            params={"region": "강남구"},
+            _test_http_client=client,
+        )
+
+    # 2차: 실패 → 캐시 반환
+    transport = httpx.MockTransport(fail_handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        second = await api_source_service.fetch(
+            source_id=source.id,
+            params={"region": "강남구"},
+            _test_http_client=client,
+        )
+
+    assert second.content == first.content
+    assert second.fetched_at.replace(tzinfo=None) == first.fetched_at.replace(tzinfo=None)
+    assert "fetch_error" not in second.raw_metadata


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #82

**🛠 작업 내역**
api_source_service.py
  - API 호출 성공 시 api_cache에 upsert (캐시 키: site_url = url_template + params, serviceKey 제외)           
  - API 호출 실패 시 캐시 조회
    - 캐시 있음 → fetched_at=cache.cached_at으로 캐시 반환
    - 캐시 없음 → 빈 content + fetch_error 기록 후 반환 (예외 throw 제거)
  - _build_site_url(), _load_cache(), _upsert_cache() 내부 헬퍼 추가

  배경
  AI가 tool을 호출하기 전 metadata.fetched_at을 보고 재호출 여부를 스스로 판단하는 구조를 위해 캐시 레이어를
  활성화. API 호출 제한은 MCP 서버가 규칙으로 강제하는 대신, AI에게 fetched_at 등 충분한 판단 재료를 제공하는
  방식으로 설계.

  test_api_source_service.py
  - test_fetch_wraps_http_errors_in_source_fetch_error →
  test_fetch_returns_empty_result_on_http_error_without_cache 로 변경 (동작 변경 반영)
  - test_fetch_writes_cache_on_success 추가
  - test_fetch_returns_cache_on_http_error 추가


**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?