### PR TITLE
FIX: MCP 알림 테스트 환경 격리

### DIFF
--- a/mcp-server/tests/notifications/test_delivery.py
+++ b/mcp-server/tests/notifications/test_delivery.py
@@ -21,9 +21,32 @@ def _settings(**overrides: Any) -> Settings:
     values = {
         "pg_url": "postgresql+asyncpg://test:test@localhost:5432/test",
         "langfuse_enabled": False,
+        "notification_telegram_enabled": False,
+        "notification_telegram_bot_token": None,
+        "notification_discord_enabled": False,
+        "notification_discord_bot_token": None,
+        "notification_email_enabled": False,
+        "notification_email_from": None,
+        "notification_email_host": None,
+        "notification_email_username": None,
+        "notification_email_password": None,
     }
     values.update(overrides)
-    return Settings(**values)
+    return Settings(_env_file=None, **values)
+
+
+def test_test_settings_do_not_read_local_notification_env() -> None:
+    settings = _settings()
+
+    assert settings.notification_telegram_enabled is False
+    assert settings.notification_telegram_bot_token is None
+    assert settings.notification_discord_enabled is False
+    assert settings.notification_discord_bot_token is None
+    assert settings.notification_email_enabled is False
+    assert settings.notification_email_from is None
+    assert settings.notification_email_host is None
+    assert settings.notification_email_username is None
+    assert settings.notification_email_password is None
 
 
 async def test_telegram_send_message_success() -> None:


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #114 

**🛠 작업 내역**

- 테스트용 _settings()가 Settings(_env_file=None, **values)로 생성되도록 변경해서 mcp-server/.env 를 읽지 못하게 함
- 회귀테스트 추가

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?