### PR TITLE
feat: 채용 도메인 정규화 - search_public_job / search_worknet_job raw passthrough 교체

### DIFF
--- a/mcp-server/src/mcp_server/domains/jobs/errors.py
+++ b/mcp-server/src/mcp_server/domains/jobs/errors.py
@@ -12,4 +12,23 @@ class JobsConfigError(JobsError):
     """
 
 
-__all__ = ["JobsError", "JobsConfigError"]
+class JobsNormalizationError(JobsError):
+    """API 응답 본문 정규화 실패 (XML/JSON 파싱, 응답 코드 비정상, 필수 필드 누락)."""
+
+
+class WorknetPermissionDeniedError(JobsNormalizationError):
+    """워크넷 OPEN-API 가 개인회원 키에 대해 거부 응답 반환.
+
+    응답 본문: <error>개인회원은 사용할 수 없는 OPEN-API입니다.</error>
+    키 교체로 해결 불가 (사업자/기관 회원 한정). 도구 레이어가 잡아서
+    사용자에게 명확한 "권한 미발급" 안내 응답을 반환할 수 있도록 일반
+    정규화 실패와 분리한다.
+    """
+
+
+__all__ = [
+    "JobsConfigError",
+    "JobsError",
+    "JobsNormalizationError",
+    "WorknetPermissionDeniedError",
+]

--- a/mcp-server/src/mcp_server/domains/jobs/normalizer.py
+++ b/mcp-server/src/mcp_server/domains/jobs/normalizer.py
@@ -1,0 +1,263 @@
+"""기획재정부 ALIO 공공기관 채용 / 한국고용정보원 워크넷 채용정보 응답 정규화.
+
+api_source_service.fetch() 가 돌려준 본문 (ALIO=JSON, 워크넷=XML) 을 도메인 모델
+list 로 변환. 정규화는 도메인 책임이라 sources 계층 예외와 분리된
+JobsNormalizationError 를 사용한다.
+
+지원 응답 (2종):
+- ALIO 채용공시 목록 (JSON, resultCode 200) → list[PublicJobPosting]
+- 워크넷 채용정보 (XML)
+  - 권한 거부 응답 (<error>개인회원은 ...</error>) → WorknetPermissionDeniedError
+  - 정상 응답 (<wantedRoot><pubJobs><wanted>...</wanted></pubJobs></wantedRoot>)
+    → list[WorknetJobPosting]
+
+워크넷 정상 응답 정규화는 추정 명세 기반으로 작성되어 있으며, 사업자/기관 권한
+확보 후 픽스처(tests/data/jobs/search_worknet_job.xml) 를 갱신한 시점에서
+실응답 구조에 맞춰 보강해야 한다.
+"""
+
+import json
+from datetime import date
+from xml.etree import ElementTree as ET
+
+from pydantic import BaseModel, Field
+
+from mcp_server.domains.jobs.errors import (
+    JobsNormalizationError,
+    WorknetPermissionDeniedError,
+)
+
+_PUBLIC_JOB_SUCCESS_CODE = 200
+
+
+# ─────────────────────────────────────────────
+# 모델
+# ─────────────────────────────────────────────
+
+
+class PublicJobPosting(BaseModel):
+    """ALIO 공공기관 채용공시 1건."""
+
+    pblnt_sn: int = Field(description="공시 일련번호 (recrutPblntSn)")
+    title: str = Field(description="공고 제목")
+    institute: str = Field(description="기관명")
+    institute_code: str | None = Field(default=None, description="공시기관코드")
+    hire_type: str | None = Field(default=None, description="고용형태명 (정규직/비정규직 등)")
+    recruit_type: str | None = Field(default=None, description="채용구분 (신입/경력/신입+경력 등)")
+    ncs_categories: list[str] = Field(default_factory=list, description="NCS 직무 분류명 리스트")
+    work_regions: list[str] = Field(default_factory=list, description="근무지역명 리스트")
+    headcount: int | None = Field(default=None, description="채용 인원")
+    pbanc_begin_date: date | None = Field(default=None, description="공고 시작일")
+    pbanc_end_date: date | None = Field(default=None, description="공고 마감일")
+    is_ongoing: bool | None = Field(default=None, description="진행 여부 (ongoingYn=Y)")
+    src_url: str | None = Field(default=None, description="원문 공고 URL")
+
+
+class WorknetJobPosting(BaseModel):
+    """워크넷 채용공고 1건 (정상 응답 구조 기준)."""
+
+    title: str = Field(description="채용 제목 (wantedTitle)")
+    company: str = Field(description="회사명/사업장명 (busplaName)")
+    region: str | None = Field(default=None, description="근무지역명 (regionNm)")
+    emp_type: str | None = Field(default=None, description="고용형태명 (empTpNm)")
+    min_education: str | None = Field(default=None, description="최소학력 (minEdubgNm)")
+    salary_type: str | None = Field(default=None, description="임금형태명 (salTpNm)")
+    reg_date: date | None = Field(default=None, description="등록일자")
+    close_date: date | None = Field(default=None, description="마감일자")
+    info_url: str | None = Field(default=None, description="상세 URL (wantedInfoUrl)")
+
+
+# ─────────────────────────────────────────────
+# 정규화 — ALIO 공공기관 채용 (JSON)
+# ─────────────────────────────────────────────
+
+
+def normalize_public_job(json_text: str) -> list[PublicJobPosting]:
+    """ALIO 공공기관 채용공시 JSON 응답 → list[PublicJobPosting].
+
+    Raises:
+        JobsNormalizationError: 응답 코드 비정상, JSON 파싱 실패, 필수 필드 누락.
+    """
+    try:
+        payload = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise JobsNormalizationError(f"ALIO 응답 JSON 파싱 실패: {exc}") from exc
+
+    code = payload.get("resultCode")
+    if code != _PUBLIC_JOB_SUCCESS_CODE:
+        msg = payload.get("resultMsg") or "(메시지 없음)"
+        raise JobsNormalizationError(f"ALIO API 비정상 응답: code={code}, msg={msg}")
+
+    items = payload.get("result") or []
+    if not isinstance(items, list):
+        raise JobsNormalizationError(
+            f"ALIO 응답 result 형식 비정상: {type(items).__name__}"
+        )
+    return [_build_public_posting(item) for item in items]
+
+
+def _build_public_posting(item: dict) -> PublicJobPosting:
+    try:
+        return PublicJobPosting(
+            pblnt_sn=int(_required(item, "recrutPblntSn")),
+            title=_required(item, "recrutPbancTtl"),
+            institute=_required(item, "instNm"),
+            institute_code=_optional_str(item, "pblntInstCd"),
+            hire_type=_optional_str(item, "hireTypeNmLst"),
+            recruit_type=_optional_str(item, "recrutSeNm"),
+            ncs_categories=_split_csv(item.get("ncsCdNmLst")),
+            work_regions=_split_csv(item.get("workRgnNmLst")),
+            headcount=_optional_int_value(item.get("recrutNope")),
+            pbanc_begin_date=_optional_yyyymmdd(item.get("pbancBgngYmd")),
+            pbanc_end_date=_optional_yyyymmdd(item.get("pbancEndYmd")),
+            is_ongoing=_optional_yn(item.get("ongoingYn")),
+            src_url=_optional_str(item, "srcUrl"),
+        )
+    except (KeyError, ValueError) as exc:
+        raise JobsNormalizationError(
+            f"ALIO result 항목 필수 필드 파싱 실패: {exc}"
+        ) from exc
+
+
+# ─────────────────────────────────────────────
+# 정규화 — 워크넷 채용 (XML, 권한 거부 분기)
+# ─────────────────────────────────────────────
+
+
+def normalize_worknet_job(xml_text: str) -> list[WorknetJobPosting]:
+    """워크넷 채용공고 XML 응답 → list[WorknetJobPosting].
+
+    권한 거부 응답(<GO24><error>...개인회원...</error></GO24>) 은 일반 정규화 실패와
+    구분된 WorknetPermissionDeniedError 로 raise. 도구 레이어에서 catch 해
+    사용자에게 "권한 미발급" 안내 응답으로 변환할 수 있다.
+
+    Raises:
+        WorknetPermissionDeniedError: 개인회원 권한 거부 응답.
+        JobsNormalizationError: 그 외 응답 형식 오류 (XML 파싱, 일반 에러 메시지).
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise JobsNormalizationError(f"워크넷 응답 XML 파싱 실패: {exc}") from exc
+
+    error_node = root.find("error")
+    if error_node is not None:
+        msg = (error_node.text or "").strip() or "(메시지 없음)"
+        if "사용할 수 없는" in msg or "개인회원" in msg:
+            raise WorknetPermissionDeniedError(msg)
+        raise JobsNormalizationError(f"워크넷 API 에러: {msg}")
+
+    # 정상 응답 구조: <wantedRoot><pubJobs><wanted>...</wanted></pubJobs></wantedRoot>
+    # findall(".//wanted") 로 루트 위치 변동에 견고하게 추출.
+    return [_build_worknet_posting(node) for node in root.findall(".//wanted")]
+
+
+def _build_worknet_posting(node: ET.Element) -> WorknetJobPosting:
+    try:
+        return WorknetJobPosting(
+            title=_required_node(node, "wantedTitle"),
+            company=_required_node(node, "busplaName"),
+            region=_node_text(node, "regionNm"),
+            emp_type=_node_text(node, "empTpNm"),
+            min_education=_node_text(node, "minEdubgNm"),
+            salary_type=_node_text(node, "salTpNm"),
+            reg_date=_optional_yyyymmdd(_node_text(node, "regDt")),
+            close_date=_optional_yyyymmdd(_node_text(node, "closeDt")),
+            info_url=_node_text(node, "wantedInfoUrl"),
+        )
+    except (KeyError, ValueError) as exc:
+        raise JobsNormalizationError(
+            f"워크넷 wanted 항목 필수 필드 파싱 실패: {exc}"
+        ) from exc
+
+
+# ─────────────────────────────────────────────
+# 공통 유틸 — JSON dict 용
+# ─────────────────────────────────────────────
+
+
+def _required(item: dict, key: str) -> str:
+    value = item.get(key)
+    if value is None or value == "":
+        raise KeyError(key)
+    return str(value).strip()
+
+
+def _optional_str(item: dict, key: str) -> str | None:
+    value = item.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int_value(value) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(str(value).strip())
+    except ValueError:
+        return None
+
+
+def _optional_yyyymmdd(value) -> date | None:
+    """'YYYYMMDD' 문자열/정수 → date. 형식 어긋나면 None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if len(text) != 8 or not text.isdigit():
+        return None
+    try:
+        return date(int(text[:4]), int(text[4:6]), int(text[6:]))
+    except ValueError:
+        return None
+
+
+def _optional_yn(value) -> bool | None:
+    if value is None:
+        return None
+    text = str(value).strip().upper()
+    if text == "Y":
+        return True
+    if text == "N":
+        return False
+    return None
+
+
+def _split_csv(value) -> list[str]:
+    """ALIO 의 'R600023,R600015' 형식 CSV → ['R600023', 'R600015']. 빈 값은 빈 리스트."""
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+# ─────────────────────────────────────────────
+# 공통 유틸 — XML node 용
+# ─────────────────────────────────────────────
+
+
+def _node_text(parent: ET.Element, tag: str) -> str | None:
+    node = parent.find(tag)
+    if node is None or node.text is None:
+        return None
+    return node.text.strip() or None
+
+
+def _required_node(parent: ET.Element, tag: str) -> str:
+    text = _node_text(parent, tag)
+    if text is None:
+        raise KeyError(tag)
+    return text
+
+
+__all__ = [
+    "JobsNormalizationError",
+    "PublicJobPosting",
+    "WorknetJobPosting",
+    "WorknetPermissionDeniedError",
+    "normalize_public_job",
+    "normalize_worknet_job",
+]

--- a/mcp-server/src/mcp_server/tools/jobs.py
+++ b/mcp-server/src/mcp_server/tools/jobs.py
@@ -1,38 +1,80 @@
-"""채용 도메인 MCP 도구 (임시 minimal passthrough).
+"""채용 도메인 MCP 도구.
 
 등록 도구 (2종):
 - search_public_job  — 기획재정부 공공기관 채용정보 (data.go.kr/data/15125273)
 - search_worknet_job — 한국고용정보원 워크넷 채용정보 (data.go.kr/data/3038225)
 
 원칙:
-- serviceKey 는 도구 인자로 받지 않는다 (Langfuse 입력 캡처 보호).
+- serviceKey/authKey 같은 비밀값은 도구 인자로 받지 않는다 (Langfuse 입력 캡처 보호).
 - 외부 호출은 sources.api_source_service.fetch() 만 경유.
-- 정규화/통계는 PLAN Phase 5 본작업에서 추가. 현재는 raw passthrough.
+- 토큰 절약을 위해 상위 _MAX_RESULTS 건만 반환.
 
-KEIS_WORKNET_JOB 주의:
-  현재 발급된 키가 사용 불가 응답을 반환할 수 있음. 도구 자체는 정상 등록되어
-  Spring AI 가 도구 목록에서 인식하고 호출까지 도달함을 확인하는 데 의의가 있다.
-  키 발급/권한이 정상화되면 코드 수정 없이 동작.
+워크넷 권한 거부 처리:
+  현재 발급된 키가 개인회원 키인 경우 외부 API 가 <error> 응답을 반환한다.
+  이는 키 교체로 해결되지 않으며 사업자/기관 회원 발급이 필요하다.
+  도구는 WorknetPermissionDeniedError 를 잡아 정상 4필드 스키마 응답으로 변환하되,
+  metadata.api_status="permission_denied" 플래그와 text 안내 메시지를 포함시켜
+  호출자(LLM/백엔드) 가 분기할 수 있게 한다.
 """
 
