### PR TITLE
feat : 부동산 등 tool+param이 필요한 api는 따로 분류.

### DIFF
--- a/mcp-server/src/mcp_server/sources/api_source_service.py
+++ b/mcp-server/src/mcp_server/sources/api_source_service.py
@@ -46,6 +46,8 @@ async def fetch(
     params = params or {}
     fetched_at = datetime.now(UTC)
 
+    cache_site_url = _derive_cache_site_url(source.tool_name, params)
+
     try:
         response_text = await _call_external_api(
             endpoint=source.url_template,
@@ -53,7 +55,7 @@ async def fetch(
             http_client=_test_http_client,
         )
     except SourceFetchError as exc:
-        cached = await _load_cache_by_tool(source.tool_name)
+        cached = await _load_cache_by_site_url(cache_site_url)
         base_meta = {
             "tool_name": source.tool_name,
             "url_template": source.url_template,
@@ -75,9 +77,10 @@ async def fetch(
             raw_metadata={**base_meta, "fetch_error": str(exc)},
         )
 
-    await _upsert_cache_by_tool(
+    await _upsert_cache_by_site_url(
         source_id=source.id,
         tool_name=source.tool_name,
+        site_url=cache_site_url,
         content=response_text,
         cached_at=fetched_at,
     )
@@ -96,54 +99,79 @@ async def fetch(
 
 
 def _build_site_url(url_template: str, params: dict) -> str:
-    """원본 호출 URL 디버그 표시용. 캐시 키로는 더 이상 사용하지 않음 (tool_name 으로 변경)."""
+    """원본 호출 URL 디버그 표시용."""
     cache_params = {k: v for k, v in params.items() if k != "serviceKey"}
     return f"{url_template}?{urlencode(sorted(cache_params.items()))}"
 
 
-def _cache_site_url(tool_name: str) -> str:
-    """캐시 site_url placeholder. UNIQUE 제약을 만족시키는 도메인 단위 1 row 키."""
-    return f"cache://{tool_name}"
+# param-keyed tool: API 필수 파라미터 조합이 캐시 키를 결정.
+# 여기 없는 tool은 bulk-fetch → tool_name 단위 1행 캐시.
+_PARAM_KEY_FIELDS: dict[str, tuple[str, ...]] = {
+    "search_house_price": ("LAWD_CD", "DEAL_YMD"),
+    "search_apt_rent":    ("LAWD_CD", "DEAL_YMD"),
+    "search_offi_trade":  ("LAWD_CD", "DEAL_YMD"),
+    "search_offi_rent":   ("LAWD_CD", "DEAL_YMD"),
+    "search_rh_rent":     ("LAWD_CD", "DEAL_YMD"),
+    "search_rh_trade":    ("LAWD_CD", "DEAL_YMD"),
+    "search_bill_info":   ("AGE",),
+}
 
 
-# 캐시 read 가 의미 있는 도구 화이트리스트.
-# 부동산 6종은 LAWD_CD 가 API 필수라 도메인 단위 단일 호출이 불가능하고, tool_name
-# 단위 1 row 캐시는 마지막 (region, deal_ymd) 응답만 보관하므로 다른 (region, ymd)
-# 호출자에게 잘못된 응답을 줄 수 있다. 따라서 부동산 도구는 캐시 read 노출 대상에서
-# 제외 — 캐시 팀의 check_api_cache 도구도 이 화이트리스트만 받아야 한다.
+def _derive_cache_site_url(tool_name: str, params: dict) -> str:
+    """tool_name + params 로 캐시 site_url 생성.
+
+    bulk-fetch tool → "cache://{tool_name}"
+    param-keyed tool → "cache://{tool_name}/{v1}/{v2}"
+
+    params 키는 대소문자 무관하게 매칭 (fetch는 대문자, check_api_cache는 소문자 허용).
+    """
+    key_fields = _PARAM_KEY_FIELDS.get(tool_name)
+    if not key_fields:
+        return f"cache://{tool_name}"
+    normalized = {k.upper(): str(v) for k, v in params.items()}
+    parts = [normalized.get(k, "") for k in key_fields]
+    return "cache://" + tool_name + "/" + "/".join(parts)
+
+
+# 모든 tool이 캐시 가능. param-keyed tool은 params 필수.
 _CACHEABLE_TOOLS: frozenset[str] = frozenset({
-    "search_public_job",
-    "search_worknet_job",
     "search_law_info",
     "search_bill_info",
+    "search_public_job",
+    "search_worknet_job",
     "search_g2b_bid",
+    "search_house_price",
+    "search_apt_rent",
+    "search_offi_trade",
+    "search_offi_rent",
+    "search_rh_rent",
+    "search_rh_trade",
 })
 
 
-async def peek_cached_at(tool_name: str) -> datetime | None:
-    """check_api_cache 전용. cached_at만 반환."""
-    if tool_name not in _CACHEABLE_TOOLS:
-        return None
-    cached = await _load_cache_by_tool(tool_name)
-    return cached.cached_at if cached is not None else None
+async def peek_cached_at(tool_name: str, params: dict | None = None) -> datetime | None:
+    """check_api_cache 전용. cached_at만 반환.
 
-
-async def peek_cached_content(tool_name: str) -> tuple[str, datetime] | None:
-    """캐시 팀의 check_api_cache 도구가 사용할 read 헬퍼.
-
-    캐시에 저장된 외부 API 응답 원문(content) 과 저장 시각(cached_at) 을 반환.
-    정규화·필터링은 도구 레이어 책임이라 여기선 raw content 그대로 노출한다.
-
-    Args:
-        tool_name: 캐시 read 대상 도구 이름.
-
-    Returns:
-        (content, cached_at) — 캐시가 있고 읽을 수 있을 때.
-        None — 캐시가 없거나, tool_name 이 _CACHEABLE_TOOLS 에 없을 때.
+    param-keyed tool(부동산·의안)은 params 필수.
+    params 없이 호출하면 None 반환 (cache miss로 처리).
     """
     if tool_name not in _CACHEABLE_TOOLS:
         return None
-    cached = await _load_cache_by_tool(tool_name)
+    site_url = _derive_cache_site_url(tool_name, params or {})
+    cached = await _load_cache_by_site_url(site_url)
+    return cached.cached_at if cached is not None else None
+
+
+async def peek_cached_content(tool_name: str, params: dict | None = None) -> tuple[str, datetime] | None:
+    """get_cached_data 전용. raw content + cached_at 반환.
+
+    param-keyed tool(부동산·의안)은 params 필수.
+    params 없이 호출하면 None 반환 (cache miss로 처리).
+    """
+    if tool_name not in _CACHEABLE_TOOLS:
+        return None
+    site_url = _derive_cache_site_url(tool_name, params or {})
+    cached = await _load_cache_by_site_url(site_url)
     if cached is None:
         return None
     return cached.content or "", cached.cached_at
@@ -158,29 +186,30 @@ async def _load_source(source_id: int) -> ApiSource:
     return source
 
 
-async def _load_cache_by_tool(tool_name: str) -> ApiCache | None:
+async def _load_cache_by_site_url(site_url: str) -> ApiCache | None:
     async with get_session() as session:
         result = await session.execute(
-            select(ApiCache).where(ApiCache.api_type == tool_name)
+            select(ApiCache).where(ApiCache.site_url == site_url)
         )
         return result.scalar_one_or_none()
 
 
-async def _upsert_cache_by_tool(
+async def _upsert_cache_by_site_url(
     source_id: int,
     tool_name: str,
+    site_url: str,
     content: str,
     cached_at: datetime,
 ) -> None:
     async with get_session() as session:
         result = await session.execute(
-            select(ApiCache).where(ApiCache.api_type == tool_name)
+            select(ApiCache).where(ApiCache.site_url == site_url)
         )
         cache = result.scalar_one_or_none()
         if cache is None:
             session.add(ApiCache(
                 source_id=source_id,
-                site_url=_cache_site_url(tool_name),
+                site_url=site_url,
                 api_type=tool_name,
                 content=content,
                 cached_at=cached_at,
@@ -234,4 +263,11 @@ async def _call_external_api(
     return response.text
 
 
-__all__ = ["fetch", "peek_cached_at", "peek_cached_content", "resolve_source_id_by_tool_name"]
+__all__ = [
+    "fetch",
+    "peek_cached_at",
+    "peek_cached_content",
+    "resolve_source_id_by_tool_name",
+    "_PARAM_KEY_FIELDS",
+    "_CACHEABLE_TOOLS",
+]

--- a/mcp-server/src/mcp_server/tools/cache_check.py
+++ b/mcp-server/src/mcp_server/tools/cache_check.py
@@ -3,6 +3,10 @@
 등록 도구 (2종):
 - check_api_cache  — staleness 센서. fetch tool 호출 전 캐시 상태 확인.
 - get_cached_data  — 캐시에서 직접 데이터 읽기. 외부 API 미호출.
+
+캐시 키 전략:
+- bulk-fetch tool (법률·채용·경매): tool_name 단위 1행.
+- param-keyed tool (부동산·의안):  tool_name + 핵심 params 조합당 1행.
 """
 
 from datetime import date, datetime
@@ -12,9 +16,18 @@ from mcp_server.domains.auction.normalizer import normalize_g2b_bid
 from mcp_server.domains.jobs.errors import WorknetPermissionDeniedError
 from mcp_server.domains.jobs.normalizer import normalize_public_job, normalize_worknet_job
 from mcp_server.domains.law.normalizer import normalize_bill_info, normalize_law_info
+from mcp_server.domains.real_estate.normalizer import (
+    normalize_apt_rent,
+    normalize_apt_trade,
+    normalize_offi_rent,
+    normalize_offi_trade,
+    normalize_rh_rent,
+    normalize_rh_trade,
+)
 from mcp_server.observability.tracing import traced
 from mcp_server.server import mcp
 from mcp_server.sources import api_source_service
+from mcp_server.sources.api_source_service import _PARAM_KEY_FIELDS
 
 _MAX_RESULTS = 20
 
@@ -26,22 +39,36 @@ _MAX_RESULTS = 20
 
 @mcp.tool()
 @traced("check_api_cache")
-async def check_api_cache(tool_name: str) -> dict[str, Any]:
+async def check_api_cache(tool_name: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     """fetch tool 호출 전 반드시 이 tool을 먼저 호출해 캐시 상태를 확인하라.
 
     반환된 cache_hit + last_fetched_at + tool_name(도메인 맥락)으로 fetch 필요 여부를 판단.
     - cache_hit: false  → search_* fetch tool 호출 필요
-    - cache_hit: true, 신선 → get_cached_data(tool_name) 호출 (외부 API 미호출)
+    - cache_hit: true, 신선 → get_cached_data(tool_name, params) 호출 (외부 API 미호출)
     - cache_hit: true, stale → search_* fetch tool 호출 필요
 
     freshness 기준은 도메인 특성에 따라 직접 판단할 것.
-    법률·의안=주 단위, 채용=일 단위, 경매=시간 단위 등.
-    부동산 6종(search_house_price 등)은 지원하지 않음.
+    법률=주 단위, 채용=일 단위, 경매=시간 단위, 부동산·의안=월/대수 단위 등.
+
+    **param-keyed tool (부동산·의안)은 params 필수:**
+    - 부동산 6종: {"lawd_cd": "11680", "deal_ymd": "202403"}
+    - search_bill_info: {"age": 22}
+    params 없이 호출하면 cache_hit: false + 안내 메시지 반환.
 
     Args:
-        tool_name: 예: "search_law_info", "search_g2b_bid".
+        tool_name: 예: "search_law_info", "search_house_price".
+        params: param-keyed tool 전용. 부동산은 lawd_cd+deal_ymd, 의안은 age 필요.
     """
-    cached_at: datetime | None = await api_source_service.peek_cached_at(tool_name)
+    if tool_name in _PARAM_KEY_FIELDS and not params:
+        required = list(_PARAM_KEY_FIELDS[tool_name])
+        return {
+            "cache_hit": False,
+            "last_fetched_at": None,
+            "tool_name": tool_name,
+            "message": f"{tool_name}은 params 필수: {required} (소문자 허용)",
+        }
+
+    cached_at: datetime | None = await api_source_service.peek_cached_at(tool_name, params)
 
     if cached_at is None:
         return {"cache_hit": False, "last_fetched_at": None, "tool_name": tool_name}
@@ -60,20 +87,30 @@ async def check_api_cache(tool_name: str) -> dict[str, Any]:
 
 @mcp.tool()
 @traced("get_cached_data")
-async def get_cached_data(tool_name: str) -> dict[str, Any]:
+async def get_cached_data(tool_name: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     """check_api_cache 결과가 cache_hit: true이고 신선하다고 판단할 때만 호출.
 
     캐시에서 데이터를 직접 읽어 정규화된 결과를 반환한다. 외부 API를 호출하지 않는다.
     응답 포맷은 fetch tool과 동일 (text, structured, source_url, metadata).
     metadata.cache_used: true 로 캐시 응답임을 표시.
 
-    캐시 없음 또는 지원하지 않는 tool_name → cache_hit: false 응답.
-    부동산 6종은 지원하지 않음.
+    **param-keyed tool (부동산·의안)은 params 필수:**
+    - 부동산 6종: {"lawd_cd": "11680", "deal_ymd": "202403"}
+    - search_bill_info: {"age": 22}
 
     Args:
-        tool_name: 예: "search_law_info", "search_g2b_bid".
+        tool_name: 예: "search_law_info", "search_house_price".
+        params: param-keyed tool 전용.
     """
-    result = await api_source_service.peek_cached_content(tool_name)
+    if tool_name in _PARAM_KEY_FIELDS and not params:
+        required = list(_PARAM_KEY_FIELDS[tool_name])
+        return {
+            "cache_hit": False,
+            "tool_name": tool_name,
+            "message": f"{tool_name}은 params 필수: {required} (소문자 허용)",
+        }
+
+    result = await api_source_service.peek_cached_content(tool_name, params)
     if result is None:
         return {
             "cache_hit": False,
@@ -90,15 +127,15 @@ async def get_cached_data(tool_name: str) -> dict[str, Any]:
             "message": f"{tool_name}은 get_cached_data 미지원 도구입니다.",
         }
 
-    return formatter(content, cached_at)
+    return formatter(content, cached_at, params or {})
 
 
 # ─────────────────────────────────────────────
-# 도메인별 formatter
+# bulk-fetch formatter (params 불필요, 시그니처 통일용 _ 무시)
 # ─────────────────────────────────────────────
 
 
-def _format_law_info(content: str, cached_at: datetime) -> dict[str, Any]:
+def _format_law_info(content: str, cached_at: datetime, _params: dict) -> dict[str, Any]:
     records = normalize_law_info(content)
     promulgation_dates = [r.promulgation_date for r in records if r.promulgation_date]
     ministries = sorted({r.ministry_name for r in records if r.ministry_name})
@@ -136,7 +173,7 @@ def _format_law_info(content: str, cached_at: datetime) -> dict[str, Any]:
     }
 
 
-def _format_bill_info(content: str, cached_at: datetime) -> dict[str, Any]:
+def _format_bill_info(content: str, cached_at: datetime, params: dict) -> dict[str, Any]:
     records = normalize_bill_info(content)
     propose_dates = [r.propose_date for r in records if r.propose_date]
     committees = sorted({r.committee for r in records if r.committee})
@@ -149,8 +186,10 @@ def _format_bill_info(content: str, cached_at: datetime) -> dict[str, Any]:
     sorted_records = sorted(records, key=lambda r: r.propose_date or date.min, reverse=True)
     returned = sorted_records[:_MAX_RESULTS]
 
+    # params에서 AGE 복원 (대소문자 무관)
+    age = int((params.get("AGE") or params.get("age") or (max(ages) if ages else 22)))
+    age_str = f"제{age}대 " if age else ""
     count = summary["count"]
-    age_str = f"제{max(ages)}대 " if ages else ""
     text = (
         f"{age_str}의안 {count}건 (캐시). 최근 발의 {summary['latest_propose_date'] or '-'}."
         if count > 0 else "의안 0건 (캐시)."
@@ -161,7 +200,7 @@ def _format_bill_info(content: str, cached_at: datetime) -> dict[str, Any]:
             "summary": summary,
             "bills": [r.model_dump(mode="json") for r in returned],
             "bills_truncated": len(sorted_records) > _MAX_RESULTS,
-            "query": {"age": max(ages) if ages else None, "page_no": 1, "num_of_rows": _MAX_RESULTS},
+            "query": {"age": age, "page_no": 1, "num_of_rows": _MAX_RESULTS},
         },
         "source_url": None,
         "metadata": {
@@ -174,7 +213,7 @@ def _format_bill_info(content: str, cached_at: datetime) -> dict[str, Any]:
     }
 
 
-def _format_public_job(content: str, cached_at: datetime) -> dict[str, Any]:
+def _format_public_job(content: str, cached_at: datetime, _params: dict) -> dict[str, Any]:
     records = normalize_public_job(content)
     ongoing_count = sum(1 for r in records if r.is_ongoing)
     institutes = sorted({r.institute for r in records if r.institute})
@@ -200,12 +239,7 @@ def _format_public_job(content: str, cached_at: datetime) -> dict[str, Any]:
             "summary": summary,
             "postings": [r.model_dump(mode="json") for r in returned],
             "postings_truncated": len(sorted_records) > _MAX_RESULTS,
-            "query": {
-                "page_no": 1,
-                "num_of_rows": _MAX_RESULTS,
-                "ongoing_yn": None,
-                "recrut_pbanc_ttl": None,
-            },
+            "query": {"page_no": 1, "num_of_rows": _MAX_RESULTS, "ongoing_yn": None, "recrut_pbanc_ttl": None},
         },
         "source_url": None,
         "metadata": {
@@ -218,17 +252,13 @@ def _format_public_job(content: str, cached_at: datetime) -> dict[str, Any]:
     }
 
 
-def _format_worknet_job(content: str, cached_at: datetime) -> dict[str, Any]:
+def _format_worknet_job(content: str, cached_at: datetime, _params: dict) -> dict[str, Any]:
     try:
         records = normalize_worknet_job(content)
     except WorknetPermissionDeniedError:
         return {
             "text": "워크넷 채용공고: 사업자/기관 회원 권한 필요 (캐시된 권한 거부 응답).",
-            "structured": {
-                "summary": {"count": 0},
-                "postings": [],
-                "postings_truncated": False,
-            },
+            "structured": {"summary": {"count": 0}, "postings": [], "postings_truncated": False},
             "source_url": None,
             "metadata": {
                 "fetched_at": cached_at.isoformat(),
@@ -284,7 +314,7 @@ def _to_eok(amount_won: int | None) -> str:
     return f"{amount_won:,}원"
 
 
-def _format_g2b_bid(content: str, cached_at: datetime) -> dict[str, Any]:
+def _format_g2b_bid(content: str, cached_at: datetime, _params: dict) -> dict[str, Any]:
     records = normalize_g2b_bid(content)
     estimated = [r.estimated_price for r in records if r.estimated_price]
     budgets = [r.assigned_budget for r in records if r.assigned_budget]
@@ -311,12 +341,7 @@ def _format_g2b_bid(content: str, cached_at: datetime) -> dict[str, Any]:
             "summary": summary,
             "notices": [r.model_dump(mode="json") for r in returned],
             "notices_truncated": len(sorted_records) > _MAX_RESULTS,
-            "query": {
-                "inqry_bgn_dt": None,
-                "inqry_end_dt": None,
-                "page_no": 1,
-                "num_of_rows": _MAX_RESULTS,
-            },
+            "query": {"inqry_bgn_dt": None, "inqry_end_dt": None, "page_no": 1, "num_of_rows": _MAX_RESULTS},
         },
         "source_url": None,
         "metadata": {
@@ -329,12 +354,100 @@ def _format_g2b_bid(content: str, cached_at: datetime) -> dict[str, Any]:
     }
 
 
-_FORMATTER_REGISTRY: dict[str, Callable[[str, datetime], dict[str, Any]]] = {
-    "search_law_info": _format_law_info,
-    "search_bill_info": _format_bill_info,
-    "search_public_job": _format_public_job,
+# ─────────────────────────────────────────────
+# param-keyed formatter — 부동산 (factory)
+# ─────────────────────────────────────────────
+
+
+def _make_real_estate_formatter(
+    normalizer: Callable,
+    tool_name: str,
+    kind: str,
+    is_trade: bool,
+) -> Callable[[str, datetime, dict], dict[str, Any]]:
+    """부동산 6종 formatter 공통 factory.
+
+    is_trade=True  → deal_amount 기준 통계 (매매)
+    is_trade=False → deposit 기준 통계 (전월세)
+    """
+    def formatter(content: str, cached_at: datetime, params: dict) -> dict[str, Any]:
+        normalized_params = {k.upper(): str(v) for k, v in params.items()}
+        lawd_cd = normalized_params.get("LAWD_CD", "")
+        deal_ymd = normalized_params.get("DEAL_YMD", "")
+
+        records = normalizer(content, lawd_cd=lawd_cd)
+
+        if is_trade:
+            amounts = [r.deal_amount for r in records]
+            summary = {
+                "count": len(records),
+                "avg_deal_amount": round(sum(amounts) / len(amounts)) if amounts else None,
+                "min_deal_amount": min(amounts) if amounts else None,
+                "max_deal_amount": max(amounts) if amounts else None,
+            }
+            sorted_records = sorted(records, key=lambda r: r.deal_amount, reverse=True)
+            text = (
+                f"LAWD_CD {lawd_cd} {deal_ymd} {kind} 실거래 {len(records)}건 (캐시). "
+                f"평균 {_to_eok(summary['avg_deal_amount'])}."
+                if records else f"LAWD_CD {lawd_cd} {deal_ymd} {kind} 실거래 0건 (캐시)."
+            )
+        else:
+            deposits = [r.deposit for r in records]
+            monthly = [r.monthly_rent for r in records]
+            summary = {
+                "count": len(records),
+                "avg_deposit": round(sum(deposits) / len(deposits)) if deposits else None,
+                "min_deposit": min(deposits) if deposits else None,
+                "max_deposit": max(deposits) if deposits else None,
+                "avg_monthly_rent": round(sum(monthly) / len(monthly)) if monthly else None,
+            }
+            sorted_records = sorted(records, key=lambda r: r.deposit, reverse=True)
+            text = (
+                f"LAWD_CD {lawd_cd} {deal_ymd} {kind} 실거래 {len(records)}건 (캐시). "
+                f"평균 보증금 {_to_eok(summary['avg_deposit'])}."
+                if records else f"LAWD_CD {lawd_cd} {deal_ymd} {kind} 실거래 0건 (캐시)."
+            )
+
+        returned = sorted_records[:_MAX_RESULTS]
+        return {
+            "text": text,
+            "structured": {
+                "summary": summary,
+                "trades": [r.model_dump(mode="json") for r in returned],
+                "trades_truncated": len(sorted_records) > _MAX_RESULTS,
+                "query": {"lawd_cd": lawd_cd, "deal_ymd": deal_ymd},
+            },
+            "source_url": None,
+            "metadata": {
+                "fetched_at": cached_at.isoformat(),
+                "raw_count": len(records),
+                "returned_count": len(returned),
+                "tool_name": tool_name,
+                "cache_used": True,
+            },
+        }
+
+    return formatter
+
+
+# ─────────────────────────────────────────────
+# 레지스트리
+# ─────────────────────────────────────────────
+
+_FORMATTER_REGISTRY: dict[str, Callable[[str, datetime, dict], dict[str, Any]]] = {
+    # bulk-fetch
+    "search_law_info":    _format_law_info,
+    "search_bill_info":   _format_bill_info,
+    "search_public_job":  _format_public_job,
     "search_worknet_job": _format_worknet_job,
-    "search_g2b_bid": _format_g2b_bid,
+    "search_g2b_bid":     _format_g2b_bid,
+    # param-keyed (부동산)
+    "search_house_price": _make_real_estate_formatter(normalize_apt_trade,  "search_house_price", "아파트 매매",      is_trade=True),
+    "search_apt_rent":    _make_real_estate_formatter(normalize_apt_rent,   "search_apt_rent",    "아파트 전월세",     is_trade=False),
+    "search_offi_trade":  _make_real_estate_formatter(normalize_offi_trade, "search_offi_trade",  "오피스텔 매매",     is_trade=True),
+    "search_offi_rent":   _make_real_estate_formatter(normalize_offi_rent,  "search_offi_rent",   "오피스텔 전월세",   is_trade=False),
+    "search_rh_rent":     _make_real_estate_formatter(normalize_rh_rent,    "search_rh_rent",     "연립다세대 전월세", is_trade=False),
+    "search_rh_trade":    _make_real_estate_formatter(normalize_rh_trade,   "search_rh_trade",    "연립다세대 매매",   is_trade=True),
 }
 
 __all__ = ["check_api_cache", "get_cached_data"]

--- a/mcp-server/tests/sources/test_api_source_service.py
+++ b/mcp-server/tests/sources/test_api_source_service.py
@@ -112,9 +112,38 @@ async def test_fetch_returns_empty_result_on_http_error_without_cache(patched_se
 
 
 @pytest.mark.asyncio
-async def test_fetch_writes_cache_on_success(patched_session_factory):
-    """성공 시 api_cache 에 도메인 단위 1 row upsert. site_url 은 cache://{tool_name}."""
-    source = await _create_source()
+async def test_fetch_writes_cache_on_success_bulk_fetch(patched_session_factory):
+    """bulk-fetch tool 성공 시 site_url = cache://{tool_name} 단일 행 upsert."""
+    source = await _create_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/law",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"items": [{"law": "민법"}]},
+            headers={"content-type": "application/json"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await api_source_service.fetch(source_id=source.id, params={}, _test_http_client=client)
+
+    async with get_session() as session:
+        result = await session.execute(select(ApiCache).where(ApiCache.source_id == source.id))
+        cache = result.scalar_one_or_none()
+
+    assert cache is not None
+    assert cache.api_type == "search_law_info"
+    assert cache.site_url == "cache://search_law_info"
+    assert "민법" in cache.content
+
+
+@pytest.mark.asyncio
+async def test_fetch_writes_cache_on_success_param_keyed(patched_session_factory):
+    """param-keyed tool 성공 시 site_url = cache://{tool_name}/{LAWD_CD}/{DEAL_YMD}."""
+    source = await _create_source()  # search_house_price
 
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -127,7 +156,7 @@ async def test_fetch_writes_cache_on_success(patched_session_factory):
     async with httpx.AsyncClient(transport=transport) as client:
         await api_source_service.fetch(
             source_id=source.id,
-            params={"region": "강남구"},
+            params={"LAWD_CD": "11680", "DEAL_YMD": "202403"},
             _test_http_client=client,
         )
 
@@ -137,14 +166,17 @@ async def test_fetch_writes_cache_on_success(patched_session_factory):
 
     assert cache is not None
     assert cache.api_type == "search_house_price"
-    assert cache.site_url == "cache://search_house_price"
+    assert cache.site_url == "cache://search_house_price/11680/202403"
     assert "1500" in cache.content
 
 
 @pytest.mark.asyncio
-async def test_fetch_overwrites_cache_per_tool_name(patched_session_factory):
-    """같은 tool_name 에 두 번 호출하면 1 row 유지(덮어쓰기)."""
-    source = await _create_source()
+async def test_fetch_overwrites_cache_for_bulk_fetch_tool(patched_session_factory):
+    """bulk-fetch tool은 같은 tool_name 두 번 호출 시 1 row 유지(덮어쓰기)."""
+    source = await _create_source(
+        tool_name="search_law_info",
+        url_template="https://example.gov/law",
+    )
     counter = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -157,11 +189,44 @@ async def test_fetch_overwrites_cache_per_tool_name(patched_session_factory):
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
+        await api_source_service.fetch(source_id=source.id, params={}, _test_http_client=client)
+        await api_source_service.fetch(source_id=source.id, params={}, _test_http_client=client)
+
+    async with get_session() as session:
+        result = await session.execute(
+            select(ApiCache).where(ApiCache.api_type == "search_law_info")
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 1
+    assert '"call": 2' in rows[0].content
+
+
+@pytest.mark.asyncio
+async def test_fetch_creates_separate_rows_for_param_keyed_tool(patched_session_factory):
+    """param-keyed tool은 (LAWD_CD, DEAL_YMD) 조합마다 별도 행 생성."""
+    source = await _create_source()  # search_house_price
+    call_no = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_no["n"] += 1
+        return httpx.Response(
+            200,
+            json={"call": call_no["n"]},
+            headers={"content-type": "application/json"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
         await api_source_service.fetch(
-            source_id=source.id, params={"region": "강남구"}, _test_http_client=client
+            source_id=source.id,
+            params={"LAWD_CD": "11680", "DEAL_YMD": "202403"},
+            _test_http_client=client,
         )
         await api_source_service.fetch(
-            source_id=source.id, params={"region": "부산"}, _test_http_client=client
+            source_id=source.id,
+            params={"LAWD_CD": "11500", "DEAL_YMD": "202403"},  # 다른 지역
+            _test_http_client=client,
         )
 
     async with get_session() as session:
@@ -170,8 +235,10 @@ async def test_fetch_overwrites_cache_per_tool_name(patched_session_factory):
         )
         rows = result.scalars().all()
 
-    assert len(rows) == 1
-    assert '"call": 2' in rows[0].content
+    assert len(rows) == 2
+    site_urls = {r.site_url for r in rows}
+    assert "cache://search_house_price/11680/202403" in site_urls
+    assert "cache://search_house_price/11500/202403" in site_urls
 
 
 @pytest.mark.asyncio
@@ -214,12 +281,8 @@ async def test_peek_cached_content_returns_content_and_cached_at(patched_session
 
 
 @pytest.mark.asyncio
-async def test_peek_cached_content_returns_none_for_real_estate_tools(patched_session_factory):
-    """부동산 6종은 _CACHEABLE_TOOLS 화이트리스트에 없어 peek_cached_content 가 항상 None.
-
-    캐시 row 가 실제로 저장돼 있어도 노출되면 안 된다 (다른 (region, ymd) 호출자에게
-    잘못된 응답을 줄 위험 차단).
-    """
+async def test_peek_cached_content_requires_params_for_real_estate(patched_session_factory):
+    """부동산은 params 포함 시 캐시 반환, params 없이 호출하면 None (다른 조합 오염 방지)."""
     source = await _create_source(
         tool_name="search_house_price",
         url_template="https://example.gov/molit/apt-trade",
@@ -234,25 +297,29 @@ async def test_peek_cached_content_returns_none_for_real_estate_tools(patched_se
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as client:
-        # 캐시는 실제로 저장됨
         await api_source_service.fetch(
             source_id=source.id,
             params={"LAWD_CD": "11680", "DEAL_YMD": "202403"},
             _test_http_client=client,
         )
 
-    # 그러나 peek_cached_content 는 None (화이트리스트 제외)
-    result = await api_source_service.peek_cached_content("search_house_price")
-    assert result is None
+    # 같은 params → 캐시 반환
+    result = await api_source_service.peek_cached_content(
+        "search_house_price", params={"LAWD_CD": "11680", "DEAL_YMD": "202403"}
+    )
+    assert result is not None
+    content, _ = result
+    assert "1500" in content
 
-    for tool_name in (
-        "search_apt_rent",
-        "search_offi_trade",
-        "search_offi_rent",
-        "search_rh_trade",
-        "search_rh_rent",
-    ):
-        assert await api_source_service.peek_cached_content(tool_name) is None
+    # params 없이 호출 → site_url 불일치 → None
+    result_no_params = await api_source_service.peek_cached_content("search_house_price")
+    assert result_no_params is None
+
+    # 다른 지역 params → site_url 불일치 → None
+    result_diff = await api_source_service.peek_cached_content(
+        "search_house_price", params={"LAWD_CD": "11500", "DEAL_YMD": "202403"}
+    )
+    assert result_diff is None
 
 
 @pytest.mark.asyncio

--- a/mcp-server/tests/tools/test_cache_check.py
+++ b/mcp-server/tests/tools/test_cache_check.py
@@ -16,17 +16,20 @@ from mcp_server.tools.cache_check import check_api_cache, get_cached_data
 _FIXTURE_LAW = Path(__file__).resolve().parents[1] / "data" / "law"
 _FIXTURE_AUCTION = Path(__file__).resolve().parents[1] / "data" / "auction"
 _FIXTURE_JOBS = Path(__file__).resolve().parents[1] / "data" / "jobs"
+_FIXTURE_RE = Path(__file__).resolve().parents[1] / "fixtures"
 
 LAW_INFO_XML = (_FIXTURE_LAW / "search_law_info.xml").read_text(encoding="utf-8")
 BILL_INFO_XML = (_FIXTURE_LAW / "search_bill_info.xml").read_text(encoding="utf-8")
 G2B_BID_JSON = (_FIXTURE_AUCTION / "search_g2b_bid.json").read_text(encoding="utf-8")
 PUBLIC_JOB_JSON = (_FIXTURE_JOBS / "search_public_job.json").read_text(encoding="utf-8")
 WORKNET_PERMISSION_DENIED_XML = (_FIXTURE_JOBS / "search_worknet_job.xml").read_text(encoding="utf-8")
+APT_TRADE_XML = (_FIXTURE_RE / "molit_apt_trade_sample.xml").read_text(encoding="utf-8")
 
 _CACHED_AT = datetime(2026, 4, 30, 10, 0, tzinfo=UTC)
 
 
-async def _seed_cache(tool_name: str, content: str) -> None:
+async def _seed_cache(tool_name: str, content: str, site_url: str | None = None) -> None:
+    """site_url 미지정 시 bulk-fetch 기본값 "cache://{tool_name}" 사용."""
     async with get_session() as session:
         source = ApiSource(
             tool_name=tool_name,
@@ -38,7 +41,7 @@ async def _seed_cache(tool_name: str, content: str) -> None:
         await session.flush()
         cache = ApiCache(
             source_id=source.id,
-            site_url=f"cache://{tool_name}",
+            site_url=site_url or f"cache://{tool_name}",
             api_type=tool_name,
             content=content,
             cached_at=_CACHED_AT,
@@ -162,10 +165,10 @@ async def test_get_source_url_is_none(patched_session_factory):
 
 @pytest.mark.asyncio
 async def test_get_bill_info_structured_key(patched_session_factory):
-    """의안 캐시 → structured.bills 키."""
-    await _seed_cache("search_bill_info", BILL_INFO_XML)
+    """의안 캐시 → structured.bills 키. search_bill_info는 param-keyed(AGE)."""
+    await _seed_cache("search_bill_info", BILL_INFO_XML, site_url="cache://search_bill_info/22")
 
-    result = await get_cached_data("search_bill_info")
+    result = await get_cached_data("search_bill_info", params={"age": 22})
 
     assert "bills" in result["structured"]
 
@@ -205,3 +208,108 @@ async def test_get_worknet_permission_denied(patched_session_factory):
     assert result["metadata"]["api_status"] == "permission_denied"
     assert result["metadata"]["cache_used"] is True
     assert result["structured"]["summary"]["count"] == 0
+
+
+# ─────────────────────────────────────────────
+# check_api_cache — param-keyed (부동산·의안)
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_real_estate_without_params(patched_session_factory):
+    """부동산 tool에 params 없이 호출 → cache_hit: false + message."""
+    result = await check_api_cache("search_house_price")
+
+    assert result["cache_hit"] is False
+    assert "message" in result
+    assert "LAWD_CD" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_check_real_estate_cache_hit(patched_session_factory):
+    """부동산 캐시 hit: 동일 params → cache_hit: true."""
+    await _seed_cache(
+        "search_house_price", APT_TRADE_XML,
+        site_url="cache://search_house_price/11680/202403",
+    )
+
+    result = await check_api_cache(
+        "search_house_price", params={"lawd_cd": "11680", "deal_ymd": "202403"}
+    )
+
+    assert result["cache_hit"] is True
+    assert result["last_fetched_at"].startswith("2026-04-30T10:00:00")
+
+
+@pytest.mark.asyncio
+async def test_check_real_estate_different_region_is_miss(patched_session_factory):
+    """강남(11680) 캐시 → 마포(11500) 조회 → cache_hit: false."""
+    await _seed_cache(
+        "search_house_price", APT_TRADE_XML,
+        site_url="cache://search_house_price/11680/202403",
+    )
+
+    result = await check_api_cache(
+        "search_house_price", params={"lawd_cd": "11500", "deal_ymd": "202403"}
+    )
+
+    assert result["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_check_bill_info_age_keyed(patched_session_factory):
+    """search_bill_info는 AGE 단위 param-keyed. AGE=22 캐시 → AGE=21 조회 → miss."""
+    await _seed_cache("search_bill_info", BILL_INFO_XML, site_url="cache://search_bill_info/22")
+
+    hit = await check_api_cache("search_bill_info", params={"age": 22})
+    miss = await check_api_cache("search_bill_info", params={"age": 21})
+
+    assert hit["cache_hit"] is True
+    assert miss["cache_hit"] is False
+
+
+# ─────────────────────────────────────────────
+# get_cached_data — param-keyed (부동산)
+# ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_real_estate_without_params(patched_session_factory):
+    """부동산 tool에 params 없이 호출 → cache_hit: false + message."""
+    result = await get_cached_data("search_house_price")
+
+    assert result["cache_hit"] is False
+    assert "message" in result
+
+
+@pytest.mark.asyncio
+async def test_get_real_estate_cache_hit_format(patched_session_factory):
+    """부동산 캐시 hit → trades 키 + cache_used: true."""
+    await _seed_cache(
+        "search_house_price", APT_TRADE_XML,
+        site_url="cache://search_house_price/11680/202403",
+    )
+
+    result = await get_cached_data(
+        "search_house_price", params={"lawd_cd": "11680", "deal_ymd": "202403"}
+    )
+
+    assert result["metadata"]["cache_used"] is True
+    assert result["source_url"] is None
+    assert "trades" in result["structured"]
+    assert "summary" in result["structured"]
+
+
+@pytest.mark.asyncio
+async def test_get_real_estate_different_region_is_miss(patched_session_factory):
+    """강남 캐시 → 마포 조회 → cache_hit: false (조합 불일치)."""
+    await _seed_cache(
+        "search_house_price", APT_TRADE_XML,
+        site_url="cache://search_house_price/11680/202403",
+    )
+
+    result = await get_cached_data(
+        "search_house_price", params={"lawd_cd": "11500", "deal_ymd": "202403"}
+    )
+
+    assert result["cache_hit"] is False


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #111 

**🛠 작업 내역**
API 종류를 나누고 그에 맞게 caching하도록 수정

- bulk-fetch: API는 wide params로 전체 fetch → 캐시는 raw 응답을 tool_name 1행 → 사용자 query는 in-memory filtering
- param-keyed: (tool_name + params) 조합 자체가 캐시 단위 → 조합마다 별도 행


**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?