### PR TITLE
Feat/api cache read activation

### DIFF
--- a/mcp-server/src/mcp_server/sources/api_source_service.py
+++ b/mcp-server/src/mcp_server/sources/api_source_service.py
@@ -3,10 +3,11 @@
 규약:
 - 도구는 직접 httpx 를 쓰지 말고 이 fetch() 만 호출한다.
 
-성공: API 호출 후 api_cache 에 upsert, RawResult 반환.
-실패:
-    캐시 있음 → RawResult(fetched_at=cache.cached_at) 반환.
-    캐시 없음 → fetch_error 기록 후 빈 RawResult 반환.
+캐시 구조 (도메인 단위 1 row):
+- api_cache 는 tool_name 당 1 row. site_url 은 placeholder (cache://{tool_name}).
+- fetch 성공 시 해당 row 를 upsert (덮어쓰기).
+- 외부 호출 실패 + 캐시 있음 → 캐시 반환 (fetched_at=cache.cached_at).
+- 외부 호출 실패 + 캐시 없음 → 빈 RawResult + fetch_error 메타.
 """
 
 import json
@@ -43,7 +44,6 @@ async def fetch(
     """
     source = await _load_source(source_id)
     params = params or {}
-    site_url = _build_site_url(source.url_template, params)
     fetched_at = datetime.now(UTC)
 
     try:
@@ -53,7 +53,7 @@ async def fetch(
             http_client=_test_http_client,
         )
     except SourceFetchError as exc:
-        cached = await _load_cache(site_url)
+        cached = await _load_cache_by_tool(source.tool_name)
         base_meta = {
             "tool_name": source.tool_name,
             "url_template": source.url_template,
@@ -75,9 +75,8 @@ async def fetch(
             raw_metadata={**base_meta, "fetch_error": str(exc)},
         )
 
-    await _upsert_cache(
+    await _upsert_cache_by_tool(
         source_id=source.id,
-        site_url=site_url,
         tool_name=source.tool_name,
         content=response_text,
         cached_at=fetched_at,
@@ -97,9 +96,49 @@ async def fetch(
 
 
 def _build_site_url(url_template: str, params: dict) -> str:
-    """캐시 키용 URL. serviceKey 제외 (DB에 API 키 저장 방지)."""
+    """원본 호출 URL 디버그 표시용. 캐시 키로는 더 이상 사용하지 않음 (tool_name 으로 변경)."""
     cache_params = {k: v for k, v in params.items() if k != "serviceKey"}
     return f"{url_template}?{urlencode(sorted(cache_params.items()))}"
+
+
+def _cache_site_url(tool_name: str) -> str:
+    """캐시 site_url placeholder. UNIQUE 제약을 만족시키는 도메인 단위 1 row 키."""
+    return f"cache://{tool_name}"
+
+
+# 캐시 read 가 의미 있는 도구 화이트리스트.
+# 부동산 6종은 LAWD_CD 가 API 필수라 도메인 단위 단일 호출이 불가능하고, tool_name
+# 단위 1 row 캐시는 마지막 (region, deal_ymd) 응답만 보관하므로 다른 (region, ymd)
+# 호출자에게 잘못된 응답을 줄 수 있다. 따라서 부동산 도구는 캐시 read 노출 대상에서
+# 제외 — 캐시 팀의 check_api_cache 도구도 이 화이트리스트만 받아야 한다.
+_CACHEABLE_TOOLS: frozenset[str] = frozenset({
+    "search_public_job",
+    "search_worknet_job",
+    "search_law_info",
+    "search_bill_info",
+    "search_g2b_bid",
+})
+
+
+async def peek_cached_content(tool_name: str) -> tuple[str, datetime] | None:
+    """캐시 팀의 check_api_cache 도구가 사용할 read 헬퍼.
+
+    캐시에 저장된 외부 API 응답 원문(content) 과 저장 시각(cached_at) 을 반환.
+    정규화·필터링은 도구 레이어 책임이라 여기선 raw content 그대로 노출한다.
+
+    Args:
+        tool_name: 캐시 read 대상 도구 이름.
+
+    Returns:
+        (content, cached_at) — 캐시가 있고 읽을 수 있을 때.
+        None — 캐시가 없거나, tool_name 이 _CACHEABLE_TOOLS 에 없을 때.
+    """
+    if tool_name not in _CACHEABLE_TOOLS:
+        return None
+    cached = await _load_cache_by_tool(tool_name)
+    if cached is None:
+        return None
+    return cached.content or "", cached.cached_at
 
 
 async def _load_source(source_id: int) -> ApiSource:
@@ -111,30 +150,29 @@ async def _load_source(source_id: int) -> ApiSource:
     return source
 
 
-async def _load_cache(site_url: str) -> ApiCache | None:
+async def _load_cache_by_tool(tool_name: str) -> ApiCache | None:
     async with get_session() as session:
         result = await session.execute(
-            select(ApiCache).where(ApiCache.site_url == site_url)
+            select(ApiCache).where(ApiCache.api_type == tool_name)
         )
         return result.scalar_one_or_none()
 
 
-async def _upsert_cache(
+async def _upsert_cache_by_tool(
     source_id: int,
-    site_url: str,
     tool_name: str,
     content: str,
     cached_at: datetime,
 ) -> None:
     async with get_session() as session:
         result = await session.execute(
-            select(ApiCache).where(ApiCache.site_url == site_url)
+            select(ApiCache).where(ApiCache.api_type == tool_name)
         )
         cache = result.scalar_one_or_none()
         if cache is None:
             session.add(ApiCache(
                 source_id=source_id,
-                site_url=site_url,
+                site_url=_cache_site_url(tool_name),
                 api_type=tool_name,
                 content=content,
                 cached_at=cached_at,
@@ -188,4 +226,4 @@ async def _call_external_api(
     return response.text
 
 
-__all__ = ["fetch", "resolve_source_id_by_tool_name"]
+__all__ = ["fetch", "peek_cached_content", "resolve_source_id_by_tool_name"]

--- a/mcp-server/src/mcp_server/tools/auction.py
+++ b/mcp-server/src/mcp_server/tools/auction.py
@@ -153,15 +153,18 @@ async def search_g2b_bid(input: SearchG2bBidInput) -> dict[str, Any]:
             "PPS_G2B_BID_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    now = datetime.now()
-    end_dt = input.inqry_end_dt or _yyyymmddhhmm(now)
-    bgn_dt = input.inqry_bgn_dt or _yyyymmddhhmm(now - timedelta(days=_DEFAULT_LOOKBACK_DAYS))
+    # 도메인 단위 bulk fetch 
+    # 시간 윈도우는 일 단위로 안정화 (캐시 키 안정성). 분 단위 now() 를 쓰면 매 호출마다
+    # 키가 달라져 캐시 hit 가 일어나지 않는다.
+    today = datetime.now().date()
+    bgn_dt = (today - timedelta(days=_DEFAULT_LOOKBACK_DAYS)).strftime("%Y%m%d") + "0000"
+    end_dt = today.strftime("%Y%m%d") + "2359"
 
     source_id = await _resolve_source_id(_TOOL_G2B_BID)
     params: dict[str, Any] = {
         "serviceKey": settings.pps_g2b_bid_api_key,
-        "pageNo": input.page_no,
-        "numOfRows": input.num_of_rows,
+        "pageNo": 1,
+        "numOfRows": 100,
         "type": "json",
         "inqryDiv": 1,  # 1=등록일시 기준
         "inqryBgnDt": bgn_dt,
@@ -169,11 +172,32 @@ async def search_g2b_bid(input: SearchG2bBidInput) -> dict[str, Any]:
     }
     raw = await api_source_service.fetch(source_id=source_id, params=params)
     records: list[BidNotice] = normalize_g2b_bid(raw.content)
-    summary = _summarize(records)
 
-    sorted_records = sorted(records, key=lambda r: r.notice_date, reverse=True)
+    # 응답 단계 filtering — 사용자가 inqry_bgn_dt/inqry_end_dt 명시 시 notice_date 가
+    # 그 윈도우에 포함되는지로 추림. 명시 안 됐으면 bulk 윈도우 그대로 사용.
+    filtered = records
+    user_bgn = input.inqry_bgn_dt
+    user_end = input.inqry_end_dt
+    if user_bgn or user_end:
+        def _in_window(r: BidNotice) -> bool:
+            ts = r.notice_date.strftime("%Y%m%d%H%M")
+            if user_bgn and ts < user_bgn:
+                return False
+            if user_end and ts > user_end:
+                return False
+            return True
+        filtered = [r for r in filtered if _in_window(r)]
+
+    summary = _summarize(filtered)
+
+    sorted_records = sorted(filtered, key=lambda r: r.notice_date, reverse=True)
+
+    # 페이지네이션
+    start = (input.page_no - 1) * input.num_of_rows
+    end = start + input.num_of_rows
+    paginated = sorted_records[start:end]
     truncated = len(sorted_records) > _MAX_RESULTS
-    returned = sorted_records[:_MAX_RESULTS]
+    returned = paginated[:_MAX_RESULTS]
 
     url_template = raw.raw_metadata.get("url_template", "")
     source_url = f"{url_template}?{_mask_query_string(params)}" if url_template else None

--- a/mcp-server/src/mcp_server/tools/jobs.py
+++ b/mcp-server/src/mcp_server/tools/jobs.py
@@ -339,7 +339,7 @@ async def search_worknet_job(input: SearchWorknetJobInput) -> dict[str, Any]:
             "KEIS_WORKNET_JOB_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    # 도메인 단위 bulk fetch — keyword/start_page/display 입력은 #4 filtering 에서 적용.
+    # 도메인 단위 bulk fetch
     source_id = await _resolve_source_id(_TOOL_WORKNET_JOB)
     params: dict[str, Any] = {
         "authKey": settings.keis_worknet_job_api_key,

--- a/mcp-server/src/mcp_server/tools/jobs.py
+++ b/mcp-server/src/mcp_server/tools/jobs.py
@@ -165,29 +165,42 @@ async def search_public_job(input: SearchPublicJobInput) -> dict[str, Any]:
             "MOEF_PUBLIC_JOB_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
+    # 도메인 단위 bulk fetch — wide 파라미터로 1회 호출해서 도메인 데이터를 캐시.
+    # 사용자 input 의 page_no/num_of_rows/ongoing_yn/recrut_pbanc_ttl 은 캐시 응답
+    # 현재는 API 호출에 반영하지 않음.
     source_id = await _resolve_source_id(_TOOL_PUBLIC_JOB)
     params: dict[str, Any] = {
         "serviceKey": settings.moef_public_job_api_key,
-        "pageNo": input.page_no,
-        "numOfRows": input.num_of_rows,
+        "pageNo": 1,
+        "numOfRows": 100,
         "resultType": "json",
     }
-    if input.ongoing_yn is not None:
-        params["ongoingYn"] = input.ongoing_yn
-    if input.recrut_pbanc_ttl:
-        params["recrutPbancTtl"] = input.recrut_pbanc_ttl
 
     raw = await api_source_service.fetch(source_id=source_id, params=params)
     records: list[PublicJobPosting] = normalize_public_job(raw.content)
-    summary = _summarize_public_job(records)
+
+    # 응답 단계 filtering — bulk fetch 결과에서 사용자 input 기준으로 추림.
+    filtered = records
+    if input.ongoing_yn == "Y":
+        filtered = [r for r in filtered if r.is_ongoing]
+    if input.recrut_pbanc_ttl:
+        keyword = input.recrut_pbanc_ttl
+        filtered = [r for r in filtered if keyword in (r.title or "")]
+
+    summary = _summarize_public_job(filtered)
 
     sorted_records = sorted(
-        records,
+        filtered,
         key=lambda r: r.pbanc_begin_date or date.min,
         reverse=True,
     )
+
+    # 페이지네이션 (사용자 page_no/num_of_rows 적용)
+    start = (input.page_no - 1) * input.num_of_rows
+    end = start + input.num_of_rows
+    paginated = sorted_records[start:end]
     truncated = len(sorted_records) > _MAX_RESULTS
-    returned = sorted_records[:_MAX_RESULTS]
+    returned = paginated[:_MAX_RESULTS]
 
     return {
         "text": _public_job_text(summary, records),
@@ -326,16 +339,15 @@ async def search_worknet_job(input: SearchWorknetJobInput) -> dict[str, Any]:
             "KEIS_WORKNET_JOB_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
+    # 도메인 단위 bulk fetch — keyword/start_page/display 입력은 #4 filtering 에서 적용.
     source_id = await _resolve_source_id(_TOOL_WORKNET_JOB)
     params: dict[str, Any] = {
         "authKey": settings.keis_worknet_job_api_key,
         "callTp": "L",
         "returnType": "XML",
-        "startPage": input.start_page,
-        "display": input.display,
+        "startPage": 1,
+        "display": 100,
     }
-    if input.keyword:
-        params["keyword"] = input.keyword
 
     raw = await api_source_service.fetch(source_id=source_id, params=params)
     source_url = _build_source_url(raw, params, secret_keys=("authKey",))
@@ -353,15 +365,29 @@ async def search_worknet_job(input: SearchWorknetJobInput) -> dict[str, Any]:
             source_id=source_id,
         )
 
-    summary = _summarize_worknet(records)
+    # 응답 단계 filtering — keyword 가 title 또는 company 에 포함되는지.
+    filtered = records
+    if input.keyword:
+        kw = input.keyword
+        filtered = [
+            r for r in filtered
+            if kw in (r.title or "") or kw in (r.company or "")
+        ]
+
+    summary = _summarize_worknet(filtered)
 
     sorted_records = sorted(
-        records,
+        filtered,
         key=lambda r: r.reg_date or date.min,
         reverse=True,
     )
+
+    # 페이지네이션 (start_page / display)
+    start = (input.start_page - 1) * input.display
+    end = start + input.display
+    paginated = sorted_records[start:end]
     truncated = len(sorted_records) > _MAX_RESULTS
-    returned = sorted_records[:_MAX_RESULTS]
+    returned = paginated[:_MAX_RESULTS]
 
     return {
         "text": _worknet_text(input.keyword, summary),

--- a/mcp-server/src/mcp_server/tools/law.py
+++ b/mcp-server/src/mcp_server/tools/law.py
@@ -287,7 +287,7 @@ async def search_bill_info(input: SearchBillInfoInput) -> dict[str, Any]:
             "NA_BILL_INFO_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
-    # 도메인 단위 bulk fetch — page_no/num_of_rows 입력은 #4 filtering 에서 적용.
+    # 도메인 단위 bulk fetch
     # AGE 는 도메인 분기 축이라 wide fetch 의 일부로 유지 (대수별로 캐시가 덮어씌워짐).
     source_id = await _resolve_source_id(_TOOL_BILL_INFO)
     params: dict[str, Any] = {

--- a/mcp-server/src/mcp_server/tools/law.py
+++ b/mcp-server/src/mcp_server/tools/law.py
@@ -140,25 +140,38 @@ async def search_law_info(input: SearchLawInfoInput) -> dict[str, Any]:
             "MOLEG_LAW_INFO_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
+    # 도메인 단위 bulk fetch — 사용자 query/page_no/num_of_rows 입력은 추후 적용.
     source_id = await _resolve_source_id(_TOOL_LAW_INFO)
     params: dict[str, Any] = {
         "serviceKey": settings.moleg_law_info_api_key,
         "target": "law",
-        "query": input.query,
-        "numOfRows": input.num_of_rows,
-        "pageNo": input.page_no,
+        "query": "*",
+        "numOfRows": 100,
+        "pageNo": 1,
     }
     raw = await api_source_service.fetch(source_id=source_id, params=params)
     records: list[LawItem] = normalize_law_info(raw.content)
-    summary = _summarize_law(records)
+
+    # 응답 단계 filtering — query 가 '*' 면 전체, 아니면 law_name substring 매칭.
+    filtered = records
+    if input.query and input.query != "*":
+        kw = input.query
+        filtered = [r for r in filtered if kw in (r.law_name or "")]
+
+    summary = _summarize_law(filtered)
 
     sorted_records = sorted(
-        records,
+        filtered,
         key=lambda r: r.promulgation_date or date.min,
         reverse=True,
     )
+
+    # 페이지네이션
+    start = (input.page_no - 1) * input.num_of_rows
+    end = start + input.num_of_rows
+    paginated = sorted_records[start:end]
     truncated = len(sorted_records) > _MAX_RESULTS
-    returned = sorted_records[:_MAX_RESULTS]
+    returned = paginated[:_MAX_RESULTS]
 
     url_template = raw.raw_metadata.get("url_template", "")
     source_url = (
@@ -274,16 +287,20 @@ async def search_bill_info(input: SearchBillInfoInput) -> dict[str, Any]:
             "NA_BILL_INFO_API_KEY 환경변수 미설정. .env 또는 배포 환경에 키를 설정하세요."
         )
 
+    # 도메인 단위 bulk fetch — page_no/num_of_rows 입력은 #4 filtering 에서 적용.
+    # AGE 는 도메인 분기 축이라 wide fetch 의 일부로 유지 (대수별로 캐시가 덮어씌워짐).
     source_id = await _resolve_source_id(_TOOL_BILL_INFO)
     params: dict[str, Any] = {
         "KEY": settings.na_bill_info_api_key,
         "Type": "xml",
-        "pIndex": input.page_no,
-        "pSize": input.num_of_rows,
+        "pIndex": 1,
+        "pSize": 100,
         "AGE": input.age,
     }
     raw = await api_source_service.fetch(source_id=source_id, params=params)
     records: list[BillItem] = normalize_bill_info(raw.content)
+
+    # 의안 도메인은 추가 필터 인자 없음 (AGE 는 API params 단계). 페이지네이션만 적용.
     summary = _summarize_bill(records)
 
     sorted_records = sorted(
@@ -291,8 +308,13 @@ async def search_bill_info(input: SearchBillInfoInput) -> dict[str, Any]:
         key=lambda r: r.propose_date or date.min,
         reverse=True,
     )
+
+    # 페이지네이션
+    start = (input.page_no - 1) * input.num_of_rows
+    end = start + input.num_of_rows
+    paginated = sorted_records[start:end]
     truncated = len(sorted_records) > _MAX_RESULTS
-    returned = sorted_records[:_MAX_RESULTS]
+    returned = paginated[:_MAX_RESULTS]
 
     url_template = raw.raw_metadata.get("url_template", "")
     source_url = (

--- a/mcp-server/tests/sources/test_api_source_service.py
+++ b/mcp-server/tests/sources/test_api_source_service.py
@@ -113,7 +113,7 @@ async def test_fetch_returns_empty_result_on_http_error_without_cache(patched_se
 
 @pytest.mark.asyncio
 async def test_fetch_writes_cache_on_success(patched_session_factory):
-    """성공 시 api_cache 에 upsert 된다."""
+    """성공 시 api_cache 에 도메인 단위 1 row upsert. site_url 은 cache://{tool_name}."""
     source = await _create_source()
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -137,7 +137,122 @@ async def test_fetch_writes_cache_on_success(patched_session_factory):
 
     assert cache is not None
     assert cache.api_type == "search_house_price"
+    assert cache.site_url == "cache://search_house_price"
     assert "1500" in cache.content
+
+
+@pytest.mark.asyncio
+async def test_fetch_overwrites_cache_per_tool_name(patched_session_factory):
+    """같은 tool_name 에 두 번 호출하면 1 row 유지(덮어쓰기)."""
+    source = await _create_source()
+    counter = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        counter["n"] += 1
+        return httpx.Response(
+            200,
+            json={"call": counter["n"]},
+            headers={"content-type": "application/json"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await api_source_service.fetch(
+            source_id=source.id, params={"region": "강남구"}, _test_http_client=client
+        )
+        await api_source_service.fetch(
+            source_id=source.id, params={"region": "부산"}, _test_http_client=client
+        )
+
+    async with get_session() as session:
+        result = await session.execute(
+            select(ApiCache).where(ApiCache.api_type == "search_house_price")
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 1
+    assert '"call": 2' in rows[0].content
+
+
+@pytest.mark.asyncio
+async def test_peek_cached_content_returns_none_when_no_cache(patched_session_factory):
+    """캐시 row 가 없을 때 peek_cached_content 는 None."""
+    await _create_source(tool_name="search_public_job", url_template="https://example.gov/alio")
+
+    result = await api_source_service.peek_cached_content("search_public_job")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_peek_cached_content_returns_content_and_cached_at(patched_session_factory):
+    """캐시 채워진 후 peek_cached_content 는 (content, cached_at) 반환."""
+    source = await _create_source(
+        tool_name="search_public_job",
+        url_template="https://example.gov/alio",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"items": [{"title": "백엔드 개발자"}]},
+            headers={"content-type": "application/json"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await api_source_service.fetch(
+            source_id=source.id, params={}, _test_http_client=client
+        )
+
+    result = await api_source_service.peek_cached_content("search_public_job")
+
+    assert result is not None
+    content, cached_at = result
+    assert "백엔드 개발자" in content
+    assert cached_at is not None
+
+
+@pytest.mark.asyncio
+async def test_peek_cached_content_returns_none_for_real_estate_tools(patched_session_factory):
+    """부동산 6종은 _CACHEABLE_TOOLS 화이트리스트에 없어 peek_cached_content 가 항상 None.
+
+    캐시 row 가 실제로 저장돼 있어도 노출되면 안 된다 (다른 (region, ymd) 호출자에게
+    잘못된 응답을 줄 위험 차단).
+    """
+    source = await _create_source(
+        tool_name="search_house_price",
+        url_template="https://example.gov/molit/apt-trade",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"items": [{"price": 1500}]},
+            headers={"content-type": "application/json"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        # 캐시는 실제로 저장됨
+        await api_source_service.fetch(
+            source_id=source.id,
+            params={"LAWD_CD": "11680", "DEAL_YMD": "202403"},
+            _test_http_client=client,
+        )
+
+    # 그러나 peek_cached_content 는 None (화이트리스트 제외)
+    result = await api_source_service.peek_cached_content("search_house_price")
+    assert result is None
+
+    for tool_name in (
+        "search_apt_rent",
+        "search_offi_trade",
+        "search_offi_rent",
+        "search_rh_trade",
+        "search_rh_rent",
+    ):
+        assert await api_source_service.peek_cached_content(tool_name) is None
 
 
 @pytest.mark.asyncio
@@ -155,7 +270,6 @@ async def test_fetch_returns_cache_on_http_error(patched_session_factory):
     def fail_handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, text="Service Unavailable")
 
-    # 1차: 성공 → 캐시 저장
     transport = httpx.MockTransport(ok_handler)
     async with httpx.AsyncClient(transport=transport) as client:
         first = await api_source_service.fetch(
@@ -164,7 +278,6 @@ async def test_fetch_returns_cache_on_http_error(patched_session_factory):
             _test_http_client=client,
         )
 
-    # 2차: 실패 → 캐시 반환
     transport = httpx.MockTransport(fail_handler)
     async with httpx.AsyncClient(transport=transport) as client:
         second = await api_source_service.fetch(

--- a/mcp-server/tests/tools/test_auction.py
+++ b/mcp-server/tests/tools/test_auction.py
@@ -146,7 +146,6 @@ async def test_search_uses_stable_daily_window_ignoring_input_dates(
     일 단위로 안정화된 윈도우 (오늘 ~ 7일전 자정 ~ 오늘 23:59) 가 사용된다.
 
     캐시 키 안정성 확보를 위해 분 단위 now() 가 아니라 일 단위로 round 한다.
-    필터링은 #4 응답 단계 filtering 도입 시 추가 예정.
     """
     await _seed_source()
     captured: dict[str, Any] = {}

--- a/mcp-server/tests/tools/test_auction.py
+++ b/mcp-server/tests/tools/test_auction.py
@@ -139,10 +139,15 @@ async def test_search_default_dates_applied(
 
 
 @pytest.mark.asyncio
-async def test_search_explicit_dates_passed_through(
+async def test_search_uses_stable_daily_window_ignoring_input_dates(
     patched_session_factory, monkeypatch: pytest.MonkeyPatch
 ):
-    """inqry_bgn_dt 명시 시 그 값이 params 에 그대로 전달."""
+    """도메인 단위 bulk fetch — inqry_bgn_dt/inqry_end_dt 사용자 input 은 무시되고
+    일 단위로 안정화된 윈도우 (오늘 ~ 7일전 자정 ~ 오늘 23:59) 가 사용된다.
+
+    캐시 키 안정성 확보를 위해 분 단위 now() 가 아니라 일 단위로 round 한다.
+    필터링은 #4 응답 단계 filtering 도입 시 추가 예정.
+    """
     await _seed_source()
     captured: dict[str, Any] = {}
     monkeypatch.setattr(api_source_service, "fetch", _make_fake_fetch(SAMPLE_JSON, captured))
@@ -151,8 +156,14 @@ async def test_search_explicit_dates_passed_through(
         SearchG2bBidInput(inqry_bgn_dt="202604010000", inqry_end_dt="202604292359")
     )
 
-    assert captured["params"]["inqryBgnDt"] == "202604010000"
-    assert captured["params"]["inqryEndDt"] == "202604292359"
+    # 사용자 input 은 무시됨
+    assert captured["params"]["inqryBgnDt"] != "202604010000"
+    assert captured["params"]["inqryEndDt"] != "202604292359"
+    # 일 단위 윈도우 — bgn 은 ...0000 (자정), end 는 ...2359 로 끝남
+    assert captured["params"]["inqryBgnDt"].endswith("0000")
+    assert captured["params"]["inqryEndDt"].endswith("2359")
+    assert captured["params"]["pageNo"] == 1
+    assert captured["params"]["numOfRows"] == 100
 
 
 @pytest.mark.asyncio

--- a/mcp-server/tests/tools/test_jobs.py
+++ b/mcp-server/tests/tools/test_jobs.py
@@ -128,10 +128,14 @@ async def test_search_public_job_returns_common_schema(
 
 
 @pytest.mark.asyncio
-async def test_search_public_job_passes_optional_params(
+async def test_search_public_job_uses_bulk_fetch_params(
     patched_session_factory, monkeypatch: pytest.MonkeyPatch
 ):
-    """ongoing_yn / recrut_pbanc_ttl 명시 시 fetch params 에 포함."""
+    """도메인 단위 bulk fetch — 사용자 input(ongoing_yn/recrut_pbanc_ttl) 은
+    API params 에 포함되지 않고, pageNo=1/numOfRows=100 wide 값으로 고정.
+
+    필터링은 추가 예정.
+    """
     await _seed_source(
         tool_name="search_public_job",
         url_template="https://example.gov/moef/public-job",
@@ -153,8 +157,12 @@ async def test_search_public_job_passes_optional_params(
         SearchPublicJobInput(ongoing_yn="Y", recrut_pbanc_ttl="데이터")
     )
 
-    assert captured["params"]["ongoingYn"] == "Y"
-    assert captured["params"]["recrutPbancTtl"] == "데이터"
+    # 사용자 input 은 API params 에 들어가지 않음
+    assert "ongoingYn" not in captured["params"]
+    assert "recrutPbancTtl" not in captured["params"]
+    # wide params 로 고정
+    assert captured["params"]["pageNo"] == 1
+    assert captured["params"]["numOfRows"] == 100
     assert captured["params"]["resultType"] == "json"
 
 
@@ -362,7 +370,10 @@ async def test_search_worknet_job_normal_response_returns_postings(
     assert result["metadata"]["api_status"] == "ok"
     assert result["structured"]["summary"]["count"] == 1
     assert result["structured"]["postings"][0]["title"] == "백엔드 개발자"
-    assert captured["params"]["keyword"] == "백엔드"
+    # #3 bulk fetch — keyword 는 API params 에 포함되지 않음 (추후 적용 예정)
+    assert "keyword" not in captured["params"]
+    assert captured["params"]["startPage"] == 1
+    assert captured["params"]["display"] == 100
 
 
 @pytest.mark.asyncio

--- a/mcp-server/tests/tools/test_law.py
+++ b/mcp-server/tests/tools/test_law.py
@@ -123,10 +123,14 @@ async def test_search_law_info_returns_common_schema(
 
 
 @pytest.mark.asyncio
-async def test_search_law_info_passes_query_to_fetch_params(
+async def test_search_law_info_uses_bulk_fetch_params(
     patched_session_factory, monkeypatch: pytest.MonkeyPatch
 ):
-    """query/page_no/num_of_rows 가 fetch params 에 그대로 전달."""
+    """도메인 단위 bulk fetch — query/page_no/num_of_rows 사용자 input 은
+    API params 에 반영되지 않고 wide 값 (query='*', pageNo=1, numOfRows=100) 으로 고정.
+
+    필터링은 추가 예정.
+    """
     await _seed_source(
         tool_name="search_law_info",
         url_template="https://example.gov/moleg/law-info",
@@ -146,9 +150,10 @@ async def test_search_law_info_passes_query_to_fetch_params(
 
     await search_law_info(SearchLawInfoInput(query="민법", page_no=2, num_of_rows=10))
 
-    assert captured["params"]["query"] == "민법"
-    assert captured["params"]["pageNo"] == 2
-    assert captured["params"]["numOfRows"] == 10
+    # 사용자 input 은 무시되고 wide params 가 전달됨
+    assert captured["params"]["query"] == "*"
+    assert captured["params"]["pageNo"] == 1
+    assert captured["params"]["numOfRows"] == 100
     assert captured["params"]["target"] == "law"
     assert captured["params"]["serviceKey"] == "test-law-key"
 
@@ -315,10 +320,14 @@ async def test_search_bill_info_returns_common_schema(
 
 
 @pytest.mark.asyncio
-async def test_search_bill_info_passes_age_and_paging_to_params(
+async def test_search_bill_info_uses_bulk_fetch_params(
     patched_session_factory, monkeypatch: pytest.MonkeyPatch
 ):
-    """AGE/pIndex/pSize 가 fetch params 에 전달."""
+    """도메인 단위 bulk fetch — AGE 는 슬라이스 키로 유지되지만 pIndex/pSize 는
+    wide 값 (1/100) 으로 고정. 사용자 input 의 page_no/num_of_rows 는 무시됨.
+
+    필터링은 추후 추가 예정.
+    """
     await _seed_source(
         tool_name="search_bill_info",
         url_template="https://example.gov/na/bill-info",
@@ -338,9 +347,11 @@ async def test_search_bill_info_passes_age_and_paging_to_params(
 
     await search_bill_info(SearchBillInfoInput(age=21, page_no=3, num_of_rows=10))
 
+    # AGE 는 사용자 input 그대로 (슬라이스 축)
     assert captured["params"]["AGE"] == 21
-    assert captured["params"]["pIndex"] == 3
-    assert captured["params"]["pSize"] == 10
+    # pIndex/pSize 는 wide 값으로 고정 (사용자 input 무시)
+    assert captured["params"]["pIndex"] == 1
+    assert captured["params"]["pSize"] == 100
     assert captured["params"]["Type"] == "xml"
     assert captured["params"]["KEY"] == "test-bill-key"
 


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #98 

**🛠 작업 내역**
param 단위 호출 대신 도메인 단위로 한 번 fetch 해서 전체 데이터를 캐시, 조회는 캐시에서 filtering 의 책임 범위 작업.

`check_api_cache` MCP 도구가 동작할 수있도록 캐시 키 통일, 도메인 단위 bulk fetch, 응답 단계 filtering, import 해서 사용할 read 헬퍼를 제공

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?