+from datetime import date, datetime
 from typing import Any
+from urllib.parse import urlencode
 
 from pydantic import BaseModel, Field
 
 from mcp_server.config import get_settings
-from mcp_server.domains.jobs.errors import JobsConfigError
+from mcp_server.domains.jobs.errors import (
+    JobsConfigError,
+    WorknetPermissionDeniedError,
+)
+from mcp_server.domains.jobs.normalizer import (
+    PublicJobPosting,
+    WorknetJobPosting,
+    normalize_public_job,
+    normalize_worknet_job,
+)
 from mcp_server.observability.tracing import traced
 from mcp_server.server import mcp
 from mcp_server.sources import api_source_service
-from mcp_server.tools._passthrough import (
-    build_passthrough_response,
-    resolve_source_id,
-)
 
 _DEFAULT_NUM_OF_ROWS = 20
+_MAX_RESULTS = 20
+
+# tool_name → api_source.id 캐시
+_cached_source_ids: dict[str, int] = {}
+
+
+async def _resolve_source_id(tool_name: str) -> int:
+    if tool_name not in _cached_source_ids:
+        _cached_source_ids[tool_name] = (
+            await api_source_service.resolve_source_id_by_tool_name(tool_name)
+        )
+    return _cached_source_ids[tool_name]
+
+
+def _mask_query_string(params: dict[str, Any], *, secret_keys: tuple[str, ...]) -> str:
+    masked = {k: ("***" if k in secret_keys else v) for k, v in params.items()}
+    return urlencode(masked, safe="*")
+
+
+def _build_source_url(raw, params: dict[str, Any], secret_keys: tuple[str, ...]) -> str | None:
+    url_template = raw.raw_metadata.get("url_template", "")
+    if not url_template:
+        return None
+    return f"{url_template}?{_mask_query_string(params, secret_keys=secret_keys)}"
+
+
+def _fetched_at(raw) -> str:
+    return (
+        raw.fetched_at.isoformat()
+        if isinstance(raw.fetched_at, datetime)
+        else str(raw.fetched_at)
+    )
+
 
 # ─────────────────────────────────────────────
