### PR TITLE
feat : cache_check 함수 추가

### DIFF
--- a/mcp-server/src/mcp_server/sources/api_source_service.py
+++ b/mcp-server/src/mcp_server/sources/api_source_service.py
@@ -120,6 +120,14 @@ _CACHEABLE_TOOLS: frozenset[str] = frozenset({
 })
 
 
+async def peek_cached_at(tool_name: str) -> datetime | None:
+    """check_api_cache 전용. cached_at만 반환."""
+    if tool_name not in _CACHEABLE_TOOLS:
+        return None
+    cached = await _load_cache_by_tool(tool_name)
+    return cached.cached_at if cached is not None else None
+
+
 async def peek_cached_content(tool_name: str) -> tuple[str, datetime] | None:
     """캐시 팀의 check_api_cache 도구가 사용할 read 헬퍼.
 
@@ -226,4 +234,4 @@ async def _call_external_api(
     return response.text
 
 
-__all__ = ["fetch", "peek_cached_content", "resolve_source_id_by_tool_name"]
+__all__ = ["fetch", "peek_cached_at", "peek_cached_content", "resolve_source_id_by_tool_name"]

--- a/mcp-server/src/mcp_server/tools/__init__.py
+++ b/mcp-server/src/mcp_server/tools/__init__.py
@@ -12,4 +12,5 @@ from mcp_server.tools import auction  # noqa: F401
 from mcp_server.tools import jobs  # noqa: F401
 from mcp_server.tools import law  # noqa: F401
 from mcp_server.tools import notifications  # noqa: F401
+from mcp_server.tools import cache_check  # noqa: F401
 from mcp_server.tools import real_estate  # noqa: F401

--- a/mcp-server/src/mcp_server/tools/cache_check.py
+++ b/mcp-server/src/mcp_server/tools/cache_check.py
@@ -1,0 +1,340 @@
+"""캐시 상태 확인 및 캐시 직접 읽기 MCP 도구.
+
+등록 도구 (2종):
+- check_api_cache  — staleness 센서. fetch tool 호출 전 캐시 상태 확인.
+- get_cached_data  — 캐시에서 직접 데이터 읽기. 외부 API 미호출.
+"""
+
+from datetime import date, datetime
+from typing import Any, Callable
+
+from mcp_server.domains.auction.normalizer import normalize_g2b_bid
+from mcp_server.domains.jobs.errors import WorknetPermissionDeniedError
+from mcp_server.domains.jobs.normalizer import normalize_public_job, normalize_worknet_job
+from mcp_server.domains.law.normalizer import normalize_bill_info, normalize_law_info
+from mcp_server.observability.tracing import traced
+from mcp_server.server import mcp
+from mcp_server.sources import api_source_service
+
+_MAX_RESULTS = 20
+
+
+# ─────────────────────────────────────────────
+# 도구 1: check_api_cache
+# ─────────────────────────────────────────────
+
+
+@mcp.tool()
+@traced("check_api_cache")
+async def check_api_cache(tool_name: str) -> dict[str, Any]:
+    """fetch tool 호출 전 반드시 이 tool을 먼저 호출해 캐시 상태를 확인하라.
+
+    반환된 cache_hit + last_fetched_at + tool_name(도메인 맥락)으로 fetch 필요 여부를 판단.
+    - cache_hit: false  → search_* fetch tool 호출 필요
+    - cache_hit: true, 신선 → get_cached_data(tool_name) 호출 (외부 API 미호출)
+    - cache_hit: true, stale → search_* fetch tool 호출 필요
+
+    freshness 기준은 도메인 특성에 따라 직접 판단할 것.
+    법률·의안=주 단위, 채용=일 단위, 경매=시간 단위 등.
+    부동산 6종(search_house_price 등)은 지원하지 않음.
+
+    Args:
+        tool_name: 예: "search_law_info", "search_g2b_bid".
+    """
+    cached_at: datetime | None = await api_source_service.peek_cached_at(tool_name)
+
+    if cached_at is None:
+        return {"cache_hit": False, "last_fetched_at": None, "tool_name": tool_name}
+
+    return {
+        "cache_hit": True,
+        "last_fetched_at": cached_at.isoformat(),
+        "tool_name": tool_name,
+    }
+
+
+# ─────────────────────────────────────────────
+# 도구 2: get_cached_data
+# ─────────────────────────────────────────────
+
+
+@mcp.tool()
+@traced("get_cached_data")
+async def get_cached_data(tool_name: str) -> dict[str, Any]:
+    """check_api_cache 결과가 cache_hit: true이고 신선하다고 판단할 때만 호출.
+
+    캐시에서 데이터를 직접 읽어 정규화된 결과를 반환한다. 외부 API를 호출하지 않는다.
+    응답 포맷은 fetch tool과 동일 (text, structured, source_url, metadata).
+    metadata.cache_used: true 로 캐시 응답임을 표시.
+
+    캐시 없음 또는 지원하지 않는 tool_name → cache_hit: false 응답.
+    부동산 6종은 지원하지 않음.
+
+    Args:
+        tool_name: 예: "search_law_info", "search_g2b_bid".
+    """
+    result = await api_source_service.peek_cached_content(tool_name)
+    if result is None:
+        return {
+            "cache_hit": False,
+            "tool_name": tool_name,
+            "message": f"캐시 없음. {tool_name}을 먼저 호출하거나 check_api_cache를 확인하세요.",
+        }
+
+    content, cached_at = result
+    formatter = _FORMATTER_REGISTRY.get(tool_name)
+    if formatter is None:
+        return {
+            "cache_hit": False,
+            "tool_name": tool_name,
+            "message": f"{tool_name}은 get_cached_data 미지원 도구입니다.",
+        }
+
+    return formatter(content, cached_at)
+
+
+# ─────────────────────────────────────────────
+# 도메인별 formatter
+# ─────────────────────────────────────────────
+
+
+def _format_law_info(content: str, cached_at: datetime) -> dict[str, Any]:
+    records = normalize_law_info(content)
+    promulgation_dates = [r.promulgation_date for r in records if r.promulgation_date]
+    ministries = sorted({r.ministry_name for r in records if r.ministry_name})
+    summary = {
+        "count": len(records),
+        "latest_promulgation_date": (
+            max(promulgation_dates).isoformat() if promulgation_dates else None
+        ),
+        "ministries": ministries,
+    }
+    sorted_records = sorted(records, key=lambda r: r.promulgation_date or date.min, reverse=True)
+    returned = sorted_records[:_MAX_RESULTS]
+
+    count = summary["count"]
+    text = (
+        f"현행법령 {count}건 (캐시). 최신 공포 {summary['latest_promulgation_date'] or '-'}."
+        if count > 0 else "현행법령 0건 (캐시)."
+    )
+    return {
+        "text": text,
+        "structured": {
+            "summary": summary,
+            "laws": [r.model_dump(mode="json") for r in returned],
+            "laws_truncated": len(sorted_records) > _MAX_RESULTS,
+            "query": {"query": "*", "page_no": 1, "num_of_rows": _MAX_RESULTS},
+        },
+        "source_url": None,
+        "metadata": {
+            "fetched_at": cached_at.isoformat(),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": "search_law_info",
+            "cache_used": True,
+        },
+    }
+
+
+def _format_bill_info(content: str, cached_at: datetime) -> dict[str, Any]:
+    records = normalize_bill_info(content)
+    propose_dates = [r.propose_date for r in records if r.propose_date]
+    committees = sorted({r.committee for r in records if r.committee})
+    ages = [r.age for r in records if r.age]
+    summary = {
+        "count": len(records),
+        "latest_propose_date": max(propose_dates).isoformat() if propose_dates else None,
+        "committees": committees,
+    }
+    sorted_records = sorted(records, key=lambda r: r.propose_date or date.min, reverse=True)
+    returned = sorted_records[:_MAX_RESULTS]
+
+    count = summary["count"]
+    age_str = f"제{max(ages)}대 " if ages else ""
+    text = (
+        f"{age_str}의안 {count}건 (캐시). 최근 발의 {summary['latest_propose_date'] or '-'}."
+        if count > 0 else "의안 0건 (캐시)."
+    )
+    return {
+        "text": text,
+        "structured": {
+            "summary": summary,
+            "bills": [r.model_dump(mode="json") for r in returned],
+            "bills_truncated": len(sorted_records) > _MAX_RESULTS,
+            "query": {"age": max(ages) if ages else None, "page_no": 1, "num_of_rows": _MAX_RESULTS},
+        },
+        "source_url": None,
+        "metadata": {
+            "fetched_at": cached_at.isoformat(),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": "search_bill_info",
+            "cache_used": True,
+        },
+    }
+
+
+def _format_public_job(content: str, cached_at: datetime) -> dict[str, Any]:
+    records = normalize_public_job(content)
+    ongoing_count = sum(1 for r in records if r.is_ongoing)
+    institutes = sorted({r.institute for r in records if r.institute})
+    begin_dates = [r.pbanc_begin_date for r in records if r.pbanc_begin_date]
+    summary = {
+        "count": len(records),
+        "ongoing_count": ongoing_count,
+        "institutes": institutes,
+        "latest_pbanc_begin_date": max(begin_dates).isoformat() if begin_dates else None,
+    }
+    sorted_records = sorted(records, key=lambda r: r.pbanc_begin_date or date.min, reverse=True)
+    returned = sorted_records[:_MAX_RESULTS]
+
+    count = summary["count"]
+    text = (
+        f"공공기관 채용공시 {count}건 (진행 {ongoing_count}건, 캐시). "
+        f"최신 {summary['latest_pbanc_begin_date'] or '-'}."
+        if count > 0 else "공공기관 채용공시 0건 (캐시)."
+    )
+    return {
+        "text": text,
+        "structured": {
+            "summary": summary,
+            "postings": [r.model_dump(mode="json") for r in returned],
+            "postings_truncated": len(sorted_records) > _MAX_RESULTS,
+            "query": {
+                "page_no": 1,
+                "num_of_rows": _MAX_RESULTS,
+                "ongoing_yn": None,
+                "recrut_pbanc_ttl": None,
+            },
+        },
+        "source_url": None,
+        "metadata": {
+            "fetched_at": cached_at.isoformat(),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": "search_public_job",
+            "cache_used": True,
+        },
+    }
+
+
+def _format_worknet_job(content: str, cached_at: datetime) -> dict[str, Any]:
+    try:
+        records = normalize_worknet_job(content)
+    except WorknetPermissionDeniedError:
+        return {
+            "text": "워크넷 채용공고: 사업자/기관 회원 권한 필요 (캐시된 권한 거부 응답).",
+            "structured": {
+                "summary": {"count": 0},
+                "postings": [],
+                "postings_truncated": False,
+            },
+            "source_url": None,
+            "metadata": {
+                "fetched_at": cached_at.isoformat(),
+                "raw_count": 0,
+                "returned_count": 0,
+                "tool_name": "search_worknet_job",
+                "cache_used": True,
+                "api_status": "permission_denied",
+            },
+        }
+
+    reg_dates = [r.reg_date for r in records if r.reg_date]
+    emp_types = sorted({r.emp_type for r in records if r.emp_type})
+    summary = {
+        "count": len(records),
+        "latest_reg_date": max(reg_dates).isoformat() if reg_dates else None,
+        "emp_types": emp_types,
+    }
+    sorted_records = sorted(records, key=lambda r: r.reg_date or date.min, reverse=True)
+    returned = sorted_records[:_MAX_RESULTS]
+
+    count = summary["count"]
+    text = (
+        f"워크넷 채용공고 {count}건 (캐시). 최신 등록 {summary['latest_reg_date'] or '-'}."
+        if count > 0 else "워크넷 채용공고 0건 (캐시)."
+    )
+    return {
+        "text": text,
+        "structured": {
+            "summary": summary,
+            "postings": [r.model_dump(mode="json") for r in returned],
+            "postings_truncated": len(sorted_records) > _MAX_RESULTS,
+            "query": {"page_no": 1, "num_of_rows": _MAX_RESULTS},
+        },
+        "source_url": None,
+        "metadata": {
+            "fetched_at": cached_at.isoformat(),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": "search_worknet_job",
+            "cache_used": True,
+        },
+    }
+
+
+def _to_eok(amount_won: int | None) -> str:
+    if amount_won is None:
+        return "-"
+    if amount_won >= 100_000_000:
+        return f"{amount_won / 100_000_000:.1f}억"
+    if amount_won >= 10_000:
+        return f"{amount_won / 10_000:,.0f}만"
+    return f"{amount_won:,}원"
+
+
+def _format_g2b_bid(content: str, cached_at: datetime) -> dict[str, Any]:
+    records = normalize_g2b_bid(content)
+    estimated = [r.estimated_price for r in records if r.estimated_price]
+    budgets = [r.assigned_budget for r in records if r.assigned_budget]
+    summary = {
+        "count": len(records),
+        "avg_estimated_price": round(sum(estimated) / len(estimated)) if estimated else None,
+        "min_estimated_price": min(estimated) if estimated else None,
+        "max_estimated_price": max(estimated) if estimated else None,
+        "total_assigned_budget": sum(budgets) if budgets else None,
+    }
+    sorted_records = sorted(records, key=lambda r: r.notice_date, reverse=True)
+    returned = sorted_records[:_MAX_RESULTS]
+
+    count = summary["count"]
+    text = (
+        f"나라장터 입찰공고 {count}건 (캐시). "
+        f"평균 추정가 {_to_eok(summary['avg_estimated_price'])}, "
+        f"최고 추정가 {_to_eok(summary['max_estimated_price'])}."
+        if count > 0 else "나라장터 입찰공고 0건 (캐시)."
+    )
+    return {
+        "text": text,
+        "structured": {
+            "summary": summary,
+            "notices": [r.model_dump(mode="json") for r in returned],
+            "notices_truncated": len(sorted_records) > _MAX_RESULTS,
+            "query": {
+                "inqry_bgn_dt": None,
+                "inqry_end_dt": None,
+                "page_no": 1,
+                "num_of_rows": _MAX_RESULTS,
+            },
+        },
+        "source_url": None,
+        "metadata": {
+            "fetched_at": cached_at.isoformat(),
+            "raw_count": len(records),
+            "returned_count": len(returned),
+            "tool_name": "search_g2b_bid",
+            "cache_used": True,
+        },
+    }
+
+
+_FORMATTER_REGISTRY: dict[str, Callable[[str, datetime], dict[str, Any]]] = {
+    "search_law_info": _format_law_info,
+    "search_bill_info": _format_bill_info,
+    "search_public_job": _format_public_job,
+    "search_worknet_job": _format_worknet_job,
+    "search_g2b_bid": _format_g2b_bid,
+}
+
+__all__ = ["check_api_cache", "get_cached_data"]

--- a/mcp-server/tests/tools/test_cache_check.py
+++ b/mcp-server/tests/tools/test_cache_check.py
@@ -1,0 +1,207 @@
+"""tools.cache_check.* 단위 테스트.
+
+실제 HTTP 호출 없이 DB(in-memory SQLite)에 캐시 행을 직접 삽입해
+check_api_cache / get_cached_data 의 동작을 격리 검증한다.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from mcp_server.db.models import ApiCache, ApiSource
+from mcp_server.db.session import get_session
+from mcp_server.tools.cache_check import check_api_cache, get_cached_data
+
+_FIXTURE_LAW = Path(__file__).resolve().parents[1] / "data" / "law"
+_FIXTURE_AUCTION = Path(__file__).resolve().parents[1] / "data" / "auction"
+_FIXTURE_JOBS = Path(__file__).resolve().parents[1] / "data" / "jobs"
+
+LAW_INFO_XML = (_FIXTURE_LAW / "search_law_info.xml").read_text(encoding="utf-8")
+BILL_INFO_XML = (_FIXTURE_LAW / "search_bill_info.xml").read_text(encoding="utf-8")
+G2B_BID_JSON = (_FIXTURE_AUCTION / "search_g2b_bid.json").read_text(encoding="utf-8")
+PUBLIC_JOB_JSON = (_FIXTURE_JOBS / "search_public_job.json").read_text(encoding="utf-8")
+WORKNET_PERMISSION_DENIED_XML = (_FIXTURE_JOBS / "search_worknet_job.xml").read_text(encoding="utf-8")
+
+_CACHED_AT = datetime(2026, 4, 30, 10, 0, tzinfo=UTC)
+
+
+async def _seed_cache(tool_name: str, content: str) -> None:
+    async with get_session() as session:
+        source = ApiSource(
+            tool_name=tool_name,
+            name=f"{tool_name} (test)",
+            url_template=f"https://example.gov/{tool_name}",
+            param_schema={"type": "object"},
+        )
+        session.add(source)
+        await session.flush()
+        cache = ApiCache(
+            source_id=source.id,
+            site_url=f"cache://{tool_name}",
+            api_type=tool_name,
+            content=content,
+            cached_at=_CACHED_AT,
+        )
+        session.add(cache)
+        await session.commit()
+
+
+# ─────────────────────────────────────────────
+# check_api_cache
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_cache_miss(patched_session_factory):
+    """캐시 행 없음 → cache_hit: false, last_fetched_at: null."""
+    result = await check_api_cache("search_law_info")
+
+    assert result["cache_hit"] is False
+    assert result["last_fetched_at"] is None
+    assert result["tool_name"] == "search_law_info"
+
+
+@pytest.mark.asyncio
+async def test_check_cache_hit(patched_session_factory):
+    """캐시 행 있음 → cache_hit: true, last_fetched_at ISO8601 문자열."""
+    await _seed_cache("search_law_info", LAW_INFO_XML)
+
+    result = await check_api_cache("search_law_info")
+
+    assert result["cache_hit"] is True
+    # SQLite은 timezone 미저장 → naive isoformat 반환. 날짜/시각 값만 검증.
+    assert result["last_fetched_at"].startswith("2026-04-30T10:00:00")
+    assert result["tool_name"] == "search_law_info"
+
+
+@pytest.mark.asyncio
+async def test_check_non_cacheable_tool(patched_session_factory):
+    """화이트리스트 외 도구(부동산) → cache_hit: false."""
+    result = await check_api_cache("search_house_price")
+
+    assert result["cache_hit"] is False
+    assert result["last_fetched_at"] is None
+
+
+# ─────────────────────────────────────────────
+# get_cached_data — cache miss / 비지원 도구
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_cache_miss(patched_session_factory):
+    """캐시 없음 → cache_hit: false + message."""
+    result = await get_cached_data("search_law_info")
+
+    assert result["cache_hit"] is False
+    assert "message" in result
+    assert result["tool_name"] == "search_law_info"
+
+
+@pytest.mark.asyncio
+async def test_get_non_cacheable_tool(patched_session_factory):
+    """화이트리스트 외 도구 → cache_hit: false."""
+    result = await get_cached_data("search_house_price")
+
+    assert result["cache_hit"] is False
+
+
+# ─────────────────────────────────────────────
+# get_cached_data — 포맷 검증 (law_info)
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_cache_hit_law_info_format(patched_session_factory):
+    """법령 캐시 → 4-field 스키마 + metadata.cache_used: true."""
+    await _seed_cache("search_law_info", LAW_INFO_XML)
+
+    result = await get_cached_data("search_law_info")
+
+    assert "text" in result
+    assert "structured" in result
+    assert "source_url" in result
+    assert "metadata" in result
+
+    structured = result["structured"]
+    assert "summary" in structured
+    assert "laws" in structured
+    assert "laws_truncated" in structured
+    assert "query" in structured
+    assert isinstance(structured["laws"], list)
+
+
+@pytest.mark.asyncio
+async def test_get_cache_used_flag(patched_session_factory):
+    """metadata.cache_used: true 확인."""
+    await _seed_cache("search_law_info", LAW_INFO_XML)
+
+    result = await get_cached_data("search_law_info")
+
+    assert result["metadata"]["cache_used"] is True
+    assert result["metadata"]["tool_name"] == "search_law_info"
+    # SQLite은 timezone 미저장 → naive isoformat 반환. 날짜/시각 값만 검증.
+    assert result["metadata"]["fetched_at"].startswith("2026-04-30T10:00:00")
+
+
+@pytest.mark.asyncio
+async def test_get_source_url_is_none(patched_session_factory):
+    """캐시 조회이므로 source_url: null."""
+    await _seed_cache("search_law_info", LAW_INFO_XML)
+
+    result = await get_cached_data("search_law_info")
+
+    assert result["source_url"] is None
+
+
+# ─────────────────────────────────────────────
+# get_cached_data — 도메인별 records key 검증
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_bill_info_structured_key(patched_session_factory):
+    """의안 캐시 → structured.bills 키."""
+    await _seed_cache("search_bill_info", BILL_INFO_XML)
+
+    result = await get_cached_data("search_bill_info")
+
+    assert "bills" in result["structured"]
+
+
+@pytest.mark.asyncio
+async def test_get_public_job_structured_key(patched_session_factory):
+    """공공 채용 캐시 → structured.postings 키."""
+    await _seed_cache("search_public_job", PUBLIC_JOB_JSON)
+
+    result = await get_cached_data("search_public_job")
+
+    assert "postings" in result["structured"]
+
+
+@pytest.mark.asyncio
+async def test_get_g2b_bid_structured_key(patched_session_factory):
+    """경매 캐시 → structured.notices 키."""
+    await _seed_cache("search_g2b_bid", G2B_BID_JSON)
+
+    result = await get_cached_data("search_g2b_bid")
+
+    assert "notices" in result["structured"]
+
+
+# ─────────────────────────────────────────────
+# get_cached_data — WorknetPermissionDenied
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_worknet_permission_denied(patched_session_factory):
+    """권한 거부 XML이 캐시된 경우 → api_status: permission_denied."""
+    await _seed_cache("search_worknet_job", WORKNET_PERMISSION_DENIED_XML)
+
+    result = await get_cached_data("search_worknet_job")
+
+    assert result["metadata"]["api_status"] == "permission_denied"
+    assert result["metadata"]["cache_used"] is True
+    assert result["structured"]["summary"]["count"] == 0


### PR DESCRIPTION

**🔗 Issue 번호**

- Close #106

**🛠 작업 내역**
check_api_cache  — staleness 센서. fetch tool 호출 전 캐시 상태 확인.               get_cached_data  —(cache hit시) 캐시에서 직접 데이터 읽기. 외부 API 미호출.

-

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?