### PR TITLE
FEAT: 법률 도메인 정규화 - search_law_info / search_bill_info raw passthrough 교체

### DIFF
--- a/mcp-server/src/mcp_server/domains/law/errors.py
+++ b/mcp-server/src/mcp_server/domains/law/errors.py
@@ -12,4 +12,12 @@ class LawConfigError(LawError):
     """
 
 
-__all__ = ["LawError", "LawConfigError"]
+class LawNormalizationError(LawError):
+    """API 응답 본문 정규화 실패 (XML 파싱, 응답 코드 비정상, 필수 필드 누락).
+
+    sources 계층의 SourceError 와 분리: 외부 호출은 성공했으나 본문이 도메인
+    스키마와 맞지 않는 상황.
+    """
+
+
+__all__ = ["LawConfigError", "LawError", "LawNormalizationError"]

--- a/mcp-server/src/mcp_server/domains/law/normalizer.py
+++ b/mcp-server/src/mcp_server/domains/law/normalizer.py
@@ -1,0 +1,211 @@
+"""법제처 국가법령정보 / 국회 의안정보 응답 정규화.
+
+api_source_service.fetch() 가 돌려준 XML 본문을 도메인 모델 list 로 변환.
+정규화는 도메인 책임이라 sources 계층 예외와 분리된 LawNormalizationError 사용.
+
+지원 응답 (2종):
+- 법제처 현행법령 목록 (LawSearch 루트, 한글 태그, resultCode "00")
+  → list[LawItem]
+- 국회 의안 검색 (서비스ID 임의 루트, head/RESULT/CODE "INFO-000", row 반복)
+  → list[BillItem]
+"""
+
+from datetime import date
+from xml.etree import ElementTree as ET
+
+from pydantic import BaseModel, Field
+
+from mcp_server.domains.law.errors import LawNormalizationError
+
+_LAW_SUCCESS_CODE = "00"
+_BILL_SUCCESS_CODE = "INFO-000"
+
+
+# ─────────────────────────────────────────────
+# 모델
+# ─────────────────────────────────────────────
+
+
+class LawItem(BaseModel):
+    """현행법령 1건 (법제처 국가법령정보 공유서비스)."""
+
+    law_no: str = Field(description="법령일련번호 (MST 식별자)")
+    law_id: str = Field(description="법령ID")
+    law_name: str = Field(description="법령명한글")
+    law_alias: str | None = Field(default=None, description="법령약칭명")
+    law_kind: str | None = Field(default=None, description="법령구분명 (법률/대통령령/부령 등)")
+    amend_kind: str | None = Field(default=None, description="제개정구분명 (일부개정/전부개정/제정 등)")
+    ministry_name: str | None = Field(default=None, description="소관부처명")
+    ministry_code: str | None = Field(default=None, description="소관부처코드")
+    promulgation_date: date | None = Field(default=None, description="공포일자")
+    promulgation_no: str | None = Field(default=None, description="공포번호")
+    enforcement_date: date | None = Field(default=None, description="시행일자")
+    current_status: str | None = Field(default=None, description="현행연혁코드 (현행/연혁 등)")
+    detail_link: str | None = Field(default=None, description="법령 상세 링크 (상대 경로)")
+
+
+class BillItem(BaseModel):
+    """국회 의안 1건 (열린국회정보 의안검색)."""
+
+    bill_id: str = Field(description="의안ID (BILL_ID)")
+    bill_no: str = Field(description="의안번호 (BILL_NO)")
+    bill_name: str = Field(description="의안명")
+    age: int | None = Field(default=None, description="국회 대수 (1~22)")
+    propose_date: date | None = Field(default=None, description="발의일자")
+    proposer: str | None = Field(default=None, description="대표 발의자 (예: '김미애의원 등 14인')")
+    committee: str | None = Field(default=None, description="소관위원회")
+    proc_result: str | None = Field(default=None, description="처리결과")
+    detail_link: str | None = Field(default=None, description="의안 상세 링크")
+
+
+# ─────────────────────────────────────────────
+# 정규화 함수
+# ─────────────────────────────────────────────
+
+
+def normalize_law_info(xml_text: str) -> list[LawItem]:
+    """법제처 현행법령 목록 XML → list[LawItem].
+
+    Raises:
+        LawNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    root = _parse_root(xml_text)
+    code = _find_text(root, "resultCode")
+    if code != _LAW_SUCCESS_CODE:
+        msg = _find_text(root, "resultMsg") or "(메시지 없음)"
+        raise LawNormalizationError(
+            f"법제처 API 비정상 응답: code={code}, msg={msg}"
+        )
+    return [_build_law_item(node) for node in root.findall("law")]
+
+
+def normalize_bill_info(xml_text: str) -> list[BillItem]:
+    """국회 의안 검색 XML → list[BillItem].
+
+    응답 루트는 서비스ID(임의 이름)라 root.findall("row") 패턴으로 추출.
+
+    Raises:
+        LawNormalizationError: 응답 코드 비정상, XML 파싱 실패, 필수 필드 누락.
+    """
+    root = _parse_root(xml_text)
+    code = _find_text(root, "head/RESULT/CODE")
+    if code != _BILL_SUCCESS_CODE:
+        msg = _find_text(root, "head/RESULT/MESSAGE") or "(메시지 없음)"
+        raise LawNormalizationError(
+            f"열린국회정보 API 비정상 응답: code={code}, msg={msg}"
+        )
+    return [_build_bill_item(node) for node in root.findall("row")]
+
+
+# ─────────────────────────────────────────────
+# Builder
+# ─────────────────────────────────────────────
+
+
+def _build_law_item(node: ET.Element) -> LawItem:
+    try:
+        return LawItem(
+            law_no=_required(node, "법령일련번호"),
+            law_id=_required(node, "법령ID"),
+            law_name=_required(node, "법령명한글"),
+            law_alias=_optional_text(node, "법령약칭명"),
+            law_kind=_optional_text(node, "법령구분명"),
+            amend_kind=_optional_text(node, "제개정구분명"),
+            ministry_name=_optional_text(node, "소관부처명"),
+            ministry_code=_optional_text(node, "소관부처코드"),
+            promulgation_date=_optional_yyyymmdd(node, "공포일자"),
+            promulgation_no=_optional_text(node, "공포번호"),
+            enforcement_date=_optional_yyyymmdd(node, "시행일자"),
+            current_status=_optional_text(node, "현행연혁코드"),
+            detail_link=_optional_text(node, "법령상세링크"),
+        )
+    except (KeyError, ValueError) as exc:
+        raise LawNormalizationError(f"law 항목 필수 필드 파싱 실패: {exc}") from exc
+
+
+def _build_bill_item(node: ET.Element) -> BillItem:
+    try:
+        return BillItem(
+            bill_id=_required(node, "BILL_ID"),
+            bill_no=_required(node, "BILL_NO"),
+            bill_name=_required(node, "BILL_NAME"),
+            age=_optional_int(node, "AGE"),
+            propose_date=_optional_iso_date(node, "PROPOSE_DT"),
+            proposer=_optional_text(node, "PROPOSER"),
+            committee=_optional_text(node, "COMMITTEE"),
+            proc_result=_optional_text(node, "PROC_RESULT"),
+            detail_link=_optional_text(node, "DETAIL_LINK"),
+        )
+    except (KeyError, ValueError) as exc:
+        raise LawNormalizationError(f"row 항목 필수 필드 파싱 실패: {exc}") from exc
+
+
+# ─────────────────────────────────────────────
+# 공통 유틸
+# ─────────────────────────────────────────────
+
+
+def _parse_root(xml_text: str) -> ET.Element:
+    try:
+        return ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise LawNormalizationError(f"법률 응답 XML 파싱 실패: {exc}") from exc
+
+
+def _find_text(parent: ET.Element, path: str) -> str | None:
+    node = parent.find(path)
+    if node is None or node.text is None:
+        return None
+    return node.text.strip() or None
+
+
+def _required(parent: ET.Element, tag: str) -> str:
+    text = _find_text(parent, tag)
+    if text is None:
+        raise KeyError(tag)
+    return text
+
+
+def _optional_text(parent: ET.Element, tag: str) -> str | None:
+    return _find_text(parent, tag)
+
+
+def _optional_int(parent: ET.Element, tag: str) -> int | None:
+    text = _find_text(parent, tag)
+    if text is None:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _optional_yyyymmdd(parent: ET.Element, tag: str) -> date | None:
+    """법제처 일자 포맷 'YYYYMMDD' → date. 8자리 숫자 아니면 None."""
+    text = _find_text(parent, tag)
+    if text is None or len(text) != 8 or not text.isdigit():
+        return None
+    try:
+        return date(int(text[:4]), int(text[4:6]), int(text[6:]))
+    except ValueError:
+        return None
+
+
+def _optional_iso_date(parent: ET.Element, tag: str) -> date | None:
+    """의안 일자 포맷 'YYYY-MM-DD' → date. 형식 어긋나면 None."""
+    text = _find_text(parent, tag)
+    if text is None:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "BillItem",
+    "LawItem",
+    "LawNormalizationError",
+    "normalize_bill_info",
+    "normalize_law_info",
+]

--- a/mcp-server/src/mcp_server/tools/law.py
+++ b/mcp-server/src/mcp_server/tools/law.py
@@ -1,30 +1,57 @@
-"""법률 도메인 MCP 도구 (임시 minimal passthrough).
+"""법률 도메인 MCP 도구.
 
 등록 도구 (2종):
 - search_law_info  — 법제처 국가법령정보 공유서비스 (data.go.kr/data/15000115)
 - search_bill_info — 국회사무처 의안정보 통합 API (data.go.kr/data/15126134)
 
 원칙:
-- serviceKey 같은 비밀값은 도구 함수 인자로 받지 않는다 (Langfuse @traced 입력 캡처).
+- serviceKey/KEY 같은 비밀값은 도구 함수 인자로 받지 않는다 (Langfuse 입력 캡처 보호).
 - 외부 호출은 sources.api_source_service.fetch() 만 경유.
-- 정규화/통계는 본작업에서 추가. 현재는 raw passthrough.
+- 토큰 절약을 위해 상위 _MAX_RESULTS 건만 반환 (정렬 키는 도구별로 다름).
 """
 
+from datetime import date, datetime
 from typing import Any
+from urllib.parse import urlencode
 
 from pydantic import BaseModel, Field
 
 from mcp_server.config import get_settings
 from mcp_server.domains.law.errors import LawConfigError
+from mcp_server.domains.law.normalizer import (
+    BillItem,
+    LawItem,
+    normalize_bill_info,
+    normalize_law_info,
+)
 from mcp_server.observability.tracing import traced
 from mcp_server.server import mcp
 from mcp_server.sources import api_source_service
-from mcp_server.tools._passthrough import (
-    build_passthrough_response,
-    resolve_source_id,
-)
 
 _DEFAULT_NUM_OF_ROWS = 20
+_MAX_RESULTS = 20
+
+# tool_name → api_source.id 캐시
+_cached_source_ids: dict[str, int] = {}
+
+
+async def _resolve_source_id(tool_name: str) -> int:
+    if tool_name not in _cached_source_ids:
+        _cached_source_ids[tool_name] = (
+            await api_source_service.resolve_source_id_by_tool_name(tool_name)
+        )
+    return _cached_source_ids[tool_name]
+
+
+def _mask_query_string(params: dict[str, Any], *, secret_keys: tuple[str, ...]) -> str:
+    """source_url 노출용 query string. 비밀 키는 '***' 로 마스킹."""
+    masked = {k: ("***" if k in secret_keys else v) for k, v in params.items()}
+    return urlencode(masked, safe="*")
+
+
+def _format_date(d: date | None) -> str:
+    return d.isoformat() if d else "-"
+
 
 # ─────────────────────────────────────────────
 # 도구 1: 법제처 국가법령정보
@@ -34,10 +61,7 @@ _TOOL_LAW_INFO = "search_law_info"
 
 
 class SearchLawInfoInput(BaseModel):
-    """현행법령 목록조회 입력 (법제처 명세 기준).
-
-    응답은 XML 고정 — 명세 상 JSON 옵션 없음. 정규화/필드 추출은 추가 예정.
-    """
+    """현행법령 목록조회 입력 (법제처 명세 기준)."""
 
     query: str = Field(
         default="*",
@@ -58,19 +82,57 @@ class SearchLawInfoInput(BaseModel):
     )
 
 
+def _summarize_law(records: list[LawItem]) -> dict[str, Any]:
+    if not records:
+        return {"count": 0, "latest_promulgation_date": None, "ministries": []}
+    promulgation_dates = [r.promulgation_date for r in records if r.promulgation_date]
+    ministries = sorted({r.ministry_name for r in records if r.ministry_name})
+    return {
+        "count": len(records),
+        "latest_promulgation_date": (
+            max(promulgation_dates).isoformat() if promulgation_dates else None
+        ),
+        "ministries": ministries,
+    }
+
+
+def _law_text(query: str, summary: dict[str, Any], records: list[LawItem]) -> str:
+    if summary["count"] == 0:
+        return f"현행법령 검색 '{query}' 0건."
+    latest_date = summary["latest_promulgation_date"] or "-"
+    latest_record = max(
+        (r for r in records if r.promulgation_date),
+        key=lambda r: r.promulgation_date,
+        default=None,
+    )
+    latest_name = latest_record.law_name if latest_record else "-"
+    return (
+        f"현행법령 검색 '{query}' {summary['count']}건. "
+        f"최신 공포 {latest_date} ({latest_name})."
+    )
+
+
 @mcp.tool()
 @traced(_TOOL_LAW_INFO)
 async def search_law_info(input: SearchLawInfoInput) -> dict[str, Any]:
     """법제처 **국가법령정보 공유서비스 — 현행법령 목록조회**.
 