-# 도구 1: 기획재정부 공공기관 채용
+# 도구 1: 기획재정부 공공기관 채용 (ALIO)
 # ─────────────────────────────────────────────
 
 _TOOL_PUBLIC_JOB = "search_public_job"
@@ -59,17 +101,62 @@ class SearchPublicJobInput(BaseModel):
     )
 
 
+def _summarize_public_job(records: list[PublicJobPosting]) -> dict[str, Any]:
+    if not records:
+        return {
+            "count": 0,
+            "ongoing_count": 0,
+            "institutes": [],
+            "latest_pbanc_begin_date": None,
+        }
+    ongoing_count = sum(1 for r in records if r.is_ongoing)
+    institutes = sorted({r.institute for r in records if r.institute})
+    begin_dates = [r.pbanc_begin_date for r in records if r.pbanc_begin_date]
+    return {
+        "count": len(records),
+        "ongoing_count": ongoing_count,
+        "institutes": institutes,
+        "latest_pbanc_begin_date": (
+            max(begin_dates).isoformat() if begin_dates else None
+        ),
+    }
+
+
+def _public_job_text(summary: dict[str, Any], records: list[PublicJobPosting]) -> str:
+    if summary["count"] == 0:
+        return "공공기관 채용공시 0건."
+    latest_record = max(
+        (r for r in records if r.pbanc_begin_date),
+        key=lambda r: r.pbanc_begin_date,
+        default=None,
+    )
+    latest_name = latest_record.title if latest_record else "-"
+    latest_date = summary["latest_pbanc_begin_date"] or "-"
+    return (
+        f"공공기관 채용공시 {summary['count']}건 "
+        f"(진행 {summary['ongoing_count']}건). "
+        f"최신 공고 {latest_date} ({latest_name})."
+    )
+
+
 @mcp.tool()
 @traced(_TOOL_PUBLIC_JOB)
 async def search_public_job(input: SearchPublicJobInput) -> dict[str, Any]:
-    """기획재정부 **공공기관 채용공시 목록조회**.
+    """기획재정부 **공공기관 채용공시 목록조회** (ALIO 기반).
 
-    공공기관 경영정보 공개시스템(ALIO) 기반 채용공시 목록 조회. 응답은 외부 API 가
-    돌려준 원본을 그대로 {text, structured.raw, source_url, metadata} 공통 스키마로
-    노출한다.
+    공공기관 경영정보 공개시스템 채용공시 목록을 조회하고 정규화된
+    PublicJobPosting 리스트와 {text, structured, source_url, metadata} 공통
+    스키마로 반환한다.
+
+    반환 dict:
+      - text: 통계 요약 (총건수 + 진행건수 + 최신 공고).
+      - structured.summary: {count, ongoing_count, institutes[], latest_pbanc_begin_date}.
+      - structured.postings: PublicJobPosting dict 의 상위 20건 (공고시작일 내림차순).
+      - structured.postings_truncated / query / source_url / metadata: 동일.
 
     Raises:
         JobsConfigError: MOEF_PUBLIC_JOB_API_KEY 미설정.