-    검색어로 현행 법령 목록(target=law)을 조회한다. 응답은 XML 이며 외부 API 가
-    돌려준 원본을 그대로 {text, structured.raw, source_url, metadata} 공통 스키마로
-    노출한다 (정규화는 보강 예정).
+    검색어로 현행 법령 목록(target=law)을 조회한다. 응답은 정규화된 LawItem 리스트와
+    {text, structured, source_url, metadata} 공통 스키마로 반환된다.
+
+    반환 dict:
+      - text: 통계 요약 한 단락 (건수 + 최신 공포일 및 법령명).
+      - structured.summary: {count, latest_promulgation_date, ministries[]}.
+      - structured.laws: LawItem dict 의 상위 20건 (공포일자 내림차순).
+      - structured.laws_truncated: 원본이 20건 초과로 절단됐으면 True.
+      - structured.query: 호출 인자 echo.
+      - source_url: 호출한 API URL + query (serviceKey '***' 마스킹).
+      - metadata: {fetched_at, raw_count, returned_count, tool_name, source_id}.
 
     Raises:
         LawConfigError: MOLEG_LAW_INFO_API_KEY 미설정.
-        SourceNotFoundError: api_source 시드 미실행.
-        SourceFetchError: 외부 API 호출 실패 (네트워크/4xx/5xx).
+        LawNormalizationError: API 응답이 비정상(코드 != "00") 또는 XML 파싱 실패.
+        SourceNotFoundError / SourceFetchError: 외부 호출 관련 오류.
     """
     settings = get_settings()
     if not settings.moleg_law_info_api_key:
@@ -78,8 +140,7 @@ async def search_law_info(input: SearchLawInfoInput) -> dict[str, Any]:
             "MOLEG_LAW_INFO_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    source_id = await resolve_source_id(_TOOL_LAW_INFO)
-    # 명세 기준 5개 필수 파라미터 (인증키/서비스대상/검색어/페이지수/페이지번호).
+    source_id = await _resolve_source_id(_TOOL_LAW_INFO)
     params: dict[str, Any] = {
         "serviceKey": settings.moleg_law_info_api_key,
         "target": "law",
@@ -88,18 +149,49 @@ async def search_law_info(input: SearchLawInfoInput) -> dict[str, Any]:
         "pageNo": input.page_no,
     }
     raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[LawItem] = normalize_law_info(raw.content)
+    summary = _summarize_law(records)
 
-    return build_passthrough_response(
-        raw=raw,
-        tool_name=_TOOL_LAW_INFO,
-        source_id=source_id,
-        params=params,
-        secret_keys=("serviceKey",),
-        summary_text=(
-            f"현행법령 목록조회 '{input.query}' (page={input.page_no}, "
-            f"rows={input.num_of_rows}) 응답 {len(raw.content or '')}자 수신."
-        ),
+    sorted_records = sorted(
+        records,
+        key=lambda r: r.promulgation_date or date.min,
+        reverse=True,
     )
+    truncated = len(sorted_records) > _MAX_RESULTS
+    returned = sorted_records[:_MAX_RESULTS]
+
+    url_template = raw.raw_metadata.get("url_template", "")
+    source_url = (
+        f"{url_template}?{_mask_query_string(params, secret_keys=('serviceKey',))}"
+        if url_template
+        else None
+    )
+
+    return {
+        "text": _law_text(input.query, summary, records),
+        "structured": {
+            "summary": summary,
+            "laws": [r.model_dump(mode="json") for r in returned],
+            "laws_truncated": truncated,
+            "query": {
+                "query": input.query,
+                "page_no": input.page_no,
+                "num_of_rows": input.num_of_rows,
+            },
+        },
+        "source_url": source_url,
+        "metadata": {
+            "fetched_at": (
+                raw.fetched_at.isoformat()
+                if isinstance(raw.fetched_at, datetime)
+                else str(raw.fetched_at)
+            ),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": _TOOL_LAW_INFO,
+            "source_id": source_id,
+        },
+    }
 
 
 # ─────────────────────────────────────────────
@@ -127,17 +219,54 @@ class SearchBillInfoInput(BaseModel):
     )
 
 
+def _summarize_bill(records: list[BillItem]) -> dict[str, Any]:
+    if not records:
+        return {"count": 0, "latest_propose_date": None, "committees": []}
+    propose_dates = [r.propose_date for r in records if r.propose_date]
+    committees = sorted({r.committee for r in records if r.committee})
+    return {
+        "count": len(records),
+        "latest_propose_date": (
+            max(propose_dates).isoformat() if propose_dates else None
+        ),
+        "committees": committees,
+    }
+
+
+def _bill_text(age: int, summary: dict[str, Any], records: list[BillItem]) -> str:
+    if summary["count"] == 0:
+        return f"제{age}대 의안 검색 0건."
+    latest_date = summary["latest_propose_date"] or "-"
+    latest_record = max(
+        (r for r in records if r.propose_date),
+        key=lambda r: r.propose_date,
+        default=None,
+    )
+    latest_name = latest_record.bill_name if latest_record else "-"
+    return (
+        f"제{age}대 의안 검색 {summary['count']}건. "
+        f"최근 발의 {latest_date} ({latest_name})."
+    )
+
+
 @mcp.tool()
 @traced(_TOOL_BILL_INFO)
 async def search_bill_info(input: SearchBillInfoInput) -> dict[str, Any]:
     """국회사무처 **의안정보** 조회 (열린국회정보 기반).
 
-    지정 대수의 의안 목록을 조회한다. 응답은 외부 API 가 돌려준 원본을 그대로
-    {text, structured.raw, source_url, metadata} 공통 스키마로 노출한다.
+    지정 대수의 의안 목록을 조회하고 정규화된 BillItem 리스트와
+    {text, structured, source_url, metadata} 공통 스키마로 반환한다.
+
+    반환 dict:
+      - text: 통계 요약 (건수 + 최근 발의일 및 의안명).
+      - structured.summary: {count, latest_propose_date, committees[]}.
+      - structured.bills: BillItem dict 의 상위 20건 (발의일자 내림차순).
+      - structured.bills_truncated / query / source_url / metadata: 동일.
 
     Raises:
         LawConfigError: NA_BILL_INFO_API_KEY 미설정.
-        SourceNotFoundError / SourceFetchError: 위와 동일.
+        LawNormalizationError: API 응답이 비정상(코드 != "INFO-000") 또는 XML 파싱 실패.
+        SourceNotFoundError / SourceFetchError: 외부 호출 관련 오류.
     """
     settings = get_settings()
     if not settings.na_bill_info_api_key:
@@ -145,12 +274,7 @@ async def search_bill_info(input: SearchBillInfoInput) -> dict[str, Any]:
             "NA_BILL_INFO_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    source_id = await resolve_source_id(_TOOL_BILL_INFO)
-    # 열린국회정보(open.assembly.go.kr) 파라미터 규약:
-    #   KEY    — 인증키
-    #   Type   — 응답 형식 (xml/json)
-    #   pIndex — 페이지 번호 (1부터)
-    #   pSize  — 페이지당 결과 수
+    source_id = await _resolve_source_id(_TOOL_BILL_INFO)
     params: dict[str, Any] = {
         "KEY": settings.na_bill_info_api_key,
         "Type": "xml",
@@ -159,18 +283,49 @@ async def search_bill_info(input: SearchBillInfoInput) -> dict[str, Any]:
         "AGE": input.age,
     }
     raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[BillItem] = normalize_bill_info(raw.content)
+    summary = _summarize_bill(records)
 
-    return build_passthrough_response(
-        raw=raw,
-        tool_name=_TOOL_BILL_INFO,
-        source_id=source_id,
-        params=params,
-        secret_keys=("KEY",),
-        summary_text=(
-            f"의안 검색 (제{input.age}대, page={input.page_no}, "
-            f"rows={input.num_of_rows}) 응답 {len(raw.content or '')}자 수신."
-        ),
+    sorted_records = sorted(
+        records,
+        key=lambda r: r.propose_date or date.min,
+        reverse=True,
     )
+    truncated = len(sorted_records) > _MAX_RESULTS
+    returned = sorted_records[:_MAX_RESULTS]
+
+    url_template = raw.raw_metadata.get("url_template", "")
+    source_url = (
+        f"{url_template}?{_mask_query_string(params, secret_keys=('KEY',))}"
+        if url_template
+        else None
+    )
+
+    return {
+        "text": _bill_text(input.age, summary, records),
+        "structured": {
+            "summary": summary,
+            "bills": [r.model_dump(mode="json") for r in returned],
+            "bills_truncated": truncated,
+            "query": {
+                "age": input.age,
+                "page_no": input.page_no,
+                "num_of_rows": input.num_of_rows,
+            },
+        },
+        "source_url": source_url,
+        "metadata": {
+            "fetched_at": (
+                raw.fetched_at.isoformat()
+                if isinstance(raw.fetched_at, datetime)
+                else str(raw.fetched_at)
+            ),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": _TOOL_BILL_INFO,
+            "source_id": source_id,
+        },
+    }
 
 
 __all__ = [

--- a/mcp-server/tests/domains/law/test_normalizer.py
+++ b/mcp-server/tests/domains/law/test_normalizer.py
@@ -1,0 +1,225 @@
+"""normalize_law_info / normalize_bill_info 정규화 단위 테스트.
+
+실제 응답 픽스처 (tests/data/law/*.xml) + 인공 케이스로 경계 조건 검증.
+"""
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from mcp_server.domains.law.errors import LawNormalizationError
+from mcp_server.domains.law.normalizer import (
+    BillItem,
+    LawItem,
+    normalize_bill_info,
+    normalize_law_info,
+)
+
+FIXTURES = Path(__file__).resolve().parents[2] / "data" / "law"
+LAW_INFO_XML = (FIXTURES / "search_law_info.xml").read_text(encoding="utf-8")
+BILL_INFO_XML = (FIXTURES / "search_bill_info.xml").read_text(encoding="utf-8")
+
+
+# ─────────────────────────────────────────────
+# normalize_law_info
+# ─────────────────────────────────────────────
+
+
+def test_normalize_law_info_real_fixture_returns_2_records():
+    """법제처 픽스처 (totalCnt=2) → 2개 LawItem."""
+    records = normalize_law_info(LAW_INFO_XML)
+    assert len(records) == 2
+    assert all(isinstance(r, LawItem) for r in records)
+
+
+def test_normalize_law_info_extracts_korean_fields():
+    """한글 태그(<법령명한글> 등) 가 정상 추출된다."""
+    records = normalize_law_info(LAW_INFO_XML)
+    first = records[0]
+    assert first.law_name == "개인정보 보호법"
+    assert first.law_no == "270351"
+    assert first.law_id == "011357"
+    assert first.law_kind == "법률"
+    assert first.amend_kind == "일부개정"
+    assert first.ministry_name == "개인정보보호위원회"
+    assert first.current_status == "현행"
+
+
+def test_normalize_law_info_parses_yyyymmdd_dates():
+    """공포일자/시행일자 'YYYYMMDD' 가 date 로 파싱된다."""
+    records = normalize_law_info(LAW_INFO_XML)
+    first = records[0]
+    assert first.promulgation_date == date(2025, 4, 1)
+    assert first.enforcement_date == date(2025, 10, 2)
+
+
+def test_normalize_law_info_empty_alias_is_none():
+    """<법령약칭명> 빈 CDATA → None."""
+    records = normalize_law_info(LAW_INFO_XML)
+    assert records[0].law_alias is None
+
+
+def test_normalize_law_info_raises_on_error_response():
+    """resultCode != '00' → LawNormalizationError."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<LawSearch>
+  <resultCode>99</resultCode>
+  <resultMsg>인증 실패</resultMsg>
+</LawSearch>"""
+    with pytest.raises(LawNormalizationError) as exc:
+        normalize_law_info(xml)
+    assert "99" in str(exc.value)
+
+
+def test_normalize_law_info_raises_on_invalid_xml():
+    """XML 파싱 실패 → LawNormalizationError."""
+    with pytest.raises(LawNormalizationError):
+        normalize_law_info("<not><valid")
+
+
+def test_normalize_law_info_returns_empty_list_when_no_law_nodes():
+    """결과 0건 (법제처는 totalCnt=0 일 때 law 노드 없음) → 빈 리스트."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<LawSearch>
+  <resultCode>00</resultCode>
+  <resultMsg>success</resultMsg>
+  <totalCnt>0</totalCnt>
+</LawSearch>"""
+    assert normalize_law_info(xml) == []
+
+
+def test_normalize_law_info_invalid_yyyymmdd_becomes_none():
+    """잘못된 8자리 일자(예: 99999999) → None, 예외 없음."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<LawSearch>
+  <resultCode>00</resultCode>
+  <resultMsg>success</resultMsg>
+  <law id="1">
+    <법령일련번호>1</법령일련번호>
+    <법령ID>X</법령ID>
+    <법령명한글>테스트법</법령명한글>
+    <공포일자>99999999</공포일자>
+  </law>
+</LawSearch>"""
+    records = normalize_law_info(xml)
+    assert records[0].promulgation_date is None
+
+
+def test_normalize_law_info_required_field_missing_raises():
+    """법령명한글 누락 → LawNormalizationError."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<LawSearch>
+  <resultCode>00</resultCode>
+  <law id="1">
+    <법령일련번호>1</법령일련번호>
+    <법령ID>X</법령ID>
+  </law>
+</LawSearch>"""
+    with pytest.raises(LawNormalizationError):
+        normalize_law_info(xml)
+
+
+# ─────────────────────────────────────────────
+# normalize_bill_info
+# ─────────────────────────────────────────────
+
+
+def test_normalize_bill_info_real_fixture_returns_records():
+    """의안 픽스처 (rows=5) → 5개 BillItem (또는 그 이상이면 모두)."""
+    records = normalize_bill_info(BILL_INFO_XML)
+    assert len(records) >= 1
+    assert all(isinstance(r, BillItem) for r in records)
+
+
+def test_normalize_bill_info_extracts_english_fields():
+    """영문 태그(BILL_NO 등) 가 정상 추출된다."""
+    records = normalize_bill_info(BILL_INFO_XML)
+    first = records[0]
+    assert first.bill_no == "2218679"
+    assert first.bill_name == "소득세법 일부개정법률안"
+    assert first.bill_id.startswith("PRC_")
+    assert first.age == 22
+    assert first.proposer == "김미애의원 등 14인"
+
+
+def test_normalize_bill_info_parses_iso_date():
+    """PROPOSE_DT 'YYYY-MM-DD' 가 date 로 파싱된다."""
+    records = normalize_bill_info(BILL_INFO_XML)
+    assert records[0].propose_date == date(2026, 4, 28)
+
+
+def test_normalize_bill_info_empty_committee_is_none():
+    """<COMMITTEE></COMMITTEE> 빈 노드 → None."""
+    records = normalize_bill_info(BILL_INFO_XML)
+    assert records[0].committee is None
+    assert records[0].proc_result is None
+
+
+def test_normalize_bill_info_raises_on_error_response():
+    """RESULT/CODE != 'INFO-000' → LawNormalizationError."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <head>
+    <RESULT>
+      <CODE>INFO-200</CODE>
+      <MESSAGE>해당하는 데이터가 없습니다.</MESSAGE>
+    </RESULT>
+  </head>
+</root>"""
+    with pytest.raises(LawNormalizationError) as exc:
+        normalize_bill_info(xml)
+    assert "INFO-200" in str(exc.value)
+
+
+def test_normalize_bill_info_returns_empty_list_when_no_rows():
+    """row 노드가 없으면 빈 리스트 (정상 응답 코드)."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <head>
+    <list_total_count>0</list_total_count>
+    <RESULT>
+      <CODE>INFO-000</CODE>
+      <MESSAGE>정상 처리되었습니다.</MESSAGE>
+    </RESULT>
+  </head>
+</root>"""
+    assert normalize_bill_info(xml) == []
+
+
+def test_normalize_bill_info_required_field_missing_raises():
+    """BILL_NAME 누락 → LawNormalizationError."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <head>
+    <RESULT>
+      <CODE>INFO-000</CODE>
+    </RESULT>
+  </head>
+  <row>
+    <BILL_ID>X</BILL_ID>
+    <BILL_NO>1</BILL_NO>
+  </row>
+</root>"""
+    with pytest.raises(LawNormalizationError):
+        normalize_bill_info(xml)
+
+
+def test_normalize_bill_info_invalid_date_becomes_none():
+    """PROPOSE_DT 형식 어긋나면 None."""
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <head>
+    <RESULT>
+      <CODE>INFO-000</CODE>
+    </RESULT>
+  </head>
+  <row>
+    <BILL_ID>X</BILL_ID>
+    <BILL_NO>1</BILL_NO>
+    <BILL_NAME>테스트의안</BILL_NAME>
+    <PROPOSE_DT>2026/04/28</PROPOSE_DT>
+  </row>
+</root>"""
+    records = normalize_bill_info(xml)
+    assert records[0].propose_date is None

--- a/mcp-server/tests/tools/test_law.py
+++ b/mcp-server/tests/tools/test_law.py
@@ -1,0 +1,451 @@
+"""tools.law.* 단위 테스트.
+
+실제 HTTP 호출 없이 api_source_service.fetch 를 stub 으로 교체해 도구 책임만 격리.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mcp_server.config import get_settings
+from mcp_server.db.models import ApiSource
+from mcp_server.db.session import get_session
+from mcp_server.domains.law.errors import LawConfigError, LawNormalizationError
+from mcp_server.sources import api_source_service
+from mcp_server.sources.errors import SourceFetchError, SourceNotFoundError
+from mcp_server.sources.result import RawResult
+from mcp_server.tools import law
+from mcp_server.tools.law import (
+    SearchBillInfoInput,
+    SearchLawInfoInput,
+    search_bill_info,
+    search_law_info,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "data" / "law"
+LAW_INFO_XML = (FIXTURES / "search_law_info.xml").read_text(encoding="utf-8")
+BILL_INFO_XML = (FIXTURES / "search_bill_info.xml").read_text(encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_module_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(law, "_cached_source_ids", {})
+
+
+@pytest.fixture(autouse=True)
+def set_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOLEG_LAW_INFO_API_KEY", "test-law-key")
+    monkeypatch.setenv("NA_BILL_INFO_API_KEY", "test-bill-key")
+    get_settings.cache_clear()
+
+
+async def _seed_source(
+    tool_name: str,
+    url_template: str,
+    name: str,
+) -> ApiSource:
+    async with get_session() as session:
+        row = ApiSource(
+            tool_name=tool_name,
+            name=name,
+            url_template=url_template,
+            param_schema={"type": "object"},
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return row
+
+
+def _make_fake_fetch(
+    content: str,
+    captured: dict[str, Any],
+    *,
+    tool_name: str,
+    url_template: str,
+):
+    async def fake(source_id: int, params: dict | None = None, **_: Any) -> RawResult:
+        captured["source_id"] = source_id
+        captured["params"] = params or {}
+        return RawResult(
+            source_type="api",
+            source_id=source_id,
+            content=content,
+            fetched_at=datetime(2026, 4, 29, 12, 0, tzinfo=UTC),
+            raw_metadata={
+                "tool_name": tool_name,
+                "url_template": url_template,
+                "params": params or {},
+            },
+        )
+
+    return fake
+
+
+# ─────────────────────────────────────────────
+# search_law_info
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_returns_common_schema(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """법제처 픽스처 → 공통 4필드 스키마 dict 반환."""
+    await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처 국가법령정보 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            LAW_INFO_XML,
+            captured,
+            tool_name="search_law_info",
+            url_template="https://example.gov/moleg/law-info",
+        ),
+    )
+
+    result = await search_law_info(SearchLawInfoInput(query="개인정보 보호법", num_of_rows=5))
+
+    assert isinstance(result["text"], str) and result["text"]
+    assert result["structured"]["summary"]["count"] == 2
+    assert len(result["structured"]["laws"]) == 2
+    assert result["structured"]["laws_truncated"] is False
+    assert "serviceKey=***" in result["source_url"]
+    assert result["metadata"]["raw_count"] == 2
+    assert result["metadata"]["tool_name"] == "search_law_info"
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_passes_query_to_fetch_params(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """query/page_no/num_of_rows 가 fetch params 에 그대로 전달."""
+    await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            LAW_INFO_XML,
+            captured,
+            tool_name="search_law_info",
+            url_template="https://example.gov/moleg/law-info",
+        ),
+    )
+
+    await search_law_info(SearchLawInfoInput(query="민법", page_no=2, num_of_rows=10))
+
+    assert captured["params"]["query"] == "민법"
+    assert captured["params"]["pageNo"] == 2
+    assert captured["params"]["numOfRows"] == 10
+    assert captured["params"]["target"] == "law"
+    assert captured["params"]["serviceKey"] == "test-law-key"
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_sorts_by_promulgation_date_desc(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """공포일자 내림차순 — 픽스처상 시행령(2025-09-23) 이 본법(2025-04-01) 보다 앞."""
+    await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            LAW_INFO_XML,
+            captured,
+            tool_name="search_law_info",
+            url_template="https://example.gov/moleg/law-info",
+        ),
+    )
+
+    result = await search_law_info(SearchLawInfoInput(query="개인정보 보호법"))
+
+    laws = result["structured"]["laws"]
+    assert laws[0]["law_name"] == "개인정보 보호법 시행령"
+    assert laws[1]["law_name"] == "개인정보 보호법"
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_propagates_normalization_error(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """resultCode != '00' → LawNormalizationError."""
+    await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처 (테스트)",
+    )
+    error_xml = """<?xml version="1.0"?>
+<LawSearch><resultCode>99</resultCode><resultMsg>error</resultMsg></LawSearch>"""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            error_xml,
+            captured,
+            tool_name="search_law_info",
+            url_template="https://example.gov/moleg/law-info",
+        ),
+    )
+
+    with pytest.raises(LawNormalizationError):
+        await search_law_info(SearchLawInfoInput(query="민법"))
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_raises_when_api_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """MOLEG_LAW_INFO_API_KEY 빈 값 → LawConfigError, fetch 호출 X."""
+    await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처 (테스트)",
+    )
+    monkeypatch.setenv("MOLEG_LAW_INFO_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(LawConfigError):
+        await search_law_info(SearchLawInfoInput(query="민법"))
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_propagates_source_not_found(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """api_source 시드 미실행 → SourceNotFoundError."""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            LAW_INFO_XML,
+            captured,
+            tool_name="search_law_info",
+            url_template="https://example.gov/moleg/law-info",
+        ),
+    )
+
+    with pytest.raises(SourceNotFoundError):
+        await search_law_info(SearchLawInfoInput(query="민법"))
+
+
+@pytest.mark.asyncio
+async def test_search_law_info_propagates_fetch_error(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처 (테스트)",
+    )
+
+    async def boom(*_args, **_kwargs):
+        raise SourceFetchError("upstream 503")
+
+    monkeypatch.setattr(api_source_service, "fetch", boom)
+
+    with pytest.raises(SourceFetchError):
+        await search_law_info(SearchLawInfoInput(query="민법"))
+
+
+def test_search_law_info_input_does_not_expose_secret_key():
+    fields = SearchLawInfoInput.model_fields
+    assert "serviceKey" not in fields
+    assert "service_key" not in fields
+
+
+# ─────────────────────────────────────────────
+# search_bill_info
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_bill_info_returns_common_schema(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """의안 픽스처 → 공통 4필드 스키마 + bills 리스트."""
+    await _seed_source(
+        tool_name="search_bill_info",
+        url_template="https://example.gov/na/bill-info",
+        name="국회 의안정보 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            BILL_INFO_XML,
+            captured,
+            tool_name="search_bill_info",
+            url_template="https://example.gov/na/bill-info",
+        ),
+    )
+
+    result = await search_bill_info(SearchBillInfoInput(age=22, num_of_rows=5))
+
+    assert isinstance(result["text"], str) and result["text"]
+    assert result["structured"]["summary"]["count"] >= 1
+    assert "bills" in result["structured"]
+    assert "KEY=***" in result["source_url"]
+    assert result["metadata"]["tool_name"] == "search_bill_info"
+
+
+@pytest.mark.asyncio
+async def test_search_bill_info_passes_age_and_paging_to_params(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """AGE/pIndex/pSize 가 fetch params 에 전달."""
+    await _seed_source(
+        tool_name="search_bill_info",
+        url_template="https://example.gov/na/bill-info",
+        name="국회 의안 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            BILL_INFO_XML,
+            captured,
+            tool_name="search_bill_info",
+            url_template="https://example.gov/na/bill-info",
+        ),
+    )
+
+    await search_bill_info(SearchBillInfoInput(age=21, page_no=3, num_of_rows=10))
+
+    assert captured["params"]["AGE"] == 21
+    assert captured["params"]["pIndex"] == 3
+    assert captured["params"]["pSize"] == 10
+    assert captured["params"]["Type"] == "xml"
+    assert captured["params"]["KEY"] == "test-bill-key"
+
+
+@pytest.mark.asyncio
+async def test_search_bill_info_propagates_normalization_error(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """RESULT/CODE != 'INFO-000' → LawNormalizationError."""
+    await _seed_source(
+        tool_name="search_bill_info",
+        url_template="https://example.gov/na/bill-info",
+        name="국회 의안 (테스트)",
+    )
+    error_xml = """<?xml version="1.0"?>
+<root><head><RESULT><CODE>INFO-200</CODE><MESSAGE>없음</MESSAGE></RESULT></head></root>"""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            error_xml,
+            captured,
+            tool_name="search_bill_info",
+            url_template="https://example.gov/na/bill-info",
+        ),
+    )
+
+    with pytest.raises(LawNormalizationError):
+        await search_bill_info(SearchBillInfoInput(age=22))
+
+
+@pytest.mark.asyncio
+async def test_search_bill_info_raises_when_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """NA_BILL_INFO_API_KEY 빈 값 → LawConfigError."""
+    await _seed_source(
+        tool_name="search_bill_info",
+        url_template="https://example.gov/na/bill-info",
+        name="국회 의안 (테스트)",
+    )
+    monkeypatch.setenv("NA_BILL_INFO_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(LawConfigError):
+        await search_bill_info(SearchBillInfoInput(age=22))
+
+
+def test_search_bill_info_input_does_not_expose_secret_key():
+    fields = SearchBillInfoInput.model_fields
+    assert "KEY" not in fields
+    assert "key" not in fields
+
+
+# ─────────────────────────────────────────────
+# 캐시 격리 — 두 도구가 같은 dict 공유하지만 키 충돌 없이
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_id_caches_per_tool_name(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    law_row = await _seed_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/moleg/law-info",
+        name="법제처",
+    )
+    bill_row = await _seed_source(
+        tool_name="search_bill_info",
+        url_template="https://example.gov/na/bill-info",
+        name="국회",
+    )
+
+    captured1: dict[str, Any] = {}
+    captured2: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            LAW_INFO_XML,
+            captured1,
+            tool_name="search_law_info",
+            url_template="https://example.gov/moleg/law-info",
+        ),
+    )
+    await search_law_info(SearchLawInfoInput(query="민법"))
+
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            BILL_INFO_XML,
+            captured2,
+            tool_name="search_bill_info",
+            url_template="https://example.gov/na/bill-info",
+        ),
+    )
+    await search_bill_info(SearchBillInfoInput(age=22))
+
+    assert law._cached_source_ids["search_law_info"] == law_row.id
+    assert law._cached_source_ids["search_bill_info"] == bill_row.id


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #90 

**🛠 작업 내역**
`search_law_info` / `search_bill_info` 두 도구는 현재 raw passthrough 상태로 외부 응답을 그대로 LLM 컨텍스트에 노출하고 있다. Spring AI 가 도구를 호출할 때마다 토큰이 소모되고, LLM 이 의미 단위로 판단하기 어렵다

부동산·경매와 동일한 도메인 정규화 패턴을 법률 도메인에 적용해 응답을 의미 있는 모니터링 단위로 끌어올린다

응답 구조는 선행 PR 에서 캡처한 픽스처 기반

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?