+        JobsNormalizationError: API 응답이 비정상(코드 != 200) 또는 JSON 파싱 실패.
         SourceNotFoundError / SourceFetchError: 외부 호출 관련 오류.
     """
     settings = get_settings()
@@ -78,7 +165,7 @@ async def search_public_job(input: SearchPublicJobInput) -> dict[str, Any]:
             "MOEF_PUBLIC_JOB_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    source_id = await resolve_source_id(_TOOL_PUBLIC_JOB)
+    source_id = await _resolve_source_id(_TOOL_PUBLIC_JOB)
     params: dict[str, Any] = {
         "serviceKey": settings.moef_public_job_api_key,
         "pageNo": input.page_no,
@@ -91,22 +178,43 @@ async def search_public_job(input: SearchPublicJobInput) -> dict[str, Any]:
         params["recrutPbancTtl"] = input.recrut_pbanc_ttl
 
     raw = await api_source_service.fetch(source_id=source_id, params=params)
+    records: list[PublicJobPosting] = normalize_public_job(raw.content)
+    summary = _summarize_public_job(records)
 
-    return build_passthrough_response(
-        raw=raw,
-        tool_name=_TOOL_PUBLIC_JOB,
-        source_id=source_id,
-        params=params,
-        secret_keys=("serviceKey",),
-        summary_text=(
-            f"공공기관 채용공시 목록조회 (page={input.page_no}, "
-            f"rows={input.num_of_rows}) 응답 {len(raw.content or '')}자 수신."
-        ),
+    sorted_records = sorted(
+        records,
+        key=lambda r: r.pbanc_begin_date or date.min,
+        reverse=True,
     )
+    truncated = len(sorted_records) > _MAX_RESULTS
+    returned = sorted_records[:_MAX_RESULTS]
+
+    return {
+        "text": _public_job_text(summary, records),
+        "structured": {
+            "summary": summary,
+            "postings": [r.model_dump(mode="json") for r in returned],
+            "postings_truncated": truncated,
+            "query": {
+                "page_no": input.page_no,
+                "num_of_rows": input.num_of_rows,
+                "ongoing_yn": input.ongoing_yn,
+                "recrut_pbanc_ttl": input.recrut_pbanc_ttl,
+            },
+        },
+        "source_url": _build_source_url(raw, params, secret_keys=("serviceKey",)),
+        "metadata": {
+            "fetched_at": _fetched_at(raw),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": _TOOL_PUBLIC_JOB,
+            "source_id": source_id,
+        },
+    }
 
 
 # ─────────────────────────────────────────────
-# 도구 2: 워크넷 채용정보 (KEIS)
+# 도구 2: 워크넷 채용정보 (KEIS) — 권한 거부 분기 포함
 # ─────────────────────────────────────────────
 
 _TOOL_WORKNET_JOB = "search_worknet_job"
@@ -128,20 +236,88 @@ class SearchWorknetJobInput(BaseModel):
     )
 
 
+def _summarize_worknet(records: list[WorknetJobPosting]) -> dict[str, Any]:
+    if not records:
+        return {"count": 0, "regions": [], "latest_reg_date": None}
+    regions = sorted({r.region for r in records if r.region})
+    reg_dates = [r.reg_date for r in records if r.reg_date]
+    return {
+        "count": len(records),
+        "regions": regions,
+        "latest_reg_date": max(reg_dates).isoformat() if reg_dates else None,
+    }
+
+
+def _worknet_text(keyword: str, summary: dict[str, Any]) -> str:
+    keyword_label = keyword or "(전체)"
+    if summary["count"] == 0:
+        return f"워크넷 채용 검색 '{keyword_label}' 0건."
+    return (
+        f"워크넷 채용 검색 '{keyword_label}' {summary['count']}건. "
+        f"최근 등록 {summary['latest_reg_date'] or '-'}."
+    )
+
+
+def _build_permission_denied_response(
+    *,
+    message: str,
+    keyword: str,
+    params: dict[str, Any],
+    source_url: str | None,
+    fetched_at_iso: str,
+    source_id: int,
+) -> dict[str, Any]:
+    """워크넷 권한 거부 응답 → 정상 4필드 스키마 + permission_denied 플래그.
+
+    호출자(LLM/백엔드) 가 metadata.api_status 로 분기할 수 있도록 일반 0건 응답과
+    구분된 형태로 반환한다.
+    """
+    return {
+        "text": (
+            f"워크넷 OPEN-API 권한 미발급 — 사업자/기관 회원 키가 필요합니다 "
+            f"(개인회원 키로 호출됨). 외부 API 응답: '{message}'"
+        ),
+        "structured": {
+            "summary": {"count": 0, "regions": [], "latest_reg_date": None},
+            "postings": [],
+            "postings_truncated": False,
+            "permission_denied": True,
+            "permission_denied_message": message,
+            "query": {
+                "keyword": keyword,
+                "page_no": params.get("startPage"),
+                "display": params.get("display"),
+            },
+        },
+        "source_url": source_url,
+        "metadata": {
+            "fetched_at": fetched_at_iso,
+            "raw_count": 0,
+            "returned_count": 0,
+            "tool_name": _TOOL_WORKNET_JOB,
+            "source_id": source_id,
+            "api_status": "permission_denied",
+        },
+    }
+
+
 @mcp.tool()
 @traced(_TOOL_WORKNET_JOB)
 async def search_worknet_job(input: SearchWorknetJobInput) -> dict[str, Any]:
     """**워크넷 채용정보** 조회 (한국고용정보원).
 
-    키워드로 채용 공고 목록을 조회한다. 응답은 외부 API 가 돌려준 원본을 그대로
-    {text, structured.raw, source_url, metadata} 공통 스키마로 노출한다.
+    키워드로 채용 공고 목록을 조회하고 정규화된 WorknetJobPosting 리스트와
+    {text, structured, source_url, metadata} 공통 스키마로 반환한다.
 
-    참고: 현재 발급 키가 사용 불가(권한/심사) 응답을 반환할 수 있다.
-    이 경우에도 도구 호출 경로(MCP → API 도달) 자체는 정상 동작하며,
-    structured.raw 에 사용 불가 메시지가 그대로 노출된다.
+    참고 — 권한 미발급 시 동작:
+      현재 발급 키가 개인회원 키이면 외부 API 가 사용 거부 응답을 반환한다.
+      이 경우 도구는 예외를 던지지 않고 정상 4필드 응답을 반환하되,
+      structured.permission_denied=True / metadata.api_status="permission_denied" /
+      text 안내 메시지를 포함해 호출자가 분기할 수 있게 한다.
 
     Raises:
         JobsConfigError: KEIS_WORKNET_JOB_API_KEY 미설정.
+        JobsNormalizationError: 권한 거부 외의 응답 형식 오류 (XML 파싱 등).
         SourceNotFoundError / SourceFetchError: 외부 호출 관련 오류.
     """
     settings = get_settings()
@@ -150,7 +326,7 @@ async def search_worknet_job(input: SearchWorknetJobInput) -> dict[str, Any]:
             "KEIS_WORKNET_JOB_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    source_id = await resolve_source_id(_TOOL_WORKNET_JOB)
+    source_id = await _resolve_source_id(_TOOL_WORKNET_JOB)
     params: dict[str, Any] = {
         "authKey": settings.keis_worknet_job_api_key,
         "callTp": "L",
@@ -162,19 +338,54 @@ async def search_worknet_job(input: SearchWorknetJobInput) -> dict[str, Any]:
         params["keyword"] = input.keyword
 
     raw = await api_source_service.fetch(source_id=source_id, params=params)
+    source_url = _build_source_url(raw, params, secret_keys=("authKey",))
+    fetched_at_iso = _fetched_at(raw)
 
-    return build_passthrough_response(
-        raw=raw,
-        tool_name=_TOOL_WORKNET_JOB,
-        source_id=source_id,
-        params=params,
-        secret_keys=("authKey",),
-        summary_text=(
-            f"워크넷 채용 검색 keyword='{input.keyword or '(전체)'}' "
-            f"(page={input.start_page}, display={input.display}) "
-            f"응답 {len(raw.content or '')}자 수신."
-        ),
+    try:
+        records: list[WorknetJobPosting] = normalize_worknet_job(raw.content)
+    except WorknetPermissionDeniedError as exc:
+        return _build_permission_denied_response(
+            message=str(exc),
+            keyword=input.keyword,
+            params=params,
+            source_url=source_url,
+            fetched_at_iso=fetched_at_iso,
+            source_id=source_id,
+        )
+
+    summary = _summarize_worknet(records)
+
+    sorted_records = sorted(
+        records,
+        key=lambda r: r.reg_date or date.min,
+        reverse=True,
     )
+    truncated = len(sorted_records) > _MAX_RESULTS
+    returned = sorted_records[:_MAX_RESULTS]
+
+    return {
+        "text": _worknet_text(input.keyword, summary),
+        "structured": {
+            "summary": summary,
+            "postings": [r.model_dump(mode="json") for r in returned],
+            "postings_truncated": truncated,
+            "permission_denied": False,
+            "query": {
+                "keyword": input.keyword,
+                "page_no": input.start_page,
+                "display": input.display,
+            },
+        },
+        "source_url": source_url,
+        "metadata": {
+            "fetched_at": fetched_at_iso,
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": _TOOL_WORKNET_JOB,
+            "source_id": source_id,
+            "api_status": "ok",
+        },
+    }
 
 
 __all__ = [

--- a/mcp-server/tests/domains/jobs/test_normalizer.py
+++ b/mcp-server/tests/domains/jobs/test_normalizer.py
@@ -1,0 +1,230 @@
+"""normalize_public_job / normalize_worknet_job 정규화 단위 테스트.
+
+실제 응답 픽스처 (tests/data/jobs/*.{json,xml}) + 인공 케이스로 경계 조건 검증.
+
+워크넷은 현재 사업자/기관 권한 미발급 상태라 정상 응답 픽스처가 없다.
+권한 거부 분기는 실제 픽스처 기반, 정상 응답 정규화는 인공 XML 기반으로 검증.
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from mcp_server.domains.jobs.errors import (
+    JobsNormalizationError,
+    WorknetPermissionDeniedError,
+)
+from mcp_server.domains.jobs.normalizer import (
+    PublicJobPosting,
+    WorknetJobPosting,
+    normalize_public_job,
+    normalize_worknet_job,
+)
+
+FIXTURES = Path(__file__).resolve().parents[2] / "data" / "jobs"
+PUBLIC_JOB_JSON = (FIXTURES / "search_public_job.json").read_text(encoding="utf-8")
+WORKNET_JOB_XML = (FIXTURES / "search_worknet_job.xml").read_text(encoding="utf-8")
+
+
+def _wrap_public_job(items: list[dict]) -> str:
+    return json.dumps(
+        {
+            "result": items,
+            "resultCode": 200,
+            "resultMsg": "성공했습니다.",
+            "totalCount": len(items),
+        }
+    )
+
+
+# ─────────────────────────────────────────────
+# normalize_public_job (ALIO JSON)
+# ─────────────────────────────────────────────
+
+
+def test_normalize_public_job_real_fixture_returns_5_records():
+    """ALIO 픽스처(rows=5) → 5개 PublicJobPosting."""
+    records = normalize_public_job(PUBLIC_JOB_JSON)
+    assert len(records) == 5
+    assert all(isinstance(r, PublicJobPosting) for r in records)
+
+
+def test_normalize_public_job_extracts_core_fields():
+    """첫 번째 항목의 핵심 필드 검증."""
+    records = normalize_public_job(PUBLIC_JOB_JSON)
+    first = records[0]
+    assert first.title  # recrutPbancTtl
+    assert first.institute  # instNm
+    assert isinstance(first.pblnt_sn, int)
+
+
+def test_normalize_public_job_parses_yyyymmdd_dates():
+    """pbancBgngYmd / pbancEndYmd 'YYYYMMDD' 가 date 로 파싱."""
+    records = normalize_public_job(PUBLIC_JOB_JSON)
+    for r in records:
+        assert isinstance(r.pbanc_begin_date, date)
+        assert isinstance(r.pbanc_end_date, date)
+
+
+def test_normalize_public_job_splits_csv_categories():
+    """ncsCdNmLst 의 CSV → list[str] 변환."""
+    records = normalize_public_job(PUBLIC_JOB_JSON)
+    has_multiple = [r for r in records if len(r.ncs_categories) > 1]
+    assert has_multiple, "픽스처에 NCS 다중 카테고리 항목 없음"
+    assert all(isinstance(c, str) for c in has_multiple[0].ncs_categories)
+
+
+def test_normalize_public_job_yn_flag_to_bool():
+    """ongoingYn='Y' → True, 'N' → False, 미지정/잘못된 값 → None."""
+    records = normalize_public_job(PUBLIC_JOB_JSON)
+    # 픽스처 5건 모두 Y
+    assert all(r.is_ongoing is True for r in records)
+
+
+def test_normalize_public_job_raises_on_error_response():
+    """resultCode != 200 → JobsNormalizationError."""
+    payload = json.dumps(
+        {"result": [], "resultCode": 401, "resultMsg": "인증 실패", "totalCount": 0}
+    )
+    with pytest.raises(JobsNormalizationError) as exc:
+        normalize_public_job(payload)
+    assert "401" in str(exc.value)
+
+
+def test_normalize_public_job_raises_on_invalid_json():
+    """JSON 파싱 실패 → JobsNormalizationError."""
+    with pytest.raises(JobsNormalizationError):
+        normalize_public_job("not a json")
+
+
+def test_normalize_public_job_empty_result_returns_empty_list():
+    """result=[] → 빈 리스트."""
+    assert normalize_public_job(_wrap_public_job([])) == []
+
+
+def test_normalize_public_job_required_field_missing_raises():
+    """recrutPblntSn 누락 → JobsNormalizationError."""
+    item = {
+        "recrutPbancTtl": "테스트 공고",
+        "instNm": "테스트 기관",
+    }
+    with pytest.raises(JobsNormalizationError):
+        normalize_public_job(_wrap_public_job([item]))
+
+
+def test_normalize_public_job_invalid_yyyymmdd_becomes_none():
+    """잘못된 8자리 일자 → None, 예외 없음."""
+    item = {
+        "recrutPblntSn": 1,
+        "recrutPbancTtl": "테스트",
+        "instNm": "테스트 기관",
+        "pbancBgngYmd": "99999999",
+        "pbancEndYmd": "",
+    }
+    records = normalize_public_job(_wrap_public_job([item]))
+    assert records[0].pbanc_begin_date is None
+    assert records[0].pbanc_end_date is None
+
+
+# ─────────────────────────────────────────────
+# normalize_worknet_job — 권한 거부 분기
+# ─────────────────────────────────────────────
+
+
+def test_normalize_worknet_job_permission_denied_real_fixture():
+    """실제 픽스처(<error>개인회원...</error>) → WorknetPermissionDeniedError."""
+    with pytest.raises(WorknetPermissionDeniedError) as exc:
+        normalize_worknet_job(WORKNET_JOB_XML)
+    assert "개인회원" in str(exc.value) or "사용할 수 없는" in str(exc.value)
+
+
+def test_normalize_worknet_job_generic_error_raises_normal_error():
+    """<error> 자식이지만 권한 거부 메시지가 아니면 일반 JobsNormalizationError."""
+    xml = """<?xml version="1.0"?>
+<GO24><error>일시적인 서비스 점검 중입니다.</error></GO24>"""
+    with pytest.raises(JobsNormalizationError) as exc:
+        normalize_worknet_job(xml)
+    # 권한 거부 서브클래스가 아니어야 함
+    assert not isinstance(exc.value, WorknetPermissionDeniedError)
+
+
+def test_normalize_worknet_job_raises_on_invalid_xml():
+    """XML 파싱 실패 → JobsNormalizationError."""
+    with pytest.raises(JobsNormalizationError):
+        normalize_worknet_job("<not><valid")
+
+
+# ─────────────────────────────────────────────
+# normalize_worknet_job — 정상 응답 (추정 명세, 인공 XML)
+# ─────────────────────────────────────────────
+
+
+def test_normalize_worknet_job_normal_response_extracts_records():
+    """정상 응답 구조 (<wantedRoot><pubJobs><wanted>...</wanted></pubJobs></wantedRoot>) 정규화."""
+    xml = """<?xml version="1.0"?>
+<wantedRoot>
+  <pubJobs>
+    <total>2</total>
+    <wanted>
+      <wantedTitle>백엔드 개발자 (Java)</wantedTitle>
+      <busplaName>테스트회사</busplaName>
+      <regionNm>서울 강남구</regionNm>
+      <empTpNm>정규직</empTpNm>
+      <minEdubgNm>대졸</minEdubgNm>
+      <salTpNm>연봉</salTpNm>
+      <regDt>20260420</regDt>
+      <closeDt>20260520</closeDt>
+      <wantedInfoUrl>https://www.work.go.kr/...</wantedInfoUrl>
+    </wanted>
+    <wanted>
+      <wantedTitle>프론트엔드 개발자</wantedTitle>
+      <busplaName>다른회사</busplaName>
+      <regionNm>경기 성남시</regionNm>
+      <empTpNm>계약직</empTpNm>
+      <minEdubgNm>학력무관</minEdubgNm>
+      <salTpNm>월급</salTpNm>
+      <regDt>20260425</regDt>
+      <closeDt>20260525</closeDt>
+      <wantedInfoUrl>https://www.work.go.kr/...</wantedInfoUrl>
+    </wanted>
+  </pubJobs>
+</wantedRoot>"""
+    records = normalize_worknet_job(xml)
+    assert len(records) == 2
+    assert all(isinstance(r, WorknetJobPosting) for r in records)
+    assert records[0].title == "백엔드 개발자 (Java)"
+    assert records[0].region == "서울 강남구"
+    assert records[0].reg_date == date(2026, 4, 20)
+
+
+def test_normalize_worknet_job_empty_pub_jobs_returns_empty_list():
+    """<wanted> 노드 없음 → 빈 리스트 (에러 아님)."""
+    xml = """<?xml version="1.0"?>
+<wantedRoot><pubJobs><total>0</total></pubJobs></wantedRoot>"""
+    assert normalize_worknet_job(xml) == []
+
+
+def test_normalize_worknet_job_required_field_missing_raises():
+    """wantedTitle 누락 → JobsNormalizationError."""
+    xml = """<?xml version="1.0"?>
+<wantedRoot><pubJobs><wanted>
+  <busplaName>회사</busplaName>
+</wanted></pubJobs></wantedRoot>"""
+    with pytest.raises(JobsNormalizationError):
+        normalize_worknet_job(xml)
+
+
+def test_normalize_worknet_job_invalid_dates_become_none():
+    """잘못된 일자 형식 → None, 예외 없음."""
+    xml = """<?xml version="1.0"?>
+<wantedRoot><pubJobs><wanted>
+  <wantedTitle>테스트</wantedTitle>
+  <busplaName>회사</busplaName>
+  <regDt>2026-04-20</regDt>
+  <closeDt></closeDt>
+</wanted></pubJobs></wantedRoot>"""
+    records = normalize_worknet_job(xml)
+    assert records[0].reg_date is None
+    assert records[0].close_date is None

--- a/mcp-server/tests/tools/test_jobs.py
+++ b/mcp-server/tests/tools/test_jobs.py
@@ -1,0 +1,471 @@
+"""tools.jobs.* 단위 테스트.
+
+실제 HTTP 호출 없이 api_source_service.fetch 를 stub 으로 교체해 도구 책임만 격리.
+워크넷은 권한 거부 응답 → 정상 4필드 + permission_denied 플래그 변환 검증 포함.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mcp_server.config import get_settings
+from mcp_server.db.models import ApiSource
+from mcp_server.db.session import get_session
+from mcp_server.domains.jobs.errors import (
+    JobsConfigError,
+    JobsNormalizationError,
+)
+from mcp_server.sources import api_source_service
+from mcp_server.sources.errors import SourceFetchError, SourceNotFoundError
+from mcp_server.sources.result import RawResult
+from mcp_server.tools import jobs
+from mcp_server.tools.jobs import (
+    SearchPublicJobInput,
+    SearchWorknetJobInput,
+    search_public_job,
+    search_worknet_job,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "data" / "jobs"
+PUBLIC_JOB_JSON = (FIXTURES / "search_public_job.json").read_text(encoding="utf-8")
+WORKNET_JOB_XML = (FIXTURES / "search_worknet_job.xml").read_text(encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_module_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(jobs, "_cached_source_ids", {})
+
+
+@pytest.fixture(autouse=True)
+def set_api_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MOEF_PUBLIC_JOB_API_KEY", "test-public-key")
+    monkeypatch.setenv("KEIS_WORKNET_JOB_API_KEY", "test-worknet-key")
+    get_settings.cache_clear()
+
+
+async def _seed_source(
+    tool_name: str,
+    url_template: str,
+    name: str,
+) -> ApiSource:
+    async with get_session() as session:
+        row = ApiSource(
+            tool_name=tool_name,
+            name=name,
+            url_template=url_template,
+            param_schema={"type": "object"},
+        )
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return row
+
+
+def _make_fake_fetch(
+    content: str,
+    captured: dict[str, Any],
+    *,
+    tool_name: str,
+    url_template: str,
+):
+    async def fake(source_id: int, params: dict | None = None, **_: Any) -> RawResult:
+        captured["source_id"] = source_id
+        captured["params"] = params or {}
+        return RawResult(
+            source_type="api",
+            source_id=source_id,
+            content=content,
+            fetched_at=datetime(2026, 4, 29, 12, 0, tzinfo=UTC),
+            raw_metadata={
+                "tool_name": tool_name,
+                "url_template": url_template,
+                "params": params or {},
+            },
+        )
+
+    return fake
+
+
+# ─────────────────────────────────────────────
+# search_public_job
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_returns_common_schema(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """ALIO 픽스처 → 공통 4필드 스키마."""
+    await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO 채용공시 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            PUBLIC_JOB_JSON,
+            captured,
+            tool_name="search_public_job",
+            url_template="https://example.gov/moef/public-job",
+        ),
+    )
+
+    result = await search_public_job(SearchPublicJobInput(num_of_rows=5))
+
+    assert isinstance(result["text"], str) and result["text"]
+    assert result["structured"]["summary"]["count"] == 5
+    assert len(result["structured"]["postings"]) == 5
+    assert result["structured"]["postings_truncated"] is False
+    assert "serviceKey=***" in result["source_url"]
+    assert result["metadata"]["raw_count"] == 5
+    assert result["metadata"]["tool_name"] == "search_public_job"
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_passes_optional_params(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """ongoing_yn / recrut_pbanc_ttl 명시 시 fetch params 에 포함."""
+    await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            PUBLIC_JOB_JSON,
+            captured,
+            tool_name="search_public_job",
+            url_template="https://example.gov/moef/public-job",
+        ),
+    )
+
+    await search_public_job(
+        SearchPublicJobInput(ongoing_yn="Y", recrut_pbanc_ttl="데이터")
+    )
+
+    assert captured["params"]["ongoingYn"] == "Y"
+    assert captured["params"]["recrutPbancTtl"] == "데이터"
+    assert captured["params"]["resultType"] == "json"
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_optional_params_omitted_by_default(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """ongoing_yn / recrut_pbanc_ttl 미지정 시 params 에 포함되지 않음."""
+    await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            PUBLIC_JOB_JSON,
+            captured,
+            tool_name="search_public_job",
+            url_template="https://example.gov/moef/public-job",
+        ),
+    )
+
+    await search_public_job(SearchPublicJobInput())
+
+    assert "ongoingYn" not in captured["params"]
+    assert "recrutPbancTtl" not in captured["params"]
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_propagates_normalization_error(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """resultCode != 200 → JobsNormalizationError."""
+    await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO (테스트)",
+    )
+    error_json = json.dumps(
+        {"result": [], "resultCode": 401, "resultMsg": "auth fail", "totalCount": 0}
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            error_json,
+            captured,
+            tool_name="search_public_job",
+            url_template="https://example.gov/moef/public-job",
+        ),
+    )
+
+    with pytest.raises(JobsNormalizationError):
+        await search_public_job(SearchPublicJobInput())
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_raises_when_api_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """MOEF_PUBLIC_JOB_API_KEY 빈 값 → JobsConfigError, fetch 호출 X."""
+    await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO (테스트)",
+    )
+    monkeypatch.setenv("MOEF_PUBLIC_JOB_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(JobsConfigError):
+        await search_public_job(SearchPublicJobInput())
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_propagates_source_not_found(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            PUBLIC_JOB_JSON,
+            captured,
+            tool_name="search_public_job",
+            url_template="https://example.gov/moef/public-job",
+        ),
+    )
+
+    with pytest.raises(SourceNotFoundError):
+        await search_public_job(SearchPublicJobInput())
+
+
+@pytest.mark.asyncio
+async def test_search_public_job_propagates_fetch_error(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO (테스트)",
+    )
+
+    async def boom(*_args, **_kwargs):
+        raise SourceFetchError("upstream 503")
+
+    monkeypatch.setattr(api_source_service, "fetch", boom)
+
+    with pytest.raises(SourceFetchError):
+        await search_public_job(SearchPublicJobInput())
+
+
+def test_search_public_job_input_does_not_expose_secret_key():
+    fields = SearchPublicJobInput.model_fields
+    assert "serviceKey" not in fields
+    assert "service_key" not in fields
+
+
+# ─────────────────────────────────────────────
+# search_worknet_job — 권한 거부 분기
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_search_worknet_job_permission_denied_returns_normal_schema(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """권한 거부 응답 → 예외 X, 정상 4필드 + permission_denied=True."""
+    await _seed_source(
+        tool_name="search_worknet_job",
+        url_template="https://example.gov/keis/worknet",
+        name="워크넷 (테스트)",
+    )
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            WORKNET_JOB_XML,
+            captured,
+            tool_name="search_worknet_job",
+            url_template="https://example.gov/keis/worknet",
+        ),
+    )
+
+    result = await search_worknet_job(SearchWorknetJobInput())
+
+    assert result["structured"]["permission_denied"] is True
+    assert result["metadata"]["api_status"] == "permission_denied"
+    assert result["structured"]["summary"]["count"] == 0
+    assert result["structured"]["postings"] == []
+    assert "권한 미발급" in result["text"]
+    assert "authKey=***" in result["source_url"]
+
+
+@pytest.mark.asyncio
+async def test_search_worknet_job_normal_response_returns_postings(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """정상 응답(<wantedRoot><pubJobs><wanted>...) → postings 리스트."""
+    await _seed_source(
+        tool_name="search_worknet_job",
+        url_template="https://example.gov/keis/worknet",
+        name="워크넷 (테스트)",
+    )
+    normal_xml = """<?xml version="1.0"?>
+<wantedRoot>
+  <pubJobs>
+    <total>1</total>
+    <wanted>
+      <wantedTitle>백엔드 개발자</wantedTitle>
+      <busplaName>테스트회사</busplaName>
+      <regionNm>서울 강남구</regionNm>
+      <empTpNm>정규직</empTpNm>
+      <regDt>20260425</regDt>
+      <closeDt>20260525</closeDt>
+      <wantedInfoUrl>https://www.work.go.kr/x</wantedInfoUrl>
+    </wanted>
+  </pubJobs>
+</wantedRoot>"""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            normal_xml,
+            captured,
+            tool_name="search_worknet_job",
+            url_template="https://example.gov/keis/worknet",
+        ),
+    )
+
+    result = await search_worknet_job(SearchWorknetJobInput(keyword="백엔드"))
+
+    assert result["structured"]["permission_denied"] is False
+    assert result["metadata"]["api_status"] == "ok"
+    assert result["structured"]["summary"]["count"] == 1
+    assert result["structured"]["postings"][0]["title"] == "백엔드 개발자"
+    assert captured["params"]["keyword"] == "백엔드"
+
+
+@pytest.mark.asyncio
+async def test_search_worknet_job_propagates_non_permission_normalization_error(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """권한 거부 외의 normalize 에러는 전파 (도구가 catch 하지 않음)."""
+    await _seed_source(
+        tool_name="search_worknet_job",
+        url_template="https://example.gov/keis/worknet",
+        name="워크넷 (테스트)",
+    )
+    error_xml = """<?xml version="1.0"?><GO24><error>일시적 점검</error></GO24>"""
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            error_xml,
+            captured,
+            tool_name="search_worknet_job",
+            url_template="https://example.gov/keis/worknet",
+        ),
+    )
+
+    with pytest.raises(JobsNormalizationError):
+        await search_worknet_job(SearchWorknetJobInput())
+
+
+@pytest.mark.asyncio
+async def test_search_worknet_job_raises_when_key_missing(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """KEIS_WORKNET_JOB_API_KEY 빈 값 → JobsConfigError, fetch 호출 X."""
+    await _seed_source(
+        tool_name="search_worknet_job",
+        url_template="https://example.gov/keis/worknet",
+        name="워크넷 (테스트)",
+    )
+    monkeypatch.setenv("KEIS_WORKNET_JOB_API_KEY", "")
+    get_settings.cache_clear()
+
+    async def fail_fetch(*_args, **_kwargs):
+        raise AssertionError("fetch 가 호출되면 안 됨")
+
+    monkeypatch.setattr(api_source_service, "fetch", fail_fetch)
+
+    with pytest.raises(JobsConfigError):
+        await search_worknet_job(SearchWorknetJobInput())
+
+
+def test_search_worknet_job_input_does_not_expose_secret_key():
+    fields = SearchWorknetJobInput.model_fields
+    assert "authKey" not in fields
+    assert "auth_key" not in fields
+
+
+# ─────────────────────────────────────────────
+# 캐시 격리
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_id_caches_per_tool_name(
+    patched_session_factory, monkeypatch: pytest.MonkeyPatch
+):
+    """두 도구가 같은 _cached_source_ids dict 공유하지만 키 충돌 없음."""
+    public_row = await _seed_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/moef/public-job",
+        name="ALIO",
+    )
+    worknet_row = await _seed_source(
+        tool_name="search_worknet_job",
+        url_template="https://example.gov/keis/worknet",
+        name="워크넷",
+    )
+
+    captured1: dict[str, Any] = {}
+    captured2: dict[str, Any] = {}
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            PUBLIC_JOB_JSON,
+            captured1,
+            tool_name="search_public_job",
+            url_template="https://example.gov/moef/public-job",
+        ),
+    )
+    await search_public_job(SearchPublicJobInput())
+
+    monkeypatch.setattr(
+        api_source_service,
+        "fetch",
+        _make_fake_fetch(
+            WORKNET_JOB_XML,
+            captured2,
+            tool_name="search_worknet_job",
+            url_template="https://example.gov/keis/worknet",
+        ),
+    )
+    await search_worknet_job(SearchWorknetJobInput())
+
+    assert jobs._cached_source_ids["search_public_job"] == public_row.id
+    assert jobs._cached_source_ids["search_worknet_job"] == worknet_row.id


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #92 

**🛠 작업 내역**
`search_public_job` / `search_worknet_job` 두 도구는 현재 raw passthrough 상태로 외부 응답을 그대로 LLM 컨텍스트에 노출하고 있다. ALIO 응답은 토큰을 폭증시키고, 워크넷 응답은 정체불명의 99자라 LLM 이 무엇을 의미하는지 알 수 없다

부동산·경매·법률과 동일한 도메인 정규화 패턴을 채용 도메인에 적용해 응답을 의미 있는 모니터링 단위로 끌어올린다

응답 구조는 선행 PR 에서 캡처한 픽스처 기반

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?