### PR TITLE
FEAT: 채용 구독 AI 알림 workflow 구현

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/ai/PromptTemplate.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/PromptTemplate.java
@@ -165,6 +165,11 @@ target 작성 규칙:
 
 필수 처리 흐름:
 - 전체 흐름은 데이터 도구 -> compare_subscription_change -> send_notification 순서입니다.
+- 구독 params.dataToolName이 있으면 그 도구를 우선 선택하세요.
+- 채용 도메인에서는 search_public_job(공공채용)과 search_worknet_job(워크넷)을 채용 데이터 도구로 사용합니다.
+- 채용 데이터 도구를 호출하기 전에 check_api_cache를 먼저 호출하세요. 채용 캐시는 일 단위로 판단하며, 신선한 cache_hit이면 get_cached_data를 사용하고 외부 데이터 도구를 호출하지 마세요.
+- 캐시가 없거나 오래되었으면 해당 채용 데이터 도구를 호출하세요.
+- search_worknet_job 또는 get_cached_data(search_worknet_job) 응답이 structured.permission_denied=true 또는 metadata.api_status="permission_denied"이면 Worknet 결과만 건너뛰세요. 이 경우 공공채용 등 사용 가능한 다른 채용 데이터가 있으면 전체 채용 구독 실행은 계속 진행하세요.
 - 데이터 조회 실패 시 해당 구독은 건너뛰고 compare_subscription_change와 send_notification을 호출하지 마세요.
 - compare_subscription_change에는 데이터 도구 응답과 구독의 params/condition을 기준으로 변화 비교에 필요한 값을 전달하세요.
 - compare_subscription_change 응답의 structured.diffs와 structured.briefing_facts를 조건 판단과 AI 브리핑 작성의 근거로 사용하세요.
@@ -176,8 +181,14 @@ target 작성 규칙:
 - structured.changed=false이면 의미 있는 변화가 없습니다. send_notification을 호출하지 말고 알림을 보내지 마세요.
 - structured.requires_ai_analysis=false이면 MCP가 AI 분석 대상이 아니라고 판정한 것입니다. AI 분석과 AI 브리핑을 생성하지 마세요. send_notification도 호출하지 마세요.
 - structured.requires_ai_analysis=true인 경우에만 structured.diffs와 structured.briefing_facts를 읽고 사용자의 params/condition 조건이 실제로 충족되는지 판단하세요.
+- structured.condition_satisfied=true이면 MCP가 구조화 조건 충족을 판정한 것입니다. 이 경우에만 AI 브리핑과 send_notification 호출을 진행하세요.
 - condition이 충족되지 않으면 send_notification을 호출하지 마세요.
 - condition이 충족되면 structured.diffs와 structured.briefing_facts를 바탕으로 간결한 사용자용 한국어 AI 브리핑을 작성하고 send_notification을 호출하세요.
+- 채용 도메인의 condition이 충족되면 compare_subscription_change 응답의 structured.briefing_postings_by_source를 우선 사용해 신규 채용공고를 출처별로 안내하세요.
+- structured.briefing_postings_by_source.public_job 목록은 "공공채용" 섹션에 공고 제목과 링크를 함께 적으세요.
+- structured.briefing_postings_by_source.worknet_job 목록은 "워크넷" 섹션에 공고 제목과 링크를 함께 적으세요.
+- public_job 또는 worknet_job 목록이 비어 있으면 해당 섹션은 생략하세요.
+- Worknet 권한 거부 응답은 신규 공고나 변화 근거로 쓰지 말고, 공공채용 신규 공고가 있으면 공공채용 섹션만 브리핑하세요.
 
 주의:
 - 각 구독은 독립적으로 처리하세요.

--- a/back/src/main/java/com/back/domain/adapter/out/ai/PromptTemplate.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/PromptTemplate.java
@@ -80,11 +80,19 @@ condition 규칙 (중요):
 - condition은 백엔드에서 비교 연산에 사용되므로 반드시 수치 기반이어야 해
 - 사용자가 명시한 수치(예: "5%", "50만원 이하")가 있으면 그대로 사용: "5% 이상 상승", "50만원 이하"
 - "반토막", "두 배" 같은 비유 표현은 수치로 변환: "반토막" → "50% 하락", "두 배" → "100% 상승"
+- 채용 도메인에서 "새 공고 뜨면", "새로 올라오면", "공고가 등록되면"은 수치 조건으로 해석 가능해. condition을 "1건 이상 증가"로 설정하고, 대상 검색어가 있으면 needs_confirmation을 false로 설정
+- 채용 도메인에서 "진행중 공고가 늘면"은 condition을 "진행중 공고 1건 이상 증가"로 설정
+- 채용 도메인에서 "3건 이상 늘면"처럼 건수가 명시되면 condition을 "{명시 건수}건 이상 증가"로 설정
 - "좀 많이", "살짝", "많이", "바뀌면", "오르면" 같은 모호한 표현은 절대 임의로 수치를 추정하지 마
 - 모호한 표현인 경우 condition을 빈 문자열("")로 두고 needs_confirmation을 true로 설정
 - confirmation_question에 구체적으로 어떤 수치 기준을 원하는지 질문. 예: "몇 % 이상 변동 시 알려드릴까요?"
 - delete 요청은 condition을 "삭제 요청"으로 설정
 - reject 요청은 condition을 "지원하지 않는 도메인"으로 설정
+
+채용 query 규칙:
+- 채용 query에는 검색 키워드와 채용 표현만 남겨. 시간, 주기, 알림 채널, 전달 방식 문구는 query나 target에 섞지 마
+- 예: "백엔드 채용 새 공고 뜨면 매일 오전 9시에 텔레그램으로 알려줘" → query: "백엔드 채용 새 공고", target: "백엔드 채용 공고"
+- 예: "공공기관 데이터 채용 진행중 공고가 늘면 알려줘" → query: "공공기관 데이터 채용", target: "공공기관 데이터 채용 진행중 공고"
 
 urls 규칙:
 - metadata.urls는 실제 존재할 것 같은 URL을 추천해서 넣어
@@ -137,6 +145,8 @@ target 작성 규칙:
 1. 이전 JSON 결과를 기반으로 사용자의 추가 입력을 반영해 전체 JSON을 업데이트해.
 2. 사용자가 명시하지 않은 필드는 이전 값을 그대로 유지해.
 3. condition 필드에 사용자가 제공한 수치를 반영해.
+   - 채용 조건 답변이 "새 공고", "새로 올라오면", "공고가 등록되면"이면 condition을 "1건 이상 증가"로 설정하고 needs_confirmation을 false로 설정해.
+   - 채용 조건 답변이 "진행중 공고가 늘면"이면 condition을 "진행중 공고 1건 이상 증가"로 설정하고 needs_confirmation을 false로 설정해.
 4. 모든 모호성이 해결되면 needs_confirmation을 false로 설정하고 confirmation_question을 빈 문자열("")로 해.
 5. 여전히 모호한 부분이 있으면 needs_confirmation을 true로 유지하고 새로운 confirmation_question을 작성해.
 6. 동일한 JSON 스키마를 사용해: [{intent, domain_name, query, condition, cron_expr, channel, api_type, metadata: {target, urls, confidence, needs_confirmation, confirmation_question}}]

--- a/back/src/main/java/com/back/domain/adapter/out/ai/PromptTemplate.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/PromptTemplate.java
@@ -172,6 +172,9 @@ target 작성 규칙:
 - search_worknet_job 또는 get_cached_data(search_worknet_job) 응답이 structured.permission_denied=true 또는 metadata.api_status="permission_denied"이면 Worknet 결과만 건너뛰세요. 이 경우 공공채용 등 사용 가능한 다른 채용 데이터가 있으면 전체 채용 구독 실행은 계속 진행하세요.
 - 데이터 조회 실패 시 해당 구독은 건너뛰고 compare_subscription_change와 send_notification을 호출하지 마세요.
 - compare_subscription_change에는 데이터 도구 응답과 구독의 params/condition을 기준으로 변화 비교에 필요한 값을 전달하세요.
+- 채용 도메인에서 공공채용과 워크넷을 모두 조회한 경우, 사용 가능한 각 도구 응답을 current.sources 배열에 담아 compare_subscription_change에 전달하세요.
+- current.sources는 MCP가 deterministic하게 count/postings를 병합하기 위한 계약입니다. AI가 공공채용/워크넷 count나 postings를 직접 합산해 새 current를 만들지 마세요.
+- Worknet 권한 거부 응답은 current.sources에 넣지 않아도 됩니다. 포함된 경우에도 MCP는 권한 거부 source를 비교 대상에서 제외합니다.
 - compare_subscription_change 응답의 structured.diffs와 structured.briefing_facts를 조건 판단과 AI 브리핑 작성의 근거로 사용하세요.
 - 원본 데이터만 보고 알림 여부를 결정하지 말고, 반드시 compare_subscription_change 결과를 기준으로 판단하세요.
 - MCP가 먼저 코드로 diff와 명확한 조건을 판정합니다. AI 분석은 structured.requires_ai_analysis=true인 경우에만 수행하세요.

--- a/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
+++ b/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,6 +40,7 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, Object>> PARAMETER_MAP = new TypeReference<>() {};
+    private static final DateTimeFormatter DEAL_YMD_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
     private static final Pattern REGION = Pattern.compile(
             "([가-힣]+(?:특별자치시|특별자치도|특별시|광역시|시|군|구)|서울|부산|대구|인천|광주|대전|울산|세종|제주)"
     );
@@ -63,7 +66,7 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
                 .map(schedule -> {
                     Optional<SubscriptionMonitoringConfig> config =
                             loadSubscriptionMonitoringConfigPort.loadBySubscriptionId(schedule.subscription().id());
-                    return buildContext(schedule, config);
+                    return buildContext(schedule, config, now);
                 })
                 .toList();
 
@@ -75,10 +78,11 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
 
     private SubscriptionContext buildContext(
             Schedule schedule,
-            Optional<SubscriptionMonitoringConfig> monitoringConfig
+            Optional<SubscriptionMonitoringConfig> monitoringConfig,
+            LocalDateTime now
     ) {
         Map<String, Object> params = monitoringConfig
-                .map(this::parameters)
+                .map(config -> parameters(config, now))
                 .orElseGet(() -> fallbackParameters(schedule.subscription().query()));
 
         NotificationChannel channel = notificationChannel(schedule.subscription().id());
@@ -113,16 +117,28 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
         }
     }
 
-    private Map<String, Object> parameters(SubscriptionMonitoringConfig config) {
+    private Map<String, Object> parameters(SubscriptionMonitoringConfig config, LocalDateTime now) {
         if (isBlank(config.parametersJson())) {
             return Map.of();
         }
         try {
-            return OBJECT_MAPPER.readValue(config.parametersJson(), PARAMETER_MAP);
+            Map<String, Object> parsed = OBJECT_MAPPER.readValue(config.parametersJson(), PARAMETER_MAP);
+            return normalizeExecutionParameters(parsed, now);
         } catch (JsonProcessingException e) {
             log.warn("parametersJson 파싱 실패 - subscriptionId: {}", config.subscriptionId(), e);
             return Map.of();
         }
+    }
+
+    private Map<String, Object> normalizeExecutionParameters(Map<String, Object> params, LocalDateTime now) {
+        Map<String, Object> normalized = new LinkedHashMap<>(params);
+        // Spring AI 실행 경로는 SearchHousePriceMcpInput을 거치지 않아 정책을 실제 tool 인자로 확정한다.
+        if ("LATEST_AVAILABLE_MONTH".equals(String.valueOf(normalized.get("dealYmdPolicy")))
+                && !normalized.containsKey("deal_ymd")
+                && !normalized.containsKey("dealYmd")) {
+            normalized.put("deal_ymd", now.minusMonths(1).format(DEAL_YMD_FORMATTER));
+        }
+        return normalized;
     }
 
     private Map<String, Object> fallbackParameters(String query) {

--- a/back/src/main/java/com/back/domain/application/service/dev/DevSubscriptionChangeSimulationService.java
+++ b/back/src/main/java/com/back/domain/application/service/dev/DevSubscriptionChangeSimulationService.java
@@ -23,14 +23,18 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -43,6 +47,12 @@ public class DevSubscriptionChangeSimulationService {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<Map<String, Object>> PARAMETER_MAP = new TypeReference<>() {};
     private static final BigDecimal DEFAULT_PREVIOUS_VALUE = BigDecimal.valueOf(100_000);
+    private static final String RECRUITMENT_DOMAIN = "recruitment";
+    private static final String TOOL_PUBLIC_JOB = "search_public_job";
+    private static final String TOOL_WORKNET_JOB = "search_worknet_job";
+    private static final long DEFAULT_RECRUITMENT_COUNT = 10;
+    private static final long DEFAULT_RECRUITMENT_ONGOING_COUNT = 3;
+    private static final long MAX_RECRUITMENT_POSTING_SAMPLES = 20;
 
     private final LoadSubscriptionPort loadSubscriptionPort;
     private final LoadSubscriptionMonitoringConfigPort loadMonitoringConfigPort;
@@ -66,7 +76,7 @@ public class DevSubscriptionChangeSimulationService {
         StructuredCondition condition = StructuredCondition.fromParameters(parameters)
                 .orElseThrow(() -> new ApiException(ErrorCode.INVALID_REQUEST));
 
-        SummaryPair summaries = fakeSummaries(condition);
+        SummaryPair summaries = fakeSummaries(subscription, config, rawParameters, condition);
         MonitoringChangeDecision decision = monitoringChangeDetector.detect(
                 summaries.previous(),
                 summaries.current(),
@@ -90,7 +100,7 @@ public class DevSubscriptionChangeSimulationService {
                 decision,
                 null
         );
-        String mcpContent = fakeMcpContent(subscription, summaries);
+        String mcpContent = fakeMcpContent(subscription, config, summaries);
         Optional<MonitoringBriefingResult> generatedBriefing = generateMonitoringBriefingPort.generate(new MonitoringBriefingRequest(
                 subscription.query(),
                 config.toolName(),
@@ -134,14 +144,89 @@ public class DevSubscriptionChangeSimulationService {
         );
     }
 
-    private SummaryPair fakeSummaries(StructuredCondition condition) {
+    private SummaryPair fakeSummaries(
+            Subscription subscription,
+            SubscriptionMonitoringConfig config,
+            Map<String, Object> rawParameters,
+            StructuredCondition condition
+    ) {
+        if (isRecruitmentSimulation(subscription, config, rawParameters)) {
+            return fakeRecruitmentSummaries(recruitmentToolName(config, rawParameters), condition);
+        }
+        return fakeRealEstateSummaries(condition);
+    }
+
+    private SummaryPair fakeRealEstateSummaries(StructuredCondition condition) {
         BigDecimal comparable = comparableValue(condition);
         BigDecimal delta = deltaValue(DEFAULT_PREVIOUS_VALUE, comparable, condition.unit());
         BigDecimal previous = previousValue(delta);
         BigDecimal signedDelta = signedDelta(delta, condition.direction());
         BigDecimal current = previous.add(signedDelta);
 
-        return new SummaryPair(summaryNode(previous), summaryNode(current));
+        return new SummaryPair(realEstateSummaryNode(previous), realEstateSummaryNode(current));
+    }
+
+    private SummaryPair fakeRecruitmentSummaries(String toolName, StructuredCondition condition) {
+        long delta = recruitmentDeltaValue(condition);
+        long signedDelta = signedCountDelta(delta, condition.direction());
+        long previousCount = Math.max(DEFAULT_RECRUITMENT_COUNT, delta * 4);
+        long previousOngoingCount = Math.min(
+                previousCount,
+                Math.max(
+                        DEFAULT_RECRUITMENT_ONGOING_COUNT,
+                        condition.metric() == StructuredCondition.Metric.ONGOING_COUNT
+                                && condition.direction() == StructuredCondition.Direction.DOWN
+                                ? delta * 4
+                                : DEFAULT_RECRUITMENT_ONGOING_COUNT
+                )
+        );
+        long currentCount = previousCount;
+        long currentOngoingCount = previousOngoingCount;
+        if (condition.metric() == StructuredCondition.Metric.ONGOING_COUNT) {
+            currentOngoingCount += signedDelta;
+            currentCount = Math.max(currentCount, currentOngoingCount);
+        } else {
+            currentCount += signedDelta;
+            if (signedDelta > 0) {
+                currentOngoingCount += signedDelta;
+            }
+        }
+        currentCount = Math.max(1, currentCount);
+        currentOngoingCount = Math.max(0, Math.min(currentOngoingCount, currentCount));
+
+        return new SummaryPair(
+                recruitmentSummaryNode(toolName, previousCount, previousOngoingCount, 0),
+                recruitmentSummaryNode(toolName, currentCount, currentOngoingCount, Math.max(0, signedDelta))
+        );
+    }
+
+    private boolean isRecruitmentSimulation(
+            Subscription subscription,
+            SubscriptionMonitoringConfig config,
+            Map<String, Object> rawParameters
+    ) {
+        return isRecruitmentDomain(subscription)
+                || isRecruitmentTool(config.toolName())
+                || isRecruitmentTool(String.valueOf(rawParameters.get("dataToolName")));
+    }
+
+    private boolean isRecruitmentDomain(Subscription subscription) {
+        return subscription.domain() != null && RECRUITMENT_DOMAIN.equals(subscription.domain().name());
+    }
+
+    private boolean isRecruitmentTool(String toolName) {
+        return TOOL_PUBLIC_JOB.equals(toolName) || TOOL_WORKNET_JOB.equals(toolName);
+    }
+
+    private String recruitmentToolName(SubscriptionMonitoringConfig config, Map<String, Object> rawParameters) {
+        if (isRecruitmentTool(config.toolName())) {
+            return config.toolName();
+        }
+        Object dataToolName = rawParameters.get("dataToolName");
+        if (dataToolName != null && isRecruitmentTool(String.valueOf(dataToolName))) {
+            return String.valueOf(dataToolName);
+        }
+        return TOOL_PUBLIC_JOB;
     }
 
     private BigDecimal comparableValue(StructuredCondition condition) {
@@ -167,7 +252,7 @@ public class DevSubscriptionChangeSimulationService {
     }
 
     private BigDecimal step(StructuredCondition.Unit unit) {
-        if (unit == StructuredCondition.Unit.PERCENT) {
+        if (unit == StructuredCondition.Unit.PERCENT || unit == StructuredCondition.Unit.COUNT) {
             return BigDecimal.ONE;
         }
         return BigDecimal.valueOf(100);
@@ -202,11 +287,99 @@ public class DevSubscriptionChangeSimulationService {
         return rounded;
     }
 
-    private JsonNode summaryNode(BigDecimal value) {
+    private long recruitmentDeltaValue(StructuredCondition condition) {
+        BigDecimal comparable = comparableValue(condition).abs();
+        BigDecimal rounded = comparable.setScale(0, RoundingMode.CEILING);
+        if (rounded.compareTo(BigDecimal.ZERO) == 0) {
+            return 1;
+        }
+        return rounded.longValue();
+    }
+
+    private long signedCountDelta(long delta, StructuredCondition.Direction direction) {
+        if (direction == StructuredCondition.Direction.DOWN) {
+            return -delta;
+        }
+        return delta;
+    }
+
+    private JsonNode realEstateSummaryNode(BigDecimal value) {
         ObjectNode summary = OBJECT_MAPPER.createObjectNode();
         summary.put("avg_deal_amount", value.setScale(0, RoundingMode.HALF_UP).longValue());
         summary.put("count", 10);
         return summary;
+    }
+
+    private JsonNode recruitmentSummaryNode(
+            String toolName,
+            long count,
+            long ongoingCount,
+            long newPostingCount
+    ) {
+        ObjectNode summary = OBJECT_MAPPER.createObjectNode();
+        summary.put("count", count);
+        summary.put("ongoing_count", ongoingCount);
+        ArrayNode postings = summary.putArray("postings");
+        long normalizedNewPostingCount = Math.min(Math.min(newPostingCount, count), MAX_RECRUITMENT_POSTING_SAMPLES);
+        long existingPostingCount = Math.min(
+                count - normalizedNewPostingCount,
+                MAX_RECRUITMENT_POSTING_SAMPLES - normalizedNewPostingCount
+        );
+        summary.put("postings_truncated", count > existingPostingCount + normalizedNewPostingCount);
+        long existingOngoingCount = Math.max(0, ongoingCount - normalizedNewPostingCount);
+        for (long index = 1; index <= existingPostingCount; index++) {
+            postings.add(existingRecruitmentPosting(toolName, index, index <= existingOngoingCount));
+        }
+        for (long index = 1; index <= normalizedNewPostingCount; index++) {
+            postings.add(newRecruitmentPosting(toolName, index));
+        }
+        return summary;
+    }
+
+    private ObjectNode existingRecruitmentPosting(String toolName, long index, boolean ongoing) {
+        ObjectNode posting = OBJECT_MAPPER.createObjectNode();
+        if (TOOL_WORKNET_JOB.equals(toolName)) {
+            String wantedAuthNo = "K12003260428%04d".formatted(index);
+            posting.put("wanted_auth_no", wantedAuthNo);
+            posting.put("title", "기존 워크넷 백엔드 개발자 " + index);
+            posting.put("company", "기존 워크넷 기업 " + index);
+            posting.put("region", "서울");
+            posting.put("is_ongoing", ongoing);
+            posting.put("info_url", "https://work.example/jobs/" + wantedAuthNo);
+            return posting;
+        }
+        long pblntSn = 2026042800L + index;
+        posting.put("pblnt_sn", pblntSn);
+        posting.put("title", "기존 공공기관 백엔드 개발자 채용 " + index);
+        posting.put("institute", "기존 공공기관 " + index);
+        posting.putArray("work_regions").add("서울");
+        posting.put("is_ongoing", ongoing);
+        posting.put("src_url", "https://public.example/jobs/" + pblntSn);
+        return posting;
+    }
+
+    private ObjectNode newRecruitmentPosting(String toolName, long index) {
+        ObjectNode posting = OBJECT_MAPPER.createObjectNode();
+        if (TOOL_WORKNET_JOB.equals(toolName)) {
+            String wantedAuthNo = "K12003260429%04d".formatted(index);
+            posting.put("wanted_auth_no", wantedAuthNo);
+            posting.put("title", index == 1 ? "워크넷 백엔드 개발자" : "워크넷 백엔드 개발자 " + index);
+            posting.put("company", "워크넷 소프트웨어");
+            posting.put("region", "서울");
+            posting.put("is_ongoing", true);
+            posting.put("info_url", "https://work.example/jobs/" + wantedAuthNo);
+            return posting;
+        }
+        long pblntSn = 2026042900L + index;
+        posting.put("pblnt_sn", pblntSn);
+        posting.put("title", index == 1
+                ? "한국데이터산업진흥원 백엔드 개발자 채용"
+                : "공공기관 백엔드 개발자 채용 " + index);
+        posting.put("institute", "한국데이터산업진흥원");
+        posting.putArray("work_regions").add("서울");
+        posting.put("is_ongoing", true);
+        posting.put("src_url", "https://public.example/jobs/" + pblntSn);
+        return posting;
     }
 
     private AlertEvent alertEvent(
@@ -224,7 +397,7 @@ public class DevSubscriptionChangeSimulationService {
                 summary,
                 "구독 조건에 맞는 변화가 감지되었습니다.",
                 List.of(new AlertSource(
-                        metricLabel(decision.metricKey()),
+                        metricLabel(subscription, decision.metricKey()),
                         null,
                         sourceDescription(decision)
                 )),
@@ -232,7 +405,15 @@ public class DevSubscriptionChangeSimulationService {
         );
     }
 
-    private String metricLabel(String metricKey) {
+    private String metricLabel(Subscription subscription, String metricKey) {
+        if (isRecruitmentDomain(subscription)) {
+            if ("count".equals(metricKey)) {
+                return "채용 공고 수 변화";
+            }
+            if ("ongoing_count".equals(metricKey)) {
+                return "진행중 채용 공고 수 변화";
+            }
+        }
         if ("avg_deal_amount".equals(metricKey)) {
             return "평균 거래금액 변화";
         }
@@ -243,7 +424,10 @@ public class DevSubscriptionChangeSimulationService {
             return "평균 월세 변화";
         }
         if ("count".equals(metricKey)) {
-            return "거래 건수 변화";
+            return "건수 변화";
+        }
+        if ("ongoing_count".equals(metricKey)) {
+            return "진행중 건수 변화";
         }
         return "구독 지표 변화";
     }
@@ -265,13 +449,111 @@ public class DevSubscriptionChangeSimulationService {
         return value.setScale(2, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString();
     }
 
-    private String fakeMcpContent(Subscription subscription, SummaryPair summaries) {
+    private String fakeMcpContent(
+            Subscription subscription,
+            SubscriptionMonitoringConfig config,
+            SummaryPair summaries
+    ) {
+        if (isRecruitmentSimulation(subscription, config, Map.of())) {
+            return fakeRecruitmentMcpContent(subscription, summaries);
+        }
         return """
                 구독 조건에 맞는 변화가 감지되었습니다.
                 요청: %s
                 이전 요약: %s
                 현재 요약: %s
                 """.formatted(subscription.query(), summaries.previous(), summaries.current()).trim();
+    }
+
+    private String fakeRecruitmentMcpContent(Subscription subscription, SummaryPair summaries) {
+        List<PostingLine> publicJobs = briefingPostings(summaries, TOOL_PUBLIC_JOB);
+        List<PostingLine> worknetJobs = briefingPostings(summaries, TOOL_WORKNET_JOB);
+        StringBuilder content = new StringBuilder();
+        content.append("구독 조건에 맞는 채용 변화가 감지되었습니다.\n");
+        content.append("요청: ").append(subscription.query());
+        appendPostingSection(content, "공공채용", publicJobs);
+        appendPostingSection(content, "워크넷", worknetJobs);
+        if (publicJobs.isEmpty() && worknetJobs.isEmpty()) {
+            content.append("\n신규 공고 상세는 현재 채용 공고 수 변화만 감지되었습니다.");
+        }
+        return content.toString().trim();
+    }
+
+    private void appendPostingSection(StringBuilder content, String label, List<PostingLine> postings) {
+        if (postings.isEmpty()) {
+            return;
+        }
+        content.append("\n\n").append(label);
+        postings.forEach(posting -> {
+            content.append("\n- ").append(posting.title());
+            if (!isBlank(posting.url())) {
+                content.append("\n  ").append(posting.url());
+            }
+        });
+    }
+
+    private List<PostingLine> briefingPostings(SummaryPair summaries, String source) {
+        Set<String> previousIds = postingIdentities(summaries.previous());
+        List<PostingLine> postings = new ArrayList<>();
+        JsonNode currentPostings = summaries.current().path("postings");
+        if (!currentPostings.isArray()) {
+            return postings;
+        }
+        currentPostings.forEach(posting -> {
+            String identity = postingIdentity(posting);
+            if (identity == null || previousIds.contains(identity) || !identity.startsWith(source + ":")) {
+                return;
+            }
+            postings.add(new PostingLine(postingTitle(posting), postingUrl(posting)));
+        });
+        return postings;
+    }
+
+    private Set<String> postingIdentities(JsonNode summary) {
+        Set<String> identities = new HashSet<>();
+        JsonNode postings = summary.path("postings");
+        if (!postings.isArray()) {
+            return identities;
+        }
+        postings.forEach(posting -> {
+            String identity = postingIdentity(posting);
+            if (identity != null) {
+                identities.add(identity);
+            }
+        });
+        return identities;
+    }
+
+    private String postingIdentity(JsonNode posting) {
+        JsonNode publicId = posting.path("pblnt_sn");
+        if (!publicId.isMissingNode() && !publicId.isNull() && !publicId.asText().isBlank()) {
+            return TOOL_PUBLIC_JOB + ":" + publicId.asText();
+        }
+        JsonNode worknetId = posting.path("wanted_auth_no");
+        if (!worknetId.isMissingNode() && !worknetId.isNull() && !worknetId.asText().isBlank()) {
+            return TOOL_WORKNET_JOB + ":" + worknetId.asText();
+        }
+        return null;
+    }
+
+    private String postingTitle(JsonNode posting) {
+        for (String key : List.of("title", "wantedTitle", "recrutPbancTtl", "recrut_pbanc_ttl")) {
+            JsonNode value = posting.path(key);
+            if (!value.isMissingNode() && !value.isNull() && !value.asText().isBlank()) {
+                return value.asText();
+            }
+        }
+        return "(제목 없음)";
+    }
+
+    private String postingUrl(JsonNode posting) {
+        for (String key : List.of("src_url", "srcUrl", "info_url", "wantedInfoUrl")) {
+            JsonNode value = posting.path(key);
+            if (!value.isMissingNode() && !value.isNull() && !value.asText().isBlank()) {
+                return value.asText();
+            }
+        }
+        return null;
     }
 
     private String notificationTitle(String message) {
@@ -323,5 +605,8 @@ public class DevSubscriptionChangeSimulationService {
     }
 
     private record SummaryPair(JsonNode previous, JsonNode current) {
+    }
+
+    private record PostingLine(String title, String url) {
     }
 }

--- a/back/src/main/java/com/back/domain/application/service/monitoring/MonitoringChangeDetector.java
+++ b/back/src/main/java/com/back/domain/application/service/monitoring/MonitoringChangeDetector.java
@@ -61,14 +61,25 @@ public class MonitoringChangeDetector {
     }
 
     private String metricKey(JsonNode previousSummary, JsonNode currentSummary, StructuredCondition condition) {
-        if (condition.metric() != StructuredCondition.Metric.AVG_PRICE) {
-            return null;
+        return switch (condition.metric()) {
+            case AVG_PRICE -> AVG_PRICE_KEYS.stream()
+                    .filter(key -> hasComparableMetric(previousSummary, currentSummary, key))
+                    .findFirst()
+                    .orElse(null);
+            case COUNT -> comparableMetricKey(previousSummary, currentSummary, "count");
+            case ONGOING_COUNT -> comparableMetricKey(previousSummary, currentSummary, "ongoing_count");
+        };
+    }
+
+    private String comparableMetricKey(JsonNode previousSummary, JsonNode currentSummary, String key) {
+        if (hasComparableMetric(previousSummary, currentSummary, key)) {
+            return key;
         }
-        return AVG_PRICE_KEYS.stream()
-                .filter(key -> decimal(previousSummary.path(key)) != null)
-                .filter(key -> decimal(currentSummary.path(key)) != null)
-                .findFirst()
-                .orElse(null);
+        return null;
+    }
+
+    private boolean hasComparableMetric(JsonNode previousSummary, JsonNode currentSummary, String key) {
+        return decimal(previousSummary.path(key)) != null && decimal(currentSummary.path(key)) != null;
     }
 
     private BigDecimal comparableValue(StructuredCondition condition, BigDecimal change, BigDecimal rate) {

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/DomainCapabilityRegistry.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/DomainCapabilityRegistry.java
@@ -23,7 +23,17 @@ public class DomainCapabilityRegistry {
                     ))
             ),
             "law-regulation", new DomainCapability("law-regulation", "법률/규제", SupportStatus.PLANNED, List.of()),
-            "recruitment", new DomainCapability("recruitment", "채용", SupportStatus.PLANNED, List.of()),
+            "recruitment", new DomainCapability(
+                    "recruitment",
+                    "채용",
+                    SupportStatus.ENABLED,
+                    List.of(new IntentCapability(
+                            "job_posting_change",
+                            null,
+                            List.of(),
+                            Map.of("dataToolName", "search_public_job")
+                    ))
+            ),
             "auction", new DomainCapability("auction", "경매/희소매물", SupportStatus.PLANNED, List.of())
     );
 

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/ParsedTaskNormalizer.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/ParsedTaskNormalizer.java
@@ -94,7 +94,7 @@ public class ParsedTaskNormalizer {
                 channel,
                 targetAddress,
                 missing,
-                assistantQuestion(missing, domainDraft.assistantMessage()),
+                assistantQuestion(domainName, missing, domainDraft.assistantMessage()),
                 confidence
         );
     }
@@ -113,7 +113,15 @@ public class ParsedTaskNormalizer {
         return null;
     }
 
-    private String assistantQuestion(List<String> missing) {
+    private String assistantQuestion(String domainName, List<String> missing) {
+        if ("recruitment".equals(domainName)) {
+            if (missing.contains("keyword")) {
+                return "어떤 채용 공고를 구독할까요? 예: 백엔드, 데이터, 공공기관 인턴 등";
+            }
+            if (missing.contains("condition")) {
+                return "어떤 채용 공고 변화가 생기면 알림을 받을까요? 예: 새 공고 1건 이상 등록 등";
+            }
+        }
         if (missing.contains("region")) {
             return "어느 지역의 아파트 매매 실거래가를 확인할까요?";
         }
@@ -129,11 +137,11 @@ public class ParsedTaskNormalizer {
         return "";
     }
 
-    private String assistantQuestion(List<String> missing, String mcpQuestion) {
+    private String assistantQuestion(String domainName, List<String> missing, String mcpQuestion) {
         if (!isBlank(mcpQuestion)) {
             return mcpQuestion;
         }
-        return assistantQuestion(missing);
+        return assistantQuestion(domainName, missing);
     }
 
     private boolean containsUnsupported(List<String> missing) {

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/StructuredCondition.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/StructuredCondition.java
@@ -86,7 +86,9 @@ public record StructuredCondition(
     }
 
     public enum Metric {
-        AVG_PRICE
+        AVG_PRICE,
+        COUNT,
+        ONGOING_COUNT
     }
 
     public enum Direction {
@@ -128,7 +130,8 @@ public record StructuredCondition(
     public enum Unit {
         PERCENT,
         MANWON,
-        EOK;
+        EOK,
+        COUNT;
 
         private static Unit from(String raw) {
             if ("만원".equals(raw)) {

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -25,12 +25,14 @@ import com.back.global.error.ErrorCode;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -49,6 +51,7 @@ public class SubscriptionConversationService {
     private static final String SUGGESTED_KEYWORD = "suggestedKeyword";
     private static final String KEYWORD_ORIGINAL = "keywordOriginal";
     private static final String DEFAULT_INTERNAL_CHECK_CRON = "0 0 * * * *";
+    private static final Pattern RECRUITMENT_COUNT_THRESHOLD = Pattern.compile("(\\d+(?:\\.\\d+)?)\\s*(?:건|개)");
     private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {
     };
 
@@ -466,6 +469,12 @@ public class SubscriptionConversationService {
             }
         }
 
+        // 채용 대상/건수 조건처럼 짧은 후속 답변은 AI JSON 파싱 실패가 잦아 로컬에서 먼저 보완한다.
+        Response recruitmentResponse = completeRecruitmentAnswerIfPossible(conversation, message, missing);
+        if (recruitmentResponse != null) {
+            return recruitmentResponse;
+        }
+
         if (missing.contains("dealType")) {
             Optional<String> dealType = parseDealTypeAnswer(message);
             if (dealType.isPresent()) {
@@ -481,6 +490,204 @@ public class SubscriptionConversationService {
         }
 
         return null;
+    }
+
+    private Response completeRecruitmentAnswerIfPossible(
+            SubscriptionConversationJpaEntity conversation,
+            String message,
+            List<String> missing
+    ) {
+        if (!isRecruitmentDraft(conversation)
+                || (!missing.contains("keyword") && !missing.contains("condition"))) {
+            return null;
+        }
+
+        Map<String, String> params = new HashMap<>(monitoringParams(conversation.getDraftMonitoringParams()));
+        boolean updated = false;
+
+        Optional<String> keyword = Optional.empty();
+        if (missing.contains("keyword")) {
+            keyword = parseRecruitmentKeywordAnswer(message);
+            if (keyword.isPresent()) {
+                clearRecruitmentKeywordValidation(params);
+                params.put("keyword", keyword.get());
+                if ("search_public_job".equals(params.getOrDefault("dataToolName", "search_public_job"))) {
+                    params.put("recrut_pbanc_ttl", keyword.get());
+                }
+                updated = true;
+            }
+        }
+
+        if (missing.contains("condition")) {
+            // 채용 조건은 가격 조건과 달리 공고 수 delta 기준 COUNT 파라미터로 저장한다.
+            Optional<Map<String, String>> condition = parseRecruitmentConditionAnswer(message);
+            if (condition.isPresent()) {
+                params.putAll(condition.get());
+                updated = true;
+            }
+        }
+
+        if (!updated) {
+            return null;
+        }
+
+        ensureRecruitmentDefaults(params);
+        String queryKeyword = keyword.orElse(params.get("keyword"));
+        updateRecruitmentParams(
+                conversation,
+                params,
+                isBlank(queryKeyword) ? conversation.getDraftQuery() : queryKeyword + " 채용 공고"
+        );
+        return completeOrAsk(conversation);
+    }
+
+    private Optional<String> parseRecruitmentKeywordAnswer(String value) {
+        if (isBlank(value)) {
+            return Optional.empty();
+        }
+
+        String candidate = value.trim();
+        int conditionStart = firstRecruitmentConditionIndex(candidate);
+        if (conditionStart >= 0) {
+            // "백엔드 전체 5건 이상 변동"처럼 대상과 조건이 한 문장에 함께 온 경우 앞부분만 검색어로 쓴다.
+            candidate = candidate.substring(0, conditionStart);
+        }
+
+        String keyword = cleanRecruitmentKeywordAnswer(candidate)
+                .replace("전체", "")
+                .replace("전부", "")
+                .replace("모든", "")
+                .replace("진행중", "")
+                .replace("진행 중", "")
+                .replaceAll("\\s+", " ")
+                .strip();
+
+        for (String prefix : List.of("공공기관 ", "공기업 ", "공공 ", "기관 ", "워크넷 ")) {
+            if (keyword.startsWith(prefix)) {
+                keyword = keyword.substring(prefix.length()).strip();
+                break;
+            }
+        }
+
+        return isBlank(keyword) ? Optional.empty() : Optional.of(keyword);
+    }
+
+    private int firstRecruitmentConditionIndex(String value) {
+        int first = value.length();
+        Matcher count = RECRUITMENT_COUNT_THRESHOLD.matcher(value);
+        if (count.find()) {
+            first = Math.min(first, count.start());
+        }
+        for (String marker : List.of(
+                "새 공고",
+                "신규 공고",
+                "진행중 공고",
+                "진행 중 공고",
+                "새로",
+                "뜨면",
+                "올라오면",
+                "등록",
+                "늘면",
+                "증가",
+                "감소",
+                "줄면",
+                "줄어",
+                "마감",
+                "변동",
+                "변화"
+        )) {
+            int index = value.indexOf(marker);
+            if (index >= 0) {
+                first = Math.min(first, index);
+            }
+        }
+        return first == value.length() ? -1 : first;
+    }
+
+    private Optional<Map<String, String>> parseRecruitmentConditionAnswer(String value) {
+        String text = value == null ? "" : value.trim();
+        Matcher count = RECRUITMENT_COUNT_THRESHOLD.matcher(text);
+        boolean hasCountThreshold = count.find();
+        if (!hasCountThreshold && !containsRecruitmentChangeWord(text)) {
+            return Optional.empty();
+        }
+
+        // 숫자가 없는 "새 공고가 올라오면" 계열은 최소 1건 증가 조건으로 해석한다.
+        String threshold = hasCountThreshold ? normalizeDecimal(count.group(1)) : "1";
+        return Optional.of(Map.of(
+                "conditionMetric", text.contains("진행중") || text.contains("진행 중") ? "ONGOING_COUNT" : "COUNT",
+                "conditionDirection", recruitmentConditionDirection(text),
+                "conditionOperator", recruitmentConditionOperator(text),
+                "conditionThreshold", threshold,
+                "conditionUnit", "COUNT"
+        ));
+    }
+
+    private boolean containsRecruitmentChangeWord(String text) {
+        return containsAny(
+                text,
+                "새 공고",
+                "신규",
+                "새로",
+                "뜨면",
+                "올라오면",
+                "등록",
+                "변화",
+                "변동",
+                "늘면",
+                "증가",
+                "마감",
+                "감소",
+                "줄면",
+                "줄어"
+        );
+    }
+
+    private String recruitmentConditionDirection(String text) {
+        if (containsAny(text, "감소", "줄면", "줄어", "마감")) {
+            return "DOWN";
+        }
+        if (containsAny(text, "새 공고", "신규", "새로", "뜨면", "올라오면", "등록", "늘면", "증가")) {
+            return "UP";
+        }
+        if (containsAny(text, "변동", "변화")) {
+            return "ANY";
+        }
+        return "UP";
+    }
+
+    private String recruitmentConditionOperator(String text) {
+        if (text.contains("미만")) {
+            return "LT";
+        }
+        if (text.contains("이하")) {
+            return "LTE";
+        }
+        if (text.contains("초과")) {
+            return "GT";
+        }
+        return "GTE";
+    }
+
+    private String normalizeDecimal(String raw) {
+        return new BigDecimal(raw).stripTrailingZeros().toPlainString();
+    }
+
+    private void ensureRecruitmentDefaults(Map<String, String> params) {
+        String toolName = params.getOrDefault("dataToolName", "search_public_job");
+        params.put("dataToolName", toolName);
+        if ("search_public_job".equals(toolName)) {
+            params.putIfAbsent("page_no", "1");
+            params.putIfAbsent("num_of_rows", "20");
+            params.putIfAbsent("ongoing_yn", "Y");
+            String keyword = params.get("keyword");
+            if (!isBlank(keyword)) {
+                params.put("recrut_pbanc_ttl", keyword);
+            }
+        } else if ("search_worknet_job".equals(toolName)) {
+            params.putIfAbsent("start_page", "1");
+            params.putIfAbsent("display", "20");
+        }
     }
 
     private List<String> missingPersistedFields(SubscriptionConversationJpaEntity conversation) {
@@ -822,6 +1029,7 @@ public class SubscriptionConversationService {
                 .replace("공고", "")
                 .replace("알려줘", "")
                 .replace("구독", "")
+                .replace("알림", "")
                 .strip();
     }
 
@@ -916,6 +1124,16 @@ public class SubscriptionConversationService {
     private boolean isRecruitmentKeywordConfirmationPending(Map<String, String> monitoringParams) {
         return ZERO_RESULTS.equals(monitoringParams.get(KEYWORD_VALIDATION_STATUS))
                 && !isBlank(monitoringParams.get(SUGGESTED_KEYWORD));
+    }
+
+    private boolean containsAny(String value, String... candidates) {
+        String text = value == null ? "" : value;
+        for (String candidate : candidates) {
+            if (text.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String lower(String value) {

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -118,6 +118,13 @@ public class SubscriptionConversationService {
                 || conversation.getStatus() == SubscriptionConversationStatus.CANCELLED) {
             return true;
         }
+        Optional<String> requestedDomain = explicitDomainFromMessage(message);
+        if (requestedDomain.isPresent()
+                && !isBlank(conversation.getDraftDomainName())
+                && !requestedDomain.get().equals(conversation.getDraftDomainName())
+                && allowsDomainSwitch(conversation, requestedDomain.get(), message)) {
+            return true;
+        }
         return isUnsupportedConversation(conversation)
                 || (isBlank(conversation.getDraftDomainName()) && isBlank(conversation.getDraftQuery()));
     }
@@ -1119,6 +1126,71 @@ public class SubscriptionConversationService {
 
     private boolean isRecruitmentDraft(SubscriptionConversationJpaEntity conversation) {
         return "recruitment".equals(conversation.getDraftDomainName());
+    }
+
+    private Optional<String> explicitDomainFromMessage(String message) {
+        String text = lower(message);
+        if (isBlank(text)) {
+            return Optional.empty();
+        }
+        int recruitmentIndex = Math.max(
+                lastIndexOfAny(text, "채용", "구인", "일자리", "워크넷"),
+                lastIndexOfEnglishWord(text, "job", "jobs", "recruitment", "recruit", "worknet")
+        );
+        int realEstateIndex = lastIndexOfAny(text, "부동산", "아파트", "매매", "전세", "월세", "실거래가", "집값", "real estate", "apartment");
+        if (recruitmentIndex < 0 && realEstateIndex < 0) {
+            return Optional.empty();
+        }
+        if (recruitmentIndex > realEstateIndex) {
+            return Optional.of("recruitment");
+        }
+        return Optional.of("real-estate");
+    }
+
+    private boolean allowsDomainSwitch(
+            SubscriptionConversationJpaEntity conversation,
+            String requestedDomain,
+            String message
+    ) {
+        if (isRecruitmentDraft(conversation)
+                && "real-estate".equals(requestedDomain)
+                && isRecruitmentKeywordConfirmationPending(monitoringParams(conversation.getDraftMonitoringParams()))) {
+            return isStrongRealEstateRequest(message);
+        }
+        return true;
+    }
+
+    private boolean isStrongRealEstateRequest(String message) {
+        String text = lower(message);
+        return containsAny(text, "부동산", "실거래가", "집값", "real estate", "house price")
+                || (containsAny(text, "아파트")
+                        && containsAny(text, "매매", "전세", "월세", "가격", "시세", "변동", "변경"));
+    }
+
+    private int lastIndexOfAny(String value, String... tokens) {
+        if (isBlank(value)) {
+            return -1;
+        }
+        int index = -1;
+        for (String token : tokens) {
+            index = Math.max(index, value.lastIndexOf(token));
+        }
+        return index;
+    }
+
+    private int lastIndexOfEnglishWord(String value, String... words) {
+        if (isBlank(value)) {
+            return -1;
+        }
+        int index = -1;
+        for (String word : words) {
+            java.util.regex.Matcher matcher = Pattern.compile("\\b" + Pattern.quote(word) + "\\b")
+                    .matcher(value);
+            while (matcher.find()) {
+                index = Math.max(index, matcher.start());
+            }
+        }
+        return index;
     }
 
     private boolean isRecruitmentKeywordConfirmationPending(Map<String, String> monitoringParams) {

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -43,6 +43,11 @@ public class SubscriptionConversationService {
 
     private static final Pattern EMAIL = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
     private static final String PENDING_DEAL_TYPE_CONFIRMATION = "pendingDealTypeConfirmation";
+    private static final String KEYWORD_CONFIRMATION = "keywordConfirmation";
+    private static final String KEYWORD_VALIDATION_STATUS = "keywordValidationStatus";
+    private static final String ZERO_RESULTS = "ZERO_RESULTS";
+    private static final String SUGGESTED_KEYWORD = "suggestedKeyword";
+    private static final String KEYWORD_ORIGINAL = "keywordOriginal";
     private static final String DEFAULT_INTERNAL_CHECK_CRON = "0 0 * * * *";
     private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {
     };
@@ -419,6 +424,10 @@ public class SubscriptionConversationService {
                 || !missingPersistedFields(conversation).contains("condition")) {
             return null;
         }
+        // 채용 조건은 COUNT 계열이므로 부동산 가격 조건 파서로 보완하지 않는다.
+        if (!isRealEstateDraft(conversation)) {
+            return null;
+        }
 
         Optional<StructuredCondition> condition = StructuredCondition.parse(message);
         if (condition.isEmpty()) {
@@ -450,6 +459,13 @@ public class SubscriptionConversationService {
             String message
     ) {
         List<String> missing = missingPersistedFields(conversation);
+        if (missing.contains(KEYWORD_CONFIRMATION)) {
+            Response response = completeKeywordConfirmationIfPossible(conversation, message);
+            if (response != null) {
+                return response;
+            }
+        }
+
         if (missing.contains("dealType")) {
             Optional<String> dealType = parseDealTypeAnswer(message);
             if (dealType.isPresent()) {
@@ -488,7 +504,15 @@ public class SubscriptionConversationService {
         if (requiresApartmentDealType(conversation)) {
             missing.add("dealType");
         }
-        if (StructuredCondition.fromParameters(monitoringParams(conversation.getDraftMonitoringParams())).isEmpty()) {
+        Map<String, String> monitoringParams = monitoringParams(conversation.getDraftMonitoringParams());
+        // 저장된 draft에는 MCP missingFields가 남지 않으므로 채용 필수 키워드를 다시 검증한다.
+        if (isRecruitmentKeywordConfirmationPending(monitoringParams)) {
+            missing.add(KEYWORD_CONFIRMATION);
+        }
+        if (isRecruitmentDraft(conversation) && isBlank(monitoringParams.get("keyword"))) {
+            missing.add("keyword");
+        }
+        if (StructuredCondition.fromParameters(monitoringParams).isEmpty()) {
             missing.add("condition");
         }
         if (conversation.getDraftDomainId() == null
@@ -617,10 +641,23 @@ public class SubscriptionConversationService {
     }
 
     private String questionForMissing(List<String> missing, SubscriptionConversationJpaEntity conversation) {
+        if (missing.contains(KEYWORD_CONFIRMATION)) {
+            Map<String, String> params = monitoringParams(conversation.getDraftMonitoringParams());
+            String keyword = params.getOrDefault(KEYWORD_ORIGINAL, params.get("keyword"));
+            String suggestedKeyword = params.get(SUGGESTED_KEYWORD);
+            return "현재 '" + keyword + "' 검색 결과가 없어요. '" + suggestedKeyword
+                    + "'를 뜻한 걸까요? 맞으면 '응', 아니면 원하는 채용 검색어를 다시 입력해 주세요.";
+        }
+        if (missing.contains("keyword") && isRecruitmentDraft(conversation)) {
+            return "어떤 채용 공고를 구독할까요? 예: 백엔드, 데이터, 공공기관 인턴 등";
+        }
         if (missing.contains("dealType")) {
             return "아파트 가격은 매매/전세/월세 중 어떤 기준인가요? 현재는 매매 실거래가 알림만 만들 수 있어요.";
         }
         if (missing.contains("condition")) {
+            if (isRecruitmentDraft(conversation)) {
+                return "어떤 채용 공고 변화가 생기면 알림을 받을까요? 예: 새 공고 1건 이상 등록 등";
+            }
             return "어떤 가격 변동 조건 시 알림을 받으시겠어요? 예: 5% 이상 상승, 50만원 이상 변동 등";
         }
         if (missing.contains("notificationChannel")) {
@@ -677,6 +714,115 @@ public class SubscriptionConversationService {
 
     private boolean isEmail(String value) {
         return !isBlank(value) && EMAIL.matcher(value.trim()).matches();
+    }
+
+    private Response completeKeywordConfirmationIfPossible(
+            SubscriptionConversationJpaEntity conversation,
+            String message
+    ) {
+        Map<String, String> params = new HashMap<>(monitoringParams(conversation.getDraftMonitoringParams()));
+        String suggestedKeyword = params.get(SUGGESTED_KEYWORD);
+        if (isBlank(suggestedKeyword)) {
+            return null;
+        }
+
+        Optional<Boolean> accepted = parseKeywordConfirmationAnswer(message);
+        if (accepted.isPresent()) {
+            if (accepted.get()) {
+                return updateRecruitmentKeywordAndComplete(conversation, params, suggestedKeyword);
+            }
+            clearRecruitmentKeyword(params);
+            updateRecruitmentParams(conversation, params, "채용 공고");
+            return completeOrAsk(conversation);
+        }
+
+        String replacement = cleanRecruitmentKeywordAnswer(message);
+        if (isBlank(replacement)) {
+            return null;
+        }
+        return updateRecruitmentKeywordAndComplete(conversation, params, replacement);
+    }
+
+    private Response updateRecruitmentKeywordAndComplete(
+            SubscriptionConversationJpaEntity conversation,
+            Map<String, String> params,
+            String keyword
+    ) {
+        clearRecruitmentKeywordValidation(params);
+        params.put("keyword", keyword);
+        if ("search_public_job".equals(params.get("dataToolName"))) {
+            params.put("recrut_pbanc_ttl", keyword);
+        }
+        updateRecruitmentParams(conversation, params, keyword + " 채용 공고");
+        return completeOrAsk(conversation);
+    }
+
+    private void updateRecruitmentParams(
+            SubscriptionConversationJpaEntity conversation,
+            Map<String, String> params,
+            String query
+    ) {
+        conversation.updateParsedDraft(
+                conversation.getParseSessionId(),
+                query,
+                conversation.getDraftDomainId(),
+                conversation.getDraftDomainName(),
+                conversation.getDraftIntent(),
+                conversation.getDraftToolName(),
+                toJson(params),
+                conversation.getDraftCronExpr(),
+                conversation.getDraftNotificationChannel(),
+                conversation.getDraftNotificationTargetAddress(),
+                conversation.getLastAssistantMessage(),
+                conversation.getStatus()
+        );
+    }
+
+    private void clearRecruitmentKeyword(Map<String, String> params) {
+        params.remove("keyword");
+        params.remove("recrut_pbanc_ttl");
+        clearRecruitmentKeywordValidation(params);
+    }
+
+    private void clearRecruitmentKeywordValidation(Map<String, String> params) {
+        params.remove(KEYWORD_VALIDATION_STATUS);
+        params.remove(KEYWORD_ORIGINAL);
+        params.remove(SUGGESTED_KEYWORD);
+    }
+
+    private Optional<Boolean> parseKeywordConfirmationAnswer(String value) {
+        String text = lower(value).trim();
+        if (text.isBlank()) {
+            return Optional.empty();
+        }
+        if (text.equals("y")
+                || text.equals("yes")
+                || text.contains("응")
+                || text.contains("네")
+                || text.contains("맞")
+                || text.contains("좋아")) {
+            return Optional.of(true);
+        }
+        if (text.equals("n")
+                || text.equals("no")
+                || text.contains("아니")
+                || text.contains("아님")
+                || text.contains("틀려")) {
+            return Optional.of(false);
+        }
+        return Optional.empty();
+    }
+
+    private String cleanRecruitmentKeywordAnswer(String value) {
+        if (isBlank(value)) {
+            return "";
+        }
+        return value.trim()
+                .replace("채용", "")
+                .replace("공고", "")
+                .replace("알려줘", "")
+                .replace("구독", "")
+                .strip();
     }
 
     private Optional<String> parseDealTypeAnswer(String value) {
@@ -757,6 +903,19 @@ public class SubscriptionConversationService {
                 || text.contains("실거래가")
                 || text.contains("변경")
                 || text.contains("변동");
+    }
+
+    private boolean isRealEstateDraft(SubscriptionConversationJpaEntity conversation) {
+        return "real-estate".equals(conversation.getDraftDomainName());
+    }
+
+    private boolean isRecruitmentDraft(SubscriptionConversationJpaEntity conversation) {
+        return "recruitment".equals(conversation.getDraftDomainName());
+    }
+
+    private boolean isRecruitmentKeywordConfirmationPending(Map<String, String> monitoringParams) {
+        return ZERO_RESULTS.equals(monitoringParams.get(KEYWORD_VALIDATION_STATUS))
+                && !isBlank(monitoringParams.get(SUGGESTED_KEYWORD));
     }
 
     private String lower(String value) {

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -504,8 +504,9 @@ public class SubscriptionConversationService {
             String message,
             List<String> missing
     ) {
+        boolean askedRecruitmentCondition = askedRecruitmentCondition(conversation);
         if (!isRecruitmentDraft(conversation)
-                || (!missing.contains("keyword") && !missing.contains("condition"))) {
+                || (!missing.contains("keyword") && !missing.contains("condition") && !askedRecruitmentCondition)) {
             return null;
         }
 
@@ -525,13 +526,19 @@ public class SubscriptionConversationService {
             }
         }
 
-        if (missing.contains("condition")) {
+        Optional<Map<String, String>> condition = Optional.empty();
+        if (missing.contains("condition") || askedRecruitmentCondition) {
             // 채용 조건은 가격 조건과 달리 공고 수 delta 기준 COUNT 파라미터로 저장한다.
-            Optional<Map<String, String>> condition = parseRecruitmentConditionAnswer(message);
+            condition = parseRecruitmentConditionAnswer(message);
             if (condition.isPresent()) {
                 params.putAll(condition.get());
                 updated = true;
             }
+        }
+
+        if (keyword.isPresent() && askedRecruitmentCondition && condition.isEmpty()) {
+            // 조건을 함께 물은 턴에서는 대상만 답한 값을 기존 기본 조건 확정으로 취급하지 않는다.
+            clearRecruitmentCondition(params);
         }
 
         if (!updated) {
@@ -546,6 +553,14 @@ public class SubscriptionConversationService {
                 isBlank(queryKeyword) ? conversation.getDraftQuery() : queryKeyword + " 채용 공고"
         );
         return completeOrAsk(conversation);
+    }
+
+    private boolean askedRecruitmentCondition(SubscriptionConversationJpaEntity conversation) {
+        if (!isRecruitmentDraft(conversation)) {
+            return false;
+        }
+        String message = conversation.getLastAssistantMessage();
+        return containsAny(message, "어떤 조건", "조건으로", "조건일 때", "채용 공고 변화");
     }
 
     private Optional<String> parseRecruitmentKeywordAnswer(String value) {
@@ -1002,6 +1017,15 @@ public class SubscriptionConversationService {
         params.remove(KEYWORD_VALIDATION_STATUS);
         params.remove(KEYWORD_ORIGINAL);
         params.remove(SUGGESTED_KEYWORD);
+    }
+
+    private void clearRecruitmentCondition(Map<String, String> params) {
+        params.remove("condition");
+        params.remove("conditionMetric");
+        params.remove("conditionDirection");
+        params.remove("conditionOperator");
+        params.remove("conditionThreshold");
+        params.remove("conditionUnit");
     }
 
     private Optional<Boolean> parseKeywordConfirmationAnswer(String value) {

--- a/back/src/test/java/com/back/domain/adapter/out/ai/PromptTemplateTest.java
+++ b/back/src/test/java/com/back/domain/adapter/out/ai/PromptTemplateTest.java
@@ -92,6 +92,20 @@ class PromptTemplateTest {
                 .contains("structured.requires_ai_analysis=false")
                 .contains("AI 분석과 AI 브리핑을 생성하지 마세요")
                 .contains("structured.requires_ai_analysis=true")
+                .contains("structured.condition_satisfied=true")
                 .contains("AI 브리핑");
+    }
+
+    @Test
+    @DisplayName("구독 실행 프롬프트는 채용 신규 공고 제목과 링크를 출처별로 브리핑하게 한다")
+    void subscriptionExecutionPromptSeparatesRecruitmentBriefingPostingsBySource() {
+        assertThat(PromptTemplate.SUBSCRIPTION_EXECUTION_SYSTEM_PROMPT)
+                .contains("briefing_postings_by_source")
+                .contains("public_job")
+                .contains("worknet_job")
+                .contains("공공채용")
+                .contains("워크넷")
+                .contains("제목")
+                .contains("링크");
     }
 }

--- a/back/src/test/java/com/back/domain/adapter/out/ai/PromptTemplateTest.java
+++ b/back/src/test/java/com/back/domain/adapter/out/ai/PromptTemplateTest.java
@@ -100,12 +100,14 @@ class PromptTemplateTest {
     @DisplayName("구독 실행 프롬프트는 채용 신규 공고 제목과 링크를 출처별로 브리핑하게 한다")
     void subscriptionExecutionPromptSeparatesRecruitmentBriefingPostingsBySource() {
         assertThat(PromptTemplate.SUBSCRIPTION_EXECUTION_SYSTEM_PROMPT)
+                .contains("current.sources")
                 .contains("briefing_postings_by_source")
                 .contains("public_job")
                 .contains("worknet_job")
                 .contains("공공채용")
                 .contains("워크넷")
                 .contains("제목")
-                .contains("링크");
+                .contains("링크")
+                .contains("권한 거부");
     }
 }

--- a/back/src/test/java/com/back/domain/adapter/out/ai/PromptTemplateTest.java
+++ b/back/src/test/java/com/back/domain/adapter/out/ai/PromptTemplateTest.java
@@ -9,6 +9,39 @@ import org.junit.jupiter.api.Test;
 class PromptTemplateTest {
 
     @Test
+    @DisplayName("파서 프롬프트는 채용 새 공고 조건을 1건 이상 증가 조건으로 해석하게 한다")
+    void parserPromptNormalizesRecruitmentNewPostingCondition() {
+        assertThat(PromptTemplate.SYSTEM_PROMPT)
+                .contains("채용 도메인")
+                .contains("새 공고")
+                .contains("1건 이상 증가")
+                .contains("needs_confirmation을 false")
+                .contains("진행중 공고")
+                .contains("진행중 공고 1건 이상 증가");
+    }
+
+    @Test
+    @DisplayName("파서 프롬프트는 채용 query와 target에 시간/채널 문구를 섞지 않게 한다")
+    void parserPromptKeepsRecruitmentQueryFocusedOnSearchTarget() {
+        assertThat(PromptTemplate.SYSTEM_PROMPT)
+                .contains("채용 query")
+                .contains("검색 키워드")
+                .contains("시간")
+                .contains("채널")
+                .contains("섞지 마");
+    }
+
+    @Test
+    @DisplayName("후속 파서 프롬프트는 채용 조건 답변도 1건 이상 증가 조건으로 보정한다")
+    void continuePromptNormalizesRecruitmentConditionAnswers() {
+        assertThat(PromptTemplate.CONTINUE_SYSTEM_PROMPT)
+                .contains("채용")
+                .contains("새 공고")
+                .contains("1건 이상 증가")
+                .contains("needs_confirmation을 false");
+    }
+
+    @Test
     @DisplayName("구독 실행 프롬프트는 MCP 알림 발송 도구 호출 계약을 포함한다")
     void subscriptionExecutionPromptRequiresSendNotificationTool() {
         assertThat(PromptTemplate.SUBSCRIPTION_EXECUTION_SYSTEM_PROMPT)

--- a/back/src/test/java/com/back/domain/application/service/CreateSubscriptionServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/CreateSubscriptionServiceTest.java
@@ -131,6 +131,44 @@ class CreateSubscriptionServiceTest {
     }
 
     @Test
+    @DisplayName("Application: 채용 구독도 기존 구독 시작 알림을 생성한다")
+    void createsRecruitmentSubscriptionStartedDelivery() {
+        User user = new User(1L, "user@example.com", "사용자", LocalDateTime.now(), null);
+        Domain domain = new Domain(3L, "recruitment");
+        FakeSaveNotificationDeliveryPort saveDeliveryPort = new FakeSaveNotificationDeliveryPort();
+        CreateSubscriptionService service = new CreateSubscriptionService(
+                new FakeLoadUserPort(user),
+                new FakeLoadDomainPort(domain),
+                new NoDuplicateSubscriptionPort(),
+                new FakeSaveSubscriptionPort(),
+                new FakeSaveSchedulePort(),
+                (endpointUserId, channel) -> Optional.empty(),
+                endpoint -> endpoint,
+                preference -> preference,
+                saveDeliveryPort,
+                new SubscriptionNotificationMessageFormatter()
+        );
+
+        service.createForUser(user.id(), new CreateSubscriptionCommand(
+                domain.id(),
+                "백엔드 채용 새 공고",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                "123456789"
+        ));
+
+        assertThat(saveDeliveryPort.saved.channel()).isEqualTo(NotificationChannel.TELEGRAM_DM);
+        assertThat(saveDeliveryPort.saved.recipient()).isEqualTo("123456789");
+        assertThat(saveDeliveryPort.saved.title()).isEqualTo("알림 설정이 완료됐어요");
+        assertThat(saveDeliveryPort.saved.message()).contains(
+                "요청: 백엔드 채용 새 공고",
+                "감시 영역: 채용",
+                "알림 방식: 변화 감지 시"
+        );
+        assertThat(saveDeliveryPort.saved.status()).isEqualTo(NotificationDeliveryStatus.PENDING);
+    }
+
+    @Test
     @DisplayName("Application: Discord 알림 구독은 Markdown 카드형 시작 알림을 생성한다")
     void createsDiscordOptimizedSubscriptionStartedDelivery() {
         User user = new User(1L, "user@example.com", "사용자", LocalDateTime.now(), null);

--- a/back/src/test/java/com/back/domain/application/service/SubscriptionMonitorServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/SubscriptionMonitorServiceTest.java
@@ -1,0 +1,92 @@
+package com.back.domain.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.back.domain.application.port.out.SaveSchedulePort;
+import com.back.domain.application.port.out.RunSubscriptionExecutionPort;
+import com.back.domain.model.domain.Domain;
+import com.back.domain.model.schedule.Schedule;
+import com.back.domain.model.subscription.Subscription;
+import com.back.domain.model.subscription.SubscriptionMonitoringConfig;
+import com.back.domain.model.user.User;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Application: 구독 모니터링 실행 위임 서비스")
+class SubscriptionMonitorServiceTest {
+
+    @Test
+    @DisplayName("Spring AI 실행 context는 최신월 부동산 정책을 deal_ymd로 보정한다")
+    void realEstateContextAddsLatestAvailableDealYmd() {
+        User user = new User(1L, "user@example.com", "사용자", LocalDateTime.now(), null);
+        Domain domain = new Domain(10L, "real-estate");
+        Subscription subscription = new Subscription(
+                "sub-1",
+                user,
+                domain,
+                "강남구 아파트 매매",
+                "apartment_trade_price",
+                true,
+                LocalDateTime.now()
+        );
+        Schedule dueSchedule = new Schedule(
+                "schedule-1",
+                subscription,
+                "0 0 9 * * *",
+                null,
+                LocalDateTime.now().minusMinutes(1)
+        );
+        CapturingSubscriptionExecutionPort executionPort = new CapturingSubscriptionExecutionPort();
+        CapturingSaveSchedulePort saveSchedulePort = new CapturingSaveSchedulePort();
+        SubscriptionMonitorService service = new SubscriptionMonitorService(
+                now -> List.of(dueSchedule),
+                subscriptionId -> Optional.of(new SubscriptionMonitoringConfig(
+                        subscriptionId,
+                        null,
+                        "apartment_trade_price",
+                        "{\"region\":\"강남구\",\"dealYmdPolicy\":\"LATEST_AVAILABLE_MONTH\"}"
+                )),
+                subscriptionId -> List.of(),
+                (userId, channel) -> Optional.empty(),
+                saveSchedulePort,
+                executionPort
+        );
+
+        service.runAll();
+
+        assertThat(executionPort.contexts).hasSize(1);
+        assertThat(executionPort.contexts.get(0).params())
+                .containsEntry("region", "강남구")
+                .containsEntry("deal_ymd", latestAvailableDealYmd());
+        assertThat(saveSchedulePort.savedSchedule).isNotNull();
+    }
+
+    private static String latestAvailableDealYmd() {
+        return LocalDateTime.now().minusMonths(1).format(DateTimeFormatter.ofPattern("yyyyMM"));
+    }
+
+    private static class CapturingSubscriptionExecutionPort implements RunSubscriptionExecutionPort {
+        private final List<SubscriptionContext> contexts = new ArrayList<>();
+
+        @Override
+        public void execute(List<SubscriptionContext> subscriptions) {
+            contexts.clear();
+            contexts.addAll(subscriptions);
+        }
+    }
+
+    private static class CapturingSaveSchedulePort implements SaveSchedulePort {
+        private Schedule savedSchedule;
+
+        @Override
+        public Schedule save(Schedule schedule) {
+            savedSchedule = schedule;
+            return schedule;
+        }
+    }
+}

--- a/back/src/test/java/com/back/domain/application/service/dev/DevSubscriptionChangeSimulationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/dev/DevSubscriptionChangeSimulationServiceTest.java
@@ -243,6 +243,144 @@ class DevSubscriptionChangeSimulationServiceTest {
     }
 
     @Test
+    @DisplayName("Application: 채용 구독 테스트 발송은 공공채용 공고 fake 데이터를 만들어 AI 브리핑에 전달한다")
+    void simulatesPublicJobChangeAlertWithRecruitmentPostings() {
+        User user = new User(1L, "user@example.com", "사용자", LocalDateTime.now(), null);
+        Subscription subscription = new Subscription(
+                "sub-1",
+                user,
+                new Domain(3L, "recruitment"),
+                "백엔드 채용 새 공고",
+                "job_posting_change",
+                true,
+                LocalDateTime.now()
+        );
+        DeliveryStore deliveryStore = new DeliveryStore();
+        FakeGenerateMonitoringBriefingPort briefingPort =
+                new FakeGenerateMonitoringBriefingPort("[AI 변화 브리핑] 백엔드 채용 새 공고가 감지되었습니다.");
+        DevSubscriptionChangeSimulationService service = newService(
+                (subscriptionId, userId) -> Optional.of(subscription),
+                subscriptionId -> Optional.of(new SubscriptionMonitoringConfig(
+                        subscriptionId,
+                        "search_public_job",
+                        "job_posting_change",
+                        """
+                                {
+                                  "dataToolName": "search_public_job",
+                                  "keyword": "백엔드",
+                                  "conditionMetric": "COUNT",
+                                  "conditionDirection": "UP",
+                                  "conditionOperator": "GTE",
+                                  "conditionThreshold": "1",
+                                  "conditionUnit": "COUNT"
+                                }
+                                """
+                )),
+                briefingPort,
+                deliveryStore
+        );
+
+        DevSubscriptionChangeSimulationResult result = service.simulate(
+                "sub-1",
+                1L,
+                LocalDateTime.of(2026, 4, 29, 9, 30)
+        );
+
+        assertThat(result.triggered()).isTrue();
+        assertThat(result.metricKey()).isEqualTo("count");
+        assertThat(briefingPort.requests).singleElement()
+                .satisfies(request -> {
+                    assertThat(request.toolName()).isEqualTo("search_public_job");
+                    assertThat(request.previousSummaryJson())
+                            .contains("\"count\":10")
+                            .contains("\"postings\"")
+                            .doesNotContain("avg_deal_amount");
+                    assertThat(request.currentSummaryJson())
+                            .contains("\"count\":11")
+                            .contains("\"postings\"")
+                            .contains("\"pblnt_sn\":2026042901")
+                            .contains("한국데이터산업진흥원 백엔드 개발자 채용")
+                            .contains("https://public.example/jobs/2026042901")
+                            .doesNotContain("avg_deal_amount");
+                    assertThat(request.mcpContent())
+                            .contains("공공채용")
+                            .contains("한국데이터산업진흥원 백엔드 개발자 채용")
+                            .contains("https://public.example/jobs/2026042901")
+                            .doesNotContain("워크넷", "avg_deal_amount");
+                });
+        assertThat(deliveryStore.saved).singleElement()
+                .satisfies(delivery -> assertThat(delivery.message()).contains("백엔드 채용 새 공고가 감지되었습니다."));
+    }
+
+    @Test
+    @DisplayName("Application: 채용 구독 테스트 발송은 워크넷 진행중 공고 fake 데이터를 만들어 AI 브리핑에 전달한다")
+    void simulatesWorknetOngoingJobChangeAlertWithRecruitmentPostings() {
+        User user = new User(1L, "user@example.com", "사용자", LocalDateTime.now(), null);
+        Subscription subscription = new Subscription(
+                "sub-1",
+                user,
+                new Domain(3L, "recruitment"),
+                "백엔드 워크넷 진행중 공고",
+                "job_posting_change",
+                true,
+                LocalDateTime.now()
+        );
+        DeliveryStore deliveryStore = new DeliveryStore();
+        FakeGenerateMonitoringBriefingPort briefingPort =
+                new FakeGenerateMonitoringBriefingPort("[AI 변화 브리핑] 워크넷 진행중 공고가 감지되었습니다.");
+        DevSubscriptionChangeSimulationService service = newService(
+                (subscriptionId, userId) -> Optional.of(subscription),
+                subscriptionId -> Optional.of(new SubscriptionMonitoringConfig(
+                        subscriptionId,
+                        "search_worknet_job",
+                        "job_posting_change",
+                        """
+                                {
+                                  "dataToolName": "search_worknet_job",
+                                  "keyword": "백엔드",
+                                  "conditionMetric": "ONGOING_COUNT",
+                                  "conditionDirection": "UP",
+                                  "conditionOperator": "GTE",
+                                  "conditionThreshold": "1",
+                                  "conditionUnit": "COUNT"
+                                }
+                                """
+                )),
+                briefingPort,
+                deliveryStore
+        );
+
+        DevSubscriptionChangeSimulationResult result = service.simulate(
+                "sub-1",
+                1L,
+                LocalDateTime.of(2026, 4, 29, 9, 30)
+        );
+
+        assertThat(result.triggered()).isTrue();
+        assertThat(result.metricKey()).isEqualTo("ongoing_count");
+        assertThat(briefingPort.requests).singleElement()
+                .satisfies(request -> {
+                    assertThat(request.toolName()).isEqualTo("search_worknet_job");
+                    assertThat(request.previousSummaryJson())
+                            .contains("\"ongoing_count\":3")
+                            .contains("\"postings\"")
+                            .doesNotContain("avg_deal_amount");
+                    assertThat(request.currentSummaryJson())
+                            .contains("\"ongoing_count\":4")
+                            .contains("\"postings\"")
+                            .contains("\"wanted_auth_no\":\"K120032604290001\"")
+                            .contains("워크넷 백엔드 개발자")
+                            .contains("https://work.example/jobs/K120032604290001")
+                            .doesNotContain("avg_deal_amount");
+                    assertThat(request.mcpContent())
+                            .contains("워크넷")
+                            .contains("워크넷 백엔드 개발자")
+                            .contains("https://work.example/jobs/K120032604290001")
+                            .doesNotContain("공공채용", "avg_deal_amount");
+                });
+    }
+
+    @Test
     @DisplayName("Application: 현재 로그인 사용자 소유 구독이 아니면 시뮬레이션을 거부한다")
     void rejectsSubscriptionOwnedByAnotherUser() {
         DeliveryStore deliveryStore = new DeliveryStore();

--- a/back/src/test/java/com/back/domain/application/service/monitoring/MonitoringChangeDetectorTest.java
+++ b/back/src/test/java/com/back/domain/application/service/monitoring/MonitoringChangeDetectorTest.java
@@ -37,6 +37,48 @@ class MonitoringChangeDetectorTest {
     }
 
     @Test
+    @DisplayName("Application: 채용 공고 수가 조건 이상 증가하면 알림 대상으로 판단한다")
+    void detectsRecruitmentCountIncrease() throws Exception {
+        JsonNode previous = objectMapper.readTree("{\"count\":10,\"ongoing_count\":4}");
+        JsonNode current = objectMapper.readTree("{\"count\":11,\"ongoing_count\":4}");
+
+        MonitoringChangeDecision decision = detector.detect(previous, current, Map.of(
+                "conditionMetric", "COUNT",
+                "conditionDirection", "UP",
+                "conditionOperator", "GTE",
+                "conditionThreshold", "1",
+                "conditionUnit", "COUNT"
+        ));
+
+        assertThat(decision.triggered()).isTrue();
+        assertThat(decision.metricKey()).isEqualTo("count");
+        assertThat(decision.previousValue()).isEqualByComparingTo(new BigDecimal("10"));
+        assertThat(decision.currentValue()).isEqualByComparingTo(new BigDecimal("11"));
+        assertThat(decision.changeValue()).isEqualByComparingTo(new BigDecimal("1"));
+    }
+
+    @Test
+    @DisplayName("Application: 진행중 채용 공고 수가 조건 이상 증가하면 알림 대상으로 판단한다")
+    void detectsRecruitmentOngoingCountIncrease() throws Exception {
+        JsonNode previous = objectMapper.readTree("{\"count\":10,\"ongoing_count\":2}");
+        JsonNode current = objectMapper.readTree("{\"count\":10,\"ongoing_count\":3}");
+
+        MonitoringChangeDecision decision = detector.detect(previous, current, Map.of(
+                "conditionMetric", "ONGOING_COUNT",
+                "conditionDirection", "UP",
+                "conditionOperator", "GTE",
+                "conditionThreshold", "1",
+                "conditionUnit", "COUNT"
+        ));
+
+        assertThat(decision.triggered()).isTrue();
+        assertThat(decision.metricKey()).isEqualTo("ongoing_count");
+        assertThat(decision.previousValue()).isEqualByComparingTo(new BigDecimal("2"));
+        assertThat(decision.currentValue()).isEqualByComparingTo(new BigDecimal("3"));
+        assertThat(decision.changeValue()).isEqualByComparingTo(new BigDecimal("1"));
+    }
+
+    @Test
     @DisplayName("Application: 가격 필드가 없으면 거래 건수 변화만으로 가격 조건을 트리거하지 않는다")
     void ignoresCountChangeForAveragePriceCondition() throws Exception {
         JsonNode previous = objectMapper.readTree("{\"count\":10}");

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/DomainCapabilityRegistryTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/DomainCapabilityRegistryTest.java
@@ -6,12 +6,12 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Application: subscription conversation capability registry")
+@DisplayName("Application: 구독 대화 도메인 기능 registry")
 class DomainCapabilityRegistryTest {
 
     @Test
-    @DisplayName("only real-estate apartment trade price is enabled")
-    void onlyRealEstateApartmentTradePriceIsEnabled() {
+    @DisplayName("부동산과 채용 구독 intent는 활성화되어 있다")
+    void realEstateAndRecruitmentSubscriptionIntentsAreEnabled() {
         DomainCapabilityRegistry registry = new DomainCapabilityRegistry();
 
         assertThat(registry.requireDomain("real-estate").status())
@@ -23,16 +23,26 @@ class DomainCapabilityRegistryTest {
                 "apartment_trade_price",
                 Map.of()
         )).containsExactly("region");
+
+        assertThat(registry.requireDomain("recruitment").status())
+                .isEqualTo(DomainCapabilityRegistry.SupportStatus.ENABLED);
+        assertThat(registry.requireIntent("recruitment", "job_posting_change").toolName())
+                .isNull();
+        assertThat(registry.requireIntent("recruitment", "job_posting_change").defaults())
+                .containsEntry("dataToolName", "search_public_job");
+        assertThat(registry.missingRequiredParameters(
+                "recruitment",
+                "job_posting_change",
+                Map.of()
+        )).isEmpty();
     }
 
     @Test
-    @DisplayName("law recruitment and auction are planned but not creatable")
-    void otherPromptDomainsArePlanned() {
+    @DisplayName("법률과 경매는 기획 상태라 구독 생성 대상이 아니다")
+    void lawAndAuctionArePlanned() {
         DomainCapabilityRegistry registry = new DomainCapabilityRegistry();
 
         assertThat(registry.requireDomain("law-regulation").status())
-                .isEqualTo(DomainCapabilityRegistry.SupportStatus.PLANNED);
-        assertThat(registry.requireDomain("recruitment").status())
                 .isEqualTo(DomainCapabilityRegistry.SupportStatus.PLANNED);
         assertThat(registry.requireDomain("auction").status())
                 .isEqualTo(DomainCapabilityRegistry.SupportStatus.PLANNED);

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/ParsedTaskNormalizerTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/ParsedTaskNormalizerTest.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Application: ParsedTask normalizer")
+@DisplayName("Application: ParsedTask 정규화 테스트")
 class ParsedTaskNormalizerTest {
 
     @Test
-    @DisplayName("does not fallback to backend domain parsing when MCP normalization is unavailable")
+    @DisplayName("MCP 정규화가 불가능하면 백엔드 도메인 파싱으로 fallback하지 않는다")
     void doesNotFallbackWhenMcpNormalizationIsUnavailable() {
         NormalizeSubscriptionDraftPort mcpNormalizer = (task, userMessage, previousDraft) -> Optional.empty();
         ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(mcpNormalizer);
@@ -32,7 +32,7 @@ class ParsedTaskNormalizerTest {
     }
 
     @Test
-    @DisplayName("merges MCP domain draft with internal check schedule and explicitly mentioned channel")
+    @DisplayName("MCP 도메인 초안에 내부 확인 주기와 명시 채널을 합성한다")
     void mergesMcpDomainDraftWithExplicitConversationFields() {
         ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(returning(domainDraft(
                 "강남구 아파트 매매 실거래가",
@@ -65,7 +65,7 @@ class ParsedTaskNormalizerTest {
     }
 
     @Test
-    @DisplayName("keeps MCP missing fields and does not accept parser default channel")
+    @DisplayName("MCP missing field를 유지하고 파서 기본 채널은 확정하지 않는다")
     void ignoresImplicitDefaultChannel() {
         ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(returning(domainDraft(
                 "강남구 아파트 매매 실거래가",
@@ -85,7 +85,7 @@ class ParsedTaskNormalizerTest {
     }
 
     @Test
-    @DisplayName("uses internal check schedule instead of asking for cadence")
+    @DisplayName("사용자에게 주기를 묻지 않고 내부 확인 주기를 사용한다")
     void usesInternalCheckScheduleInsteadOfAskingForCadence() {
         ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(returning(domainDraft(
                 "강남구 아파트 매매 실거래가",
@@ -107,7 +107,30 @@ class ParsedTaskNormalizerTest {
     }
 
     @Test
-    @DisplayName("reuses previous channel when MCP keeps the same domain")
+    @DisplayName("MCP 질문이 없으면 채용 전용 fallback 질문을 사용한다")
+    void usesRecruitmentFallbackQuestionWhenMcpQuestionIsBlank() {
+        ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(returning(new DomainNormalizedSubscriptionDraft(
+                "채용 알려줘",
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                Map.of("dataToolName", "search_public_job"),
+                List.of("keyword", "condition"),
+                "",
+                0.91
+        )));
+
+        SubscriptionDraft draft = normalizer.normalize(
+                recruitmentTask("채용 알려줘", ""),
+                "채용 알려줘"
+        );
+
+        assertThat(draft.assistantMessage()).contains("어떤 채용 공고");
+        assertThat(draft.assistantMessage()).doesNotContain("가격");
+    }
+
+    @Test
+    @DisplayName("MCP 결과가 같은 도메인이면 이전 채널을 재사용한다")
     void reusesPreviousConversationFieldsForSameDomain() {
         ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(returning(domainDraft(
                 "강남구 아파트 매매 실거래가",
@@ -150,7 +173,7 @@ class ParsedTaskNormalizerTest {
     }
 
     @Test
-    @DisplayName("does not append channel question for unsupported MCP drafts")
+    @DisplayName("지원하지 않는 MCP 초안에는 채널 질문을 덧붙이지 않는다")
     void doesNotAppendConversationFieldsForUnsupportedDrafts() {
         ParsedTaskNormalizer normalizer = new ParsedTaskNormalizer(returning(new DomainNormalizedSubscriptionDraft(
                 "강남구 아파트 전세",
@@ -205,6 +228,23 @@ class ParsedTaskNormalizerTest {
                 condition,
                 "0 9 * * *",
                 "telegram",
+                "api",
+                query,
+                List.of(),
+                0.9,
+                false,
+                ""
+        );
+    }
+
+    private ParsedTask recruitmentTask(String query, String condition) {
+        return new ParsedTask(
+                "create",
+                "채용",
+                query,
+                condition,
+                "",
+                "",
                 "api",
                 query,
                 List.of(),

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/StructuredConditionTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/StructuredConditionTest.java
@@ -2,15 +2,16 @@ package com.back.domain.application.service.subscriptionconversation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("Application: structured monitoring condition")
+@DisplayName("Application: 구조화된 모니터링 조건 테스트")
 class StructuredConditionTest {
 
     @Test
-    @DisplayName("parses percent rise condition into canonical fields")
+    @DisplayName("퍼센트 상승 조건을 표준 필드로 파싱한다")
     void parsesPercentRiseCondition() {
         Optional<StructuredCondition> parsed = StructuredCondition.parse("5% 이상 상승");
 
@@ -24,8 +25,48 @@ class StructuredConditionTest {
     }
 
     @Test
-    @DisplayName("rejects vague condition without numeric threshold")
+    @DisplayName("숫자 기준값이 없는 모호한 조건은 거부한다")
     void rejectsVagueCondition() {
         assertThat(StructuredCondition.parse("오르면 알려줘")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("채용 공고 수 조건 파라미터를 허용한다")
+    void acceptsRecruitmentCountConditionParameters() {
+        Optional<StructuredCondition> parsed = StructuredCondition.fromParameters(Map.of(
+                "conditionMetric", "COUNT",
+                "conditionDirection", "UP",
+                "conditionOperator", "GTE",
+                "conditionThreshold", "1",
+                "conditionUnit", "COUNT"
+        ));
+
+        assertThat(parsed).isPresent();
+        assertThat(parsed.get().metric()).isEqualTo(StructuredCondition.Metric.COUNT);
+        assertThat(parsed.get().unit()).isEqualTo(StructuredCondition.Unit.COUNT);
+        assertThat(parsed.get().toParameterMap())
+                .containsEntry("conditionMetric", "COUNT")
+                .containsEntry("conditionThreshold", "1")
+                .containsEntry("conditionUnit", "COUNT");
+    }
+
+    @Test
+    @DisplayName("채용 진행중 공고 수 조건 파라미터를 허용한다")
+    void acceptsRecruitmentOngoingCountConditionParameters() {
+        Optional<StructuredCondition> parsed = StructuredCondition.fromParameters(Map.of(
+                "conditionMetric", "ONGOING_COUNT",
+                "conditionDirection", "UP",
+                "conditionOperator", "GTE",
+                "conditionThreshold", "2",
+                "conditionUnit", "COUNT"
+        ));
+
+        assertThat(parsed).isPresent();
+        assertThat(parsed.get().metric()).isEqualTo(StructuredCondition.Metric.ONGOING_COUNT);
+        assertThat(parsed.get().unit()).isEqualTo(StructuredCondition.Unit.COUNT);
+        assertThat(parsed.get().toParameterMap())
+                .containsEntry("conditionMetric", "ONGOING_COUNT")
+                .containsEntry("conditionThreshold", "2")
+                .containsEntry("conditionUnit", "COUNT");
     }
 }

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -636,6 +636,259 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
+    @DisplayName("부동산 조건 대기 중 채용 입력은 기존 가격 조건으로 흡수하지 않고 새 대화로 파싱한다")
+    void realEstateConditionWaitStartsNewConversationForRecruitmentRequest() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-real-estate",
+                "강남구 아파트 매매 실거래가",
+                1L,
+                "real-estate",
+                "apartment_trade_price",
+                "search_house_price",
+                "{" +
+                        "\"dealYmdPolicy\":\"LATEST_AVAILABLE_MONTH\"," +
+                        "\"region\":\"강남구\"" +
+                        "}",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                null,
+                "어떤 가격 변동 조건 시 알림을 받으시겠어요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-recruitment", List.of(new ParsedTask(
+                "create",
+                "채용",
+                "백엔드 채용 새 공고",
+                "1건 이상 증가",
+                "",
+                "telegram",
+                "api",
+                "백엔드 채용 공고",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "백엔드 채용 새 공고 1건 이상 텔레그램으로 알려줘",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isEqualTo(1);
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.draft()).isNotNull();
+        assertThat(response.draft().domainLabel()).isEqualTo("채용");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("conditionMetric", "COUNT")
+                .containsEntry("conditionUnit", "COUNT")
+                .doesNotContainEntry("conditionMetric", "AVG_PRICE");
+    }
+
+    @Test
+    @DisplayName("부동산 채널 대기 중 채용 입력은 기존 draft 채널 선택으로 흡수하지 않는다")
+    void realEstateChannelWaitStartsNewConversationForRecruitmentRequest() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-real-estate",
+                "강남구 아파트 매매 실거래가",
+                1L,
+                "real-estate",
+                "apartment_trade_price",
+                "search_house_price",
+                "{" +
+                        "\"dealYmdPolicy\":\"LATEST_AVAILABLE_MONTH\"," +
+                        "\"region\":\"강남구\"," +
+                        "\"conditionMetric\":\"AVG_PRICE\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"5\"," +
+                        "\"conditionUnit\":\"PERCENT\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "알림을 받을 채널을 선택해 주세요.",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-recruitment", List.of(new ParsedTask(
+                "create",
+                "채용",
+                "백엔드 채용 새 공고",
+                "1건 이상 증가",
+                "",
+                "telegram",
+                "api",
+                "백엔드 채용 공고",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "백엔드 채용 새 공고 뜨면 텔레그램으로 알려줘",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isEqualTo(1);
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.draft()).isNotNull();
+        assertThat(response.draft().domainLabel()).isEqualTo("채용");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("dataToolName", "search_public_job")
+                .containsEntry("keyword", "백엔드")
+                .containsEntry("conditionMetric", "COUNT");
+    }
+
+    @Test
+    @DisplayName("부동산 채널 대기 중 영어 채용 입력도 기존 draft 채널 선택으로 흡수하지 않는다")
+    void realEstateChannelWaitStartsNewConversationForEnglishRecruitmentRequest() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-real-estate",
+                "강남구 아파트 매매 실거래가",
+                1L,
+                "real-estate",
+                "apartment_trade_price",
+                "search_house_price",
+                "{" +
+                        "\"dealYmdPolicy\":\"LATEST_AVAILABLE_MONTH\"," +
+                        "\"region\":\"강남구\"," +
+                        "\"conditionMetric\":\"AVG_PRICE\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"5\"," +
+                        "\"conditionUnit\":\"PERCENT\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "알림을 받을 채널을 선택해 주세요.",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-recruitment", List.of(new ParsedTask(
+                "create",
+                "recruitment",
+                "backend jobs",
+                "1건 이상 증가",
+                "",
+                "telegram",
+                "api",
+                "backend jobs",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "backend jobs telegram",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isEqualTo(1);
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.draft()).isNotNull();
+        assertThat(response.draft().domainLabel()).isEqualTo("채용");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("conditionMetric", "COUNT")
+                .containsEntry("conditionUnit", "COUNT");
+    }
+
+    @Test
+    @DisplayName("부동산 채널 대기 중 영어 단수 job 입력도 기존 draft 채널 선택으로 흡수하지 않는다")
+    void realEstateChannelWaitStartsNewConversationForEnglishSingularJobRequest() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-real-estate",
+                "강남구 아파트 매매 실거래가",
+                1L,
+                "real-estate",
+                "apartment_trade_price",
+                "search_house_price",
+                "{" +
+                        "\"dealYmdPolicy\":\"LATEST_AVAILABLE_MONTH\"," +
+                        "\"region\":\"강남구\"," +
+                        "\"conditionMetric\":\"AVG_PRICE\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"5\"," +
+                        "\"conditionUnit\":\"PERCENT\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "알림을 받을 채널을 선택해 주세요.",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-recruitment", List.of(new ParsedTask(
+                "create",
+                "recruitment",
+                "backend job",
+                "1건 이상 증가",
+                "",
+                "telegram",
+                "api",
+                "backend job",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "backend job, telegram",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isEqualTo(1);
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.draft()).isNotNull();
+        assertThat(response.draft().domainLabel()).isEqualTo("채용");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("conditionMetric", "COUNT")
+                .containsEntry("conditionUnit", "COUNT");
+    }
+
+    @Test
     @DisplayName("0건 채용 키워드 후보가 있으면 사용자 확인을 질문한다")
     void recruitmentDraftWithZeroResultKeywordSuggestionAsksForConfirmation() {
         SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
@@ -750,6 +1003,207 @@ class SubscriptionConversationServiceTest {
                 .containsEntry("recrut_pbanc_ttl", "백엔드")
                 .doesNotContainKey("keywordValidationStatus")
                 .doesNotContainKey("suggestedKeyword");
+    }
+
+    @Test
+    @DisplayName("채용 키워드 확인 중 부동산 입력은 키워드로 저장하지 않고 새 대화로 파싱한다")
+    void recruitmentKeywordConfirmationStartsNewConversationForRealEstateRequest() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-recruitment",
+                "벡엔드 채용 공고",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"keyword\":\"벡엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"벡엔드\"," +
+                        "\"keywordValidationStatus\":\"ZERO_RESULTS\"," +
+                        "\"keywordOriginal\":\"벡엔드\"," +
+                        "\"suggestedKeyword\":\"백엔드\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                null,
+                "현재 '벡엔드' 검색 결과가 없어요. '백엔드'를 뜻한 걸까요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-real-estate", List.of(new ParsedTask(
+                "create",
+                "부동산",
+                "강남구 아파트 매매 실거래가",
+                "5% 이상 상승",
+                "",
+                "telegram",
+                "api",
+                "강남구 아파트 매매 실거래가 변동",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "강남구 아파트 매매 실거래가 5% 상승 텔레그램으로 알려줘",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isEqualTo(1);
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.draft()).isNotNull();
+        assertThat(response.draft().domainLabel()).isEqualTo("부동산");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("conditionMetric", "AVG_PRICE")
+                .containsEntry("conditionUnit", "PERCENT");
+    }
+
+    @Test
+    @DisplayName("채용 키워드 확인 중 채용 말고 부동산 입력은 부동산 새 대화로 파싱한다")
+    void recruitmentKeywordConfirmationUsesLastExplicitDomainInMixedDomainRequest() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-recruitment",
+                "벡엔드 채용 공고",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"keyword\":\"벡엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"벡엔드\"," +
+                        "\"keywordValidationStatus\":\"ZERO_RESULTS\"," +
+                        "\"keywordOriginal\":\"벡엔드\"," +
+                        "\"suggestedKeyword\":\"백엔드\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                null,
+                "현재 '벡엔드' 검색 결과가 없어요. '백엔드'를 뜻한 걸까요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-real-estate", List.of(new ParsedTask(
+                "create",
+                "부동산",
+                "강남구 아파트 매매 실거래가",
+                "5% 이상 상승",
+                "",
+                "telegram",
+                "api",
+                "강남구 아파트 매매 실거래가 변동",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "채용 말고 강남구 아파트 매매 실거래가 5% 상승 텔레그램으로 알려줘",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isEqualTo(1);
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.draft()).isNotNull();
+        assertThat(response.draft().domainLabel()).isEqualTo("부동산");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("conditionMetric", "AVG_PRICE")
+                .containsEntry("conditionUnit", "PERCENT");
+    }
+
+    @Test
+    @DisplayName("채용 키워드 확인 중 아파트 직무 입력은 부동산 새 대화가 아니라 키워드로 저장한다")
+    void recruitmentKeywordConfirmationKeepsApartmentJobKeywordInRecruitmentDraft() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-recruitment",
+                "벡엔드 채용 공고",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"keyword\":\"벡엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"벡엔드\"," +
+                        "\"keywordValidationStatus\":\"ZERO_RESULTS\"," +
+                        "\"keywordOriginal\":\"벡엔드\"," +
+                        "\"suggestedKeyword\":\"백엔드\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                null,
+                "현재 '벡엔드' 검색 결과가 없어요. '백엔드'를 뜻한 걸까요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-real-estate", List.of(realEstateTask(false)));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "아파트 경비",
+                null
+        );
+
+        assertThat(parseTaskUseCase.parseCallCount).isZero();
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.status()).isEqualTo("READY_FOR_CONFIRMATION");
+        assertThat(response.draft().domainLabel()).isEqualTo("채용");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("keyword", "아파트 경비")
+                .containsEntry("recrut_pbanc_ttl", "아파트 경비")
+                .doesNotContainKeys("keywordValidationStatus", "keywordOriginal", "suggestedKeyword");
     }
 
     @Test

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -591,6 +591,57 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
+    @DisplayName("채용 조건 질문 뒤 키워드만 답하면 기본 조건을 확정하지 않고 조건을 다시 질문한다")
+    void recruitmentKeywordOnlyAnswerAfterConditionQuestionAsksConditionAgain() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "채용 알림",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "어떤 종류의 채용 공고를 모니터링할까요? 또한, 어떤 조건으로 알림을 받을까요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        SubscriptionConversationService service = service(loadNotificationEndpointPort);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "간호사",
+                null
+        );
+
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.status()).isEqualTo("NEEDS_INPUT");
+        assertThat(response.assistantMessage()).contains("채용 공고 변화");
+        assertThat(response.assistantMessage()).doesNotContain("채널");
+        assertThat(conversation.getDraftMonitoringParams())
+                .contains("\"keyword\":\"간호사\"")
+                .contains("\"recrut_pbanc_ttl\":\"간호사\"")
+                .doesNotContain("\"conditionMetric\"")
+                .doesNotContain("\"conditionThreshold\"");
+    }
+
+    @Test
     @DisplayName("채용 조건만 답하면 조건만 보완하고 대상 키워드를 계속 질문한다")
     void recruitmentConditionOnlyAnswerDoesNotInventKeyword() {
         SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -543,6 +543,99 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
+    @DisplayName("채용 대상과 건수 조건 답변은 AI 이어가기 없이 초안을 보완한다")
+    void recruitmentKeywordAndCountConditionAnswerCompletesLocally() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "채용 알림",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "어떤 종류의 채용 공고를 모니터링하시겠어요? 그리고 어떤 조건일 때 알림을 받으시겠어요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        SubscriptionConversationService service = service(loadNotificationEndpointPort);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "백엔드 전체 5건 이상 변동이 생길때",
+                null
+        );
+
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.status()).isEqualTo("NEEDS_INPUT");
+        assertThat(response.assistantMessage()).contains("채널");
+        assertThat(conversation.getDraftQuery()).isEqualTo("백엔드 채용 공고");
+        assertThat(conversation.getDraftMonitoringParams())
+                .contains("\"keyword\":\"백엔드\"")
+                .contains("\"recrut_pbanc_ttl\":\"백엔드\"")
+                .contains("\"conditionMetric\":\"COUNT\"")
+                .contains("\"conditionDirection\":\"ANY\"")
+                .contains("\"conditionThreshold\":\"5\"")
+                .contains("\"conditionUnit\":\"COUNT\"");
+    }
+
+    @Test
+    @DisplayName("채용 조건만 답하면 조건만 보완하고 대상 키워드를 계속 질문한다")
+    void recruitmentConditionOnlyAnswerDoesNotInventKeyword() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "채용 알림",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "어떤 종류의 채용 공고를 모니터링하시겠어요? 그리고 어떤 조건일 때 알림을 받으시겠어요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        SubscriptionConversationService service = service(loadNotificationEndpointPort);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "새 공고가 1건 이상 등록되면",
+                null
+        );
+
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.status()).isEqualTo("NEEDS_INPUT");
+        assertThat(response.assistantMessage()).contains("어떤 채용 공고");
+        assertThat(conversation.getDraftMonitoringParams())
+                .doesNotContain("\"keyword\"")
+                .contains("\"conditionMetric\":\"COUNT\"")
+                .contains("\"conditionDirection\":\"UP\"")
+                .contains("\"conditionThreshold\":\"1\"");
+    }
+
+    @Test
     @DisplayName("0건 채용 키워드 후보가 있으면 사용자 확인을 질문한다")
     void recruitmentDraftWithZeroResultKeywordSuggestionAsksForConfirmation() {
         SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-@DisplayName("Application: subscription conversation service")
+@DisplayName("Application: 구독 대화 서비스 테스트")
 class SubscriptionConversationServiceTest {
 
     private final SubscriptionConversationJpaRepository conversationRepository =
@@ -53,7 +53,7 @@ class SubscriptionConversationServiceTest {
             (userId, channel) -> Optional.empty();
 
     @Test
-    @DisplayName("new message parses with authenticated user id and asks missing channel")
+    @DisplayName("새 메시지는 인증 사용자 id로 파싱하고 누락된 채널을 질문한다")
     void newMessageParsesWithAuthenticatedUserId() {
         when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(realEstateTask(false)));
@@ -76,7 +76,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("parser needsConfirmation question is surfaced and continued with parseSessionId")
+    @DisplayName("파서 확인 질문을 표시하고 parseSessionId로 대화를 이어간다")
     void continuesParserConfirmationSession() {
         SubscriptionConversationJpaEntity savedConversation = new SubscriptionConversationJpaEntity(1L);
         savedConversation.updateParsedDraft(
@@ -127,7 +127,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("follow-up parser result keeps previously selected channel and internal check schedule")
+    @DisplayName("후속 파서 결과는 이전 선택 채널과 내부 확인 주기를 유지한다")
     void followUpKeepsPreviousCadenceAndChannel() {
         SubscriptionConversationJpaEntity savedConversation = new SubscriptionConversationJpaEntity(1L);
         savedConversation.updateParsedDraft(
@@ -183,7 +183,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("percent condition answer keeps deal type confirmation before channel")
+    @DisplayName("퍼센트 조건 답변 후에도 채널보다 거래 유형 확인을 먼저 유지한다")
     void percentConditionAnswerKeepsDealTypeBeforeChannel() {
         SubscriptionConversationJpaEntity savedConversation = new SubscriptionConversationJpaEntity(1L);
         savedConversation.updateParsedDraft(
@@ -224,7 +224,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("percent condition answer keeps ambiguous apartment deal type unresolved")
+    @DisplayName("퍼센트 조건 답변은 모호한 아파트 거래 유형을 확정하지 않는다")
     void percentConditionAnswerKeepsAmbiguousApartmentDealTypeUnresolved() {
         SubscriptionConversationJpaEntity savedConversation = new SubscriptionConversationJpaEntity(1L);
         savedConversation.updateParsedDraft(
@@ -266,7 +266,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("percent condition answer keeps the current ambiguous conversation even when MCP tool is not resolved yet")
+    @DisplayName("MCP tool이 아직 없어도 퍼센트 조건 답변은 현재 모호한 대화를 유지한다")
     void percentConditionAnswerKeepsAmbiguousConversationWithoutResolvedTool() {
         SubscriptionConversationJpaEntity savedConversation = new SubscriptionConversationJpaEntity(1L);
         savedConversation.updateParsedDraft(
@@ -325,7 +325,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("needsConfirmation parser result asks the parser question without quick actions")
+    @DisplayName("needsConfirmation 파서 결과는 quick action 없이 파서 질문을 표시한다")
     void asksParserConfirmationQuestion() {
         when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(realEstateTask(true)));
@@ -344,18 +344,334 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("planned domain does not create subscription")
-    void plannedDomainDoesNotCreateSubscription() {
+    @DisplayName("공고 수 조건이 있는 채용 요청은 확인 단계로 진행한다")
+    void recruitmentRequestWithCountConditionAdvancesToConfirmation() {
         when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(new ParsedTask(
                 "create",
                 "채용",
-                "카카오 백엔드 채용공고",
-                "경력 3년 이하",
+                "백엔드 채용 새 공고",
+                "1건 이상 증가",
+                "0 9 * * *",
+                "telegram",
+                "api",
+                "백엔드 채용 공고",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                null,
+                "백엔드 채용 새 공고 뜨면 텔레그램으로 알려줘",
+                null
+        );
+
+        assertThat(response.status()).isEqualTo("READY_FOR_CONFIRMATION");
+        assertThat(response.draft().domainLabel()).isEqualTo("채용");
+        assertThat(response.draft().intent()).isEqualTo("job_posting_change");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("dataToolName", "search_public_job")
+                .containsEntry("keyword", "백엔드")
+                .containsEntry("conditionMetric", "COUNT")
+                .containsEntry("conditionUnit", "COUNT");
+        assertThat(response.actions()).extracting(SubscriptionConversationService.ActionOption::type)
+                .contains("CONFIRM_SUBSCRIPTION");
+        assertThat(createSubscriptionUseCase.receivedCommand).isNull();
+    }
+
+    @Test
+    @DisplayName("키워드가 없는 채용 초안은 채널 선택 후 채용 대상을 질문한다")
+    void recruitmentDraftWithoutKeywordAsksRecruitmentTargetAfterSelectingChannel() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "채용 알려줘",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "알림을 받을 채널을 선택해 주세요.",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                null,
+                new SubscriptionConversationService.ActionRequest("SELECT_CHANNEL", "TELEGRAM_DM")
+        );
+
+        assertThat(response.status()).isEqualTo("NEEDS_INPUT");
+        assertThat(response.assistantMessage()).contains("어떤 채용 공고");
+        assertThat(response.assistantMessage()).doesNotContain("가격");
+        assertThat(createSubscriptionUseCase.receivedCommand).isNull();
+    }
+
+    @Test
+    @DisplayName("조건이 없는 채용 초안은 채용 변화 조건을 질문한다")
+    void recruitmentDraftWithoutConditionAsksRecruitmentChangeCondition() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "백엔드 채용",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"keyword\":\"백엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"백엔드\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "알림을 받을 채널을 선택해 주세요.",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                null,
+                new SubscriptionConversationService.ActionRequest("SELECT_CHANNEL", "TELEGRAM_DM")
+        );
+
+        assertThat(response.status()).isEqualTo("NEEDS_INPUT");
+        assertThat(response.assistantMessage()).contains("채용 공고 변화");
+        assertThat(response.assistantMessage()).doesNotContain("가격");
+        assertThat(createSubscriptionUseCase.receivedCommand).isNull();
+    }
+
+    @Test
+    @DisplayName("채용 조건 답변은 부동산 가격 파서로 완료하지 않는다")
+    void recruitmentConditionAnswerIsNotCompletedByRealEstatePriceParser() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "백엔드 채용",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"page_no\":\"1\"," +
+                        "\"num_of_rows\":\"20\"," +
+                        "\"ongoing_yn\":\"Y\"," +
+                        "\"keyword\":\"백엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"백엔드\"" +
+                        "}",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                null,
+                "어떤 채용 공고 변화가 생기면 알림을 받을까요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.continueResult = new ParseResult("parse-1", List.of(new ParsedTask(
+                "create",
+                "채용",
+                "백엔드 채용 새 공고",
+                "1건 이상 증가",
+                "",
+                "",
+                "api",
+                "백엔드 채용 공고",
+                List.of(),
+                0.9,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "5% 상승",
+                null
+        );
+
+        assertThat(parseTaskUseCase.continueCallCount).isEqualTo(1);
+        assertThat(response.status()).isEqualTo("READY_FOR_CONFIRMATION");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("conditionMetric", "COUNT")
+                .containsEntry("conditionUnit", "COUNT");
+    }
+
+    @Test
+    @DisplayName("0건 채용 키워드 후보가 있으면 사용자 확인을 질문한다")
+    void recruitmentDraftWithZeroResultKeywordSuggestionAsksForConfirmation() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "벡엔드 채용 공고",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"keyword\":\"벡엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"벡엔드\"," +
+                        "\"keywordValidationStatus\":\"ZERO_RESULTS\"," +
+                        "\"suggestedKeyword\":\"백엔드\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                null,
+                null,
+                "알림을 받을 채널을 선택해 주세요.",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                null,
+                new SubscriptionConversationService.ActionRequest("SELECT_CHANNEL", "TELEGRAM_DM")
+        );
+
+        assertThat(response.status()).isEqualTo("NEEDS_INPUT");
+        assertThat(response.assistantMessage()).contains("벡엔드");
+        assertThat(response.assistantMessage()).contains("백엔드");
+        assertThat(response.assistantMessage()).doesNotContain("가격");
+    }
+
+    @Test
+    @DisplayName("긍정 답변은 채용 키워드 후보를 적용한다")
+    void affirmativeAnswerAcceptsRecruitmentKeywordSuggestion() {
+        SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
+        conversation.updateParsedDraft(
+                "parse-1",
+                "벡엔드 채용 공고",
+                3L,
+                "recruitment",
+                "job_posting_change",
+                "search_public_job",
+                "{" +
+                        "\"dataToolName\":\"search_public_job\"," +
+                        "\"keyword\":\"벡엔드\"," +
+                        "\"recrut_pbanc_ttl\":\"벡엔드\"," +
+                        "\"keywordValidationStatus\":\"ZERO_RESULTS\"," +
+                        "\"suggestedKeyword\":\"백엔드\"," +
+                        "\"conditionMetric\":\"COUNT\"," +
+                        "\"conditionDirection\":\"UP\"," +
+                        "\"conditionOperator\":\"GTE\"," +
+                        "\"conditionThreshold\":\"1\"," +
+                        "\"conditionUnit\":\"COUNT\"" +
+                        "}",
+                "0 0 * * * *",
+                NotificationChannel.TELEGRAM_DM,
+                null,
+                "현재 '벡엔드' 검색 결과가 없어요. '백엔드'를 뜻한 걸까요?",
+                SubscriptionConversationStatus.COLLECTING
+        );
+        when(conversationRepository.findByIdAndUserId(conversation.getId(), 1L))
+                .thenReturn(Optional.of(conversation));
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.continueResult = new ParseResult("parse-1", List.of(new ParsedTask(
+                "reject",
+                "기타",
+                "응",
+                "",
+                "",
+                "",
+                "",
+                "응",
+                List.of(),
+                0.1,
+                false,
+                ""
+        )));
+        LoadNotificationEndpointPort connectedTelegram = (userId, channel) -> channel == NotificationChannel.TELEGRAM_DM
+                ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "123456789", true))
+                : Optional.empty();
+        SubscriptionConversationService service = service(connectedTelegram);
+
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                conversation.getId(),
+                "응",
+                null
+        );
+
+        assertThat(parseTaskUseCase.continueCallCount).isZero();
+        assertThat(response.status()).isEqualTo("READY_FOR_CONFIRMATION");
+        assertThat(response.draft().monitoringParams())
+                .containsEntry("keyword", "백엔드")
+                .containsEntry("recrut_pbanc_ttl", "백엔드")
+                .doesNotContainKey("keywordValidationStatus")
+                .doesNotContainKey("suggestedKeyword");
+    }
+
+    @Test
+    @DisplayName("기획 상태 도메인은 구독을 생성하지 않는다")
+    void plannedDomainDoesNotCreateSubscription() {
+        when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(new ParsedTask(
+                "create",
+                "법률",
+                "개인정보보호법 개정",
+                "1건 이상 증가",
                 "0 * * * *",
                 "email",
-                "crawl",
-                "카카오 백엔드 채용공고",
+                "api",
+                "개인정보보호법 개정",
                 List.of(),
                 0.9,
                 false,
@@ -366,7 +682,7 @@ class SubscriptionConversationServiceTest {
         SubscriptionConversationService.Response response = service.handle(
                 1L,
                 null,
-                "카카오 채용공고 이메일로 매시간 알려줘",
+                "개인정보보호법 개정되면 이메일로 알려줘",
                 null
         );
 
@@ -378,7 +694,7 @@ class SubscriptionConversationServiceTest {
     // withStoredMcpTool()이 Spring AI 위임으로 제거됨 → toolName은 더 이상 저장되지 않음
 
     @Test
-    @DisplayName("explicit unconnected DM channel asks for connection before confirmation")
+    @DisplayName("연결되지 않은 DM 채널을 명시하면 확인 전에 연결을 요구한다")
     void explicitUnconnectedDmChannelAsksForConnectionBeforeConfirmation() {
         when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(realEstateTask(false)));
@@ -398,7 +714,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("ambiguous apartment change request asks for a deal type instead of becoming ready")
+    @DisplayName("모호한 아파트 변경 요청은 확인 단계 대신 거래 유형을 질문한다")
     void ambiguousApartmentChangeRequestAsksForDealType() {
         when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(new ParsedTask(
@@ -434,7 +750,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("generic apartment price request asks for deal type before condition")
+    @DisplayName("일반 아파트 가격 요청은 조건보다 거래 유형을 먼저 질문한다")
     void genericApartmentPriceRequestAsksForDealTypeBeforeCondition() {
         when(conversationRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
         parseTaskUseCase.parseResult = new ParseResult("parse-1", List.of(new ParsedTask(
@@ -467,7 +783,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("pending deal type confirmation accepts short trade answer without AI continuation")
+    @DisplayName("거래 유형 확인 대기는 AI 이어가기 없이 짧은 매매 답변을 수락한다")
     void pendingDealTypeConfirmationAcceptsShortTradeAnswer() {
         SubscriptionConversationJpaEntity savedConversation = new SubscriptionConversationJpaEntity(1L);
         savedConversation.updateParsedDraft(
@@ -516,7 +832,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("unsupported draft starts a new parse for the next free text message")
+    @DisplayName("지원하지 않는 초안 뒤의 자유 입력은 새 파싱을 시작한다")
     void unsupportedDraftStartsNewParseForNextMessage() {
         SubscriptionConversationJpaEntity unsupportedConversation = new SubscriptionConversationJpaEntity(1L);
         unsupportedConversation.updateParsedDraft(
@@ -566,7 +882,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("confirmed ready draft creates subscription and saves monitoring config")
+    @DisplayName("확정된 준비 초안은 구독을 생성하고 모니터링 설정을 저장한다")
     void confirmCreatesSubscriptionAndMonitoringConfig() {
         SubscriptionConversationJpaEntity readyConversation = new SubscriptionConversationJpaEntity(1L);
         readyConversation.updateParsedDraft(
@@ -620,7 +936,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("ready draft without condition asks for condition instead of creating subscription")
+    @DisplayName("조건이 없는 준비 초안은 구독 생성 대신 조건을 질문한다")
     void readyDraftWithoutConditionAsksForConditionInsteadOfCreatingSubscription() {
         SubscriptionConversationJpaEntity readyConversation = new SubscriptionConversationJpaEntity(1L);
         readyConversation.updateParsedDraft(
@@ -658,7 +974,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("selecting a connected channel advances the draft to confirmation")
+    @DisplayName("연결된 채널을 선택하면 초안이 확인 단계로 진행한다")
     void selectingConnectedChannelAdvancesToConfirmation() {
         SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
         conversation.updateParsedDraft(
@@ -696,7 +1012,7 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("typed channel answer is handled locally instead of reparsing as a new request")
+    @DisplayName("채널 직접 입력은 새 요청으로 재파싱하지 않고 로컬에서 처리한다")
     void typedChannelAnswerIsHandledLocally() {
         SubscriptionConversationJpaEntity conversation = new SubscriptionConversationJpaEntity(1L);
         conversation.updateParsedDraft(
@@ -838,6 +1154,9 @@ class SubscriptionConversationServiceTest {
                         task.confidence()
                 ));
             }
+            if ("recruitment".equals(domainName)) {
+                return Optional.of(recruitmentDraft(query, task, userMessage));
+            }
             if (!"real-estate".equals(domainName)) {
                 return Optional.of(new DomainNormalizedSubscriptionDraft(
                         query,
@@ -886,6 +1205,87 @@ class SubscriptionConversationServiceTest {
                     questionForMissing(missing),
                     task.confidence()
             ));
+        }
+
+        private static DomainNormalizedSubscriptionDraft recruitmentDraft(
+                String query,
+                ParsedTask task,
+                String userMessage
+        ) {
+            Map<String, String> params = new LinkedHashMap<>();
+            params.put("dataToolName", "search_public_job");
+            params.put("page_no", "1");
+            params.put("num_of_rows", "20");
+            params.put("ongoing_yn", "Y");
+
+            String keyword = recruitmentKeyword(query, task.target());
+            if (!isBlank(keyword)) {
+                params.put("keyword", keyword);
+                params.put("recrut_pbanc_ttl", keyword);
+            }
+
+            params.putAll(recruitmentConditionParams(task.condition(), userMessage, task.target()));
+
+            List<String> missing = new java.util.ArrayList<>();
+            if (!params.containsKey("keyword")) {
+                missing.add("keyword");
+            }
+            if (StructuredCondition.fromParameters(params).isEmpty()) {
+                missing.add("condition");
+            }
+
+            return new DomainNormalizedSubscriptionDraft(
+                    query,
+                    "recruitment",
+                    "job_posting_change",
+                    "search_public_job",
+                    params,
+                    missing,
+                    recruitmentQuestionForMissing(missing),
+                    task.confidence()
+            );
+        }
+
+        private static String recruitmentKeyword(String query, String target) {
+            String text = !isBlank(query) ? query : target;
+            if (isBlank(text)) {
+                return "";
+            }
+            String keyword = text
+                    .replace("진행중 공고", "")
+                    .replace("새 공고", "")
+                    .replace("신규 공고", "")
+                    .replace("채용", "")
+                    .replace("공고", "")
+                    .trim();
+            if (keyword.startsWith("공공기관 ")) {
+                keyword = keyword.substring("공공기관 ".length()).trim();
+            }
+            return keyword;
+        }
+
+        private static Map<String, String> recruitmentConditionParams(
+                String condition,
+                String userMessage,
+                String target
+        ) {
+            String text = (condition == null ? "" : condition) + " "
+                    + (userMessage == null ? "" : userMessage) + " "
+                    + (target == null ? "" : target);
+            if (!containsAny(text, "새 공고", "신규", "등록", "증가", "늘면", "이상")) {
+                return Map.of();
+            }
+            String threshold = condition == null ? "" : condition.replaceAll("[^0-9.]", "");
+            if (threshold.isBlank()) {
+                threshold = "1";
+            }
+            return Map.of(
+                    "conditionMetric", text.contains("진행중") ? "ONGOING_COUNT" : "COUNT",
+                    "conditionDirection", "UP",
+                    "conditionOperator", "GTE",
+                    "conditionThreshold", threshold,
+                    "conditionUnit", "COUNT"
+            );
         }
 
         private static Map<String, String> conditionParams(String condition) {
@@ -939,6 +1339,16 @@ class SubscriptionConversationServiceTest {
             }
             if (missing.contains("condition")) {
                 return "어떤 가격 변동 조건 시 알림을 받으시겠어요? 예: 5% 이상 상승, 50만원 이상 변동 등";
+            }
+            return "";
+        }
+
+        private static String recruitmentQuestionForMissing(List<String> missing) {
+            if (missing.contains("keyword")) {
+                return "어떤 채용 공고를 구독할까요? 예: 백엔드, 데이터, 공공기관 인턴 등";
+            }
+            if (missing.contains("condition")) {
+                return "어떤 채용 공고 변화가 생기면 알림을 받을까요? 예: 새 공고 1건 이상 등록 등";
             }
             return "";
         }

--- a/front/src/app/components/subscription-chat.tsx
+++ b/front/src/app/components/subscription-chat.tsx
@@ -10,9 +10,11 @@ import {
   type NotificationChannelId,
 } from "../lib/subscriptions";
 import {
+  STALE_CONVERSATION_MESSAGE,
   SUBSCRIPTION_CHAT_SESSION_KEY,
   decodeSubscriptionChatSession,
   encodeSubscriptionChatSession,
+  isStaleConversationError,
   type ChatMessage,
   type DebugJsonSnapshot,
   type SubscriptionChatSessionSnapshot,
@@ -78,6 +80,22 @@ export function SubscriptionChat({
     setSubscriptions(response.data);
   }, [onUnauthenticated]);
 
+  const resetExpiredConversation = useCallback(() => {
+    sessionStorage.removeItem(SUBSCRIPTION_CHAT_SESSION_KEY);
+    sessionStorage.removeItem(PENDING_CHANNEL_KEY);
+    setConversationId(null);
+    setActions([]);
+    setDraft(null);
+    setMessages([
+      {
+        id: createMessageId("assistant-reset"),
+        role: "assistant",
+        content: STALE_CONVERSATION_MESSAGE,
+      },
+    ]);
+    setStatusMessage("");
+  }, []);
+
   const applyConversationResponse = useCallback(
     async (
       response: ConversationResponse,
@@ -140,12 +158,16 @@ export function SubscriptionChat({
       if (response.error.code === "UNAUTHENTICATED") {
         onUnauthenticated?.();
       }
+      if (isStaleConversationError(response.error, pending.conversationId)) {
+        resetExpiredConversation();
+        return;
+      }
       setStatusMessage(response.error.message);
       return;
     }
 
     await applyConversationResponse(response.data);
-  }, [applyConversationResponse, onUnauthenticated]);
+  }, [applyConversationResponse, onUnauthenticated, resetExpiredConversation]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -242,6 +264,10 @@ export function SubscriptionChat({
       if (response.error.code === "UNAUTHENTICATED") {
         onUnauthenticated?.();
       }
+      if (isStaleConversationError(response.error, requestPayload.conversationId)) {
+        resetExpiredConversation();
+        return;
+      }
       replaceMessage(pendingMessageId, response.error.message, "error");
       setStatusMessage(response.error.message);
       return;
@@ -297,6 +323,10 @@ export function SubscriptionChat({
     if (!response.ok) {
       if (response.error.code === "UNAUTHENTICATED") {
         onUnauthenticated?.();
+      }
+      if (isStaleConversationError(response.error, requestPayload.conversationId)) {
+        resetExpiredConversation();
+        return;
       }
       replaceMessage(pendingMessageId, response.error.message, "error");
       setStatusMessage(response.error.message);

--- a/front/src/app/lib/subscription-chat-session.test.mts
+++ b/front/src/app/lib/subscription-chat-session.test.mts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  STALE_CONVERSATION_MESSAGE,
   SUBSCRIPTION_CHAT_SESSION_TTL_MS,
   decodeSubscriptionChatSession,
   encodeSubscriptionChatSession,
+  isStaleConversationError,
   type SubscriptionChatSessionSnapshot,
 } from "./subscription-chat-session.ts";
 
@@ -55,5 +57,25 @@ describe("subscription chat session persistence", () => {
       null,
     );
     assert.equal(decodeSubscriptionChatSession("{", 1_000), null);
+  });
+
+  it("detects stale conversation errors only when an old conversation id was sent", () => {
+    assert.equal(
+      isStaleConversationError({ code: "SESSION_NOT_FOUND", message: "세션을 찾을 수 없습니다." }, "conversation-1"),
+      true,
+    );
+    assert.equal(
+      isStaleConversationError({ code: "INVALID_REQUEST", message: "요청 값이 올바르지 않습니다." }, "conversation-1"),
+      true,
+    );
+    assert.equal(
+      isStaleConversationError({ code: "INVALID_REQUEST", message: "요청 값이 올바르지 않습니다." }, null),
+      false,
+    );
+    assert.equal(
+      isStaleConversationError({ code: "INSUFFICIENT_TOKEN", message: "토큰이 부족합니다." }, "conversation-1"),
+      false,
+    );
+    assert.equal(STALE_CONVERSATION_MESSAGE, "이전 대화가 만료되어 새로 시작할게요.");
   });
 });

--- a/front/src/app/lib/subscription-chat-session.ts
+++ b/front/src/app/lib/subscription-chat-session.ts
@@ -29,8 +29,20 @@ type StoredSubscriptionChatSession = {
   snapshot: SubscriptionChatSessionSnapshot;
 };
 
+export const STALE_CONVERSATION_MESSAGE = "이전 대화가 만료되어 새로 시작할게요.";
 export const SUBSCRIPTION_CHAT_SESSION_KEY = "subscription-chat-session";
 export const SUBSCRIPTION_CHAT_SESSION_TTL_MS = 30 * 60 * 1000;
+
+export function isStaleConversationError(
+  error: { code: string },
+  conversationId: string | null | undefined,
+): boolean {
+  return (
+    typeof conversationId === "string" &&
+    conversationId.trim() !== "" &&
+    (error.code === "SESSION_NOT_FOUND" || error.code === "INVALID_REQUEST")
+  );
+}
 
 export function encodeSubscriptionChatSession(
   snapshot: SubscriptionChatSessionSnapshot,

--- a/mcp-server/src/mcp_server/domains/jobs/normalizer.py
+++ b/mcp-server/src/mcp_server/domains/jobs/normalizer.py
@@ -56,6 +56,7 @@ class PublicJobPosting(BaseModel):
 class WorknetJobPosting(BaseModel):
     """워크넷 채용공고 1건 (정상 응답 구조 기준)."""
 
+    wanted_auth_no: str | None = Field(default=None, description="구인인증번호 (wantedAuthNo)")
     title: str = Field(description="채용 제목 (wantedTitle)")
     company: str = Field(description="회사명/사업장명 (busplaName)")
     region: str | None = Field(default=None, description="근무지역명 (regionNm)")
@@ -155,11 +156,12 @@ def normalize_worknet_job(xml_text: str) -> list[WorknetJobPosting]:
 def _build_worknet_posting(node: ET.Element) -> WorknetJobPosting:
     try:
         return WorknetJobPosting(
-            title=_required_node(node, "wantedTitle"),
-            company=_required_node(node, "busplaName"),
-            region=_node_text(node, "regionNm"),
-            emp_type=_node_text(node, "empTpNm"),
-            min_education=_node_text(node, "minEdubgNm"),
+            wanted_auth_no=_node_text(node, "wantedAuthNo"),
+            title=_required_any_node(node, ("title", "wantedTitle")),
+            company=_required_any_node(node, ("company", "busplaName")),
+            region=_first_node_text(node, ("region", "regionNm")),
+            emp_type=_first_node_text(node, ("empTpNm", "empTpCd")),
+            min_education=_first_node_text(node, ("minEdubg", "minEdubgNm")),
             salary_type=_node_text(node, "salTpNm"),
             reg_date=_optional_yyyymmdd(_node_text(node, "regDt")),
             close_date=_optional_yyyymmdd(_node_text(node, "closeDt")),
@@ -250,6 +252,22 @@ def _required_node(parent: ET.Element, tag: str) -> str:
     text = _node_text(parent, tag)
     if text is None:
         raise KeyError(tag)
+    return text
+
+
+def _first_node_text(parent: ET.Element, tags: tuple[str, ...]) -> str | None:
+    """공식 필드명과 기존 추정 필드명 중 먼저 존재하는 값을 반환한다."""
+    for tag in tags:
+        text = _node_text(parent, tag)
+        if text is not None:
+            return text
+    return None
+
+
+def _required_any_node(parent: ET.Element, tags: tuple[str, ...]) -> str:
+    text = _first_node_text(parent, tags)
+    if text is None:
+        raise KeyError("/".join(tags))
     return text
 
 

--- a/mcp-server/src/mcp_server/subscriptions/change_models.py
+++ b/mcp-server/src/mcp_server/subscriptions/change_models.py
@@ -35,6 +35,14 @@ class SummaryDiff(BaseModel):
     direction: Literal["increase", "decrease", "changed"] = "changed"
 
 
+class BriefingPosting(BaseModel):
+    """AI 브리핑에 노출할 신규 채용 공고 요약."""
+
+    posting_id: str
+    title: str
+    url: str | None = None
+
+
 class SubscriptionChangeResult(BaseModel):
     """AI 브리핑 생성을 위한 구조화된 변화 비교 결과."""
 
@@ -47,6 +55,7 @@ class SubscriptionChangeResult(BaseModel):
     current_summary: dict[str, Any]
     diffs: list[SummaryDiff] = Field(default_factory=list)
     briefing_facts: list[str] = Field(default_factory=list)
+    briefing_postings_by_source: dict[str, list[BriefingPosting]] = Field(default_factory=dict)
     condition_satisfied: bool | None = None
     requires_ai_analysis: bool = False
     condition_reason: str | None = None

--- a/mcp-server/src/mcp_server/subscriptions/change_service.py
+++ b/mcp-server/src/mcp_server/subscriptions/change_service.py
@@ -74,6 +74,99 @@ def extract_current_summary(current: dict[str, Any]) -> dict[str, Any]:
     raise ValueError("current.structured 또는 current.structured.summary 가 필요합니다.")
 
 
+def normalize_current_response(current: dict[str, Any]) -> dict[str, Any]:
+    """current.sources 계약을 단일 MCP 응답으로 병합해 AI 임의 합산을 막는다."""
+    sources = current.get("sources")
+    if not isinstance(sources, list):
+        return current
+
+    merged_postings: list[dict[str, Any]] = []
+    merged_texts: list[str] = []
+    total_count = 0
+    total_ongoing_count = 0
+    skipped_count = 0
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if is_permission_denied_source(source):
+            skipped_count += 1
+            continue
+
+        structured = source.get("structured")
+        structured = structured if isinstance(structured, dict) else {}
+        summary = structured.get("summary")
+        summary = summary if isinstance(summary, dict) else {}
+        postings = structured.get("postings")
+        postings = [posting for posting in postings if isinstance(posting, dict)] if isinstance(postings, list) else []
+
+        total_count += summary_count(summary, "count", len(postings))
+        total_ongoing_count += summary_count(
+            summary,
+            "ongoing_count",
+            sum(1 for posting in postings if is_ongoing_posting(posting)),
+        )
+        merged_postings.extend(postings)
+
+        text = source.get("text")
+        if isinstance(text, str) and text.strip():
+            merged_texts.append(text.strip())
+
+    return {
+        "text": "\n".join(merged_texts),
+        "structured": {
+            "summary": {
+                "count": total_count,
+                "ongoing_count": total_ongoing_count,
+            },
+            "postings": merged_postings,
+            "postings_truncated": any_source_truncated(sources),
+        },
+        "source_url": None,
+        "metadata": {
+            "tool_name": "merged_recruitment_sources",
+            "source_count": len(sources),
+            "skipped_source_count": skipped_count,
+        },
+    }
+
+
+def is_permission_denied_source(source: dict[str, Any]) -> bool:
+    structured = source.get("structured")
+    metadata = source.get("metadata")
+    return (
+        isinstance(structured, dict)
+        and structured.get("permission_denied") is True
+    ) or (
+        isinstance(metadata, dict)
+        and metadata.get("api_status") == "permission_denied"
+    )
+
+
+def summary_count(summary: dict[str, Any], field: str, default: int) -> int:
+    value = summary.get(field)
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def any_source_truncated(sources: list[Any]) -> bool:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        structured = source.get("structured")
+        if isinstance(structured, dict) and structured.get("postings_truncated") is True:
+            return True
+    return False
+
+
 def enrich_summary_with_posting_ids(
     summary: dict[str, Any],
     current: dict[str, Any],
@@ -227,11 +320,12 @@ class SubscriptionChangeService:
     async def compare(self, input_model: SubscriptionChangeInput) -> SubscriptionChangeResult:
         now = datetime.now(UTC)
         params_hash = stable_params_hash(input_model.params)
+        current = normalize_current_response(input_model.current)
         current_summary = enrich_summary_with_posting_ids(
-            extract_current_summary(input_model.current),
-            input_model.current,
+            extract_current_summary(current),
+            current,
         )
-        current_content = input_model.current.get("text")
+        current_content = current.get("text")
         current_content = current_content if isinstance(current_content, str) else None
 
         async with get_session() as session:
@@ -290,7 +384,7 @@ class SubscriptionChangeService:
             briefing_postings_by_source = build_briefing_postings_by_source(
                 comparison_summary,
                 current_summary,
-                input_model.current,
+                current,
             )
             condition_satisfied, requires_ai_analysis, condition_reason = ai_analysis_gate(
                 input_model.params,

--- a/mcp-server/src/mcp_server/subscriptions/change_service.py
+++ b/mcp-server/src/mcp_server/subscriptions/change_service.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_server.db.models import SubscriptionSnapshotState
 from mcp_server.db.session import get_session
 from mcp_server.subscriptions.change_models import (
+    BriefingPosting,
     SubscriptionChangeInput,
     SubscriptionChangeResult,
     SummaryDiff,
@@ -38,6 +39,9 @@ POSTING_ID_KEY_GROUPS = (
     ("worknet_job", ("wanted_auth_no", "wantedAuthNo")),
 )
 POSTING_ONGOING_KEYS = ("is_ongoing", "isOngoing", "ongoing_yn", "ongoingYn")
+BRIEFING_POSTING_SOURCES = ("public_job", "worknet_job")
+POSTING_TITLE_KEYS = ("title", "wantedTitle", "recrutPbancTtl", "recrut_pbanc_ttl")
+POSTING_URL_KEYS = ("src_url", "srcUrl", "info_url", "wantedInfoUrl")
 
 # conditionMetric 과 current summary 필드를 분리해 도메인별 비교 대상이 섞이지 않게 한다.
 METRIC_SUMMARY_KEYS = {
@@ -121,6 +125,13 @@ def posting_identity(posting: dict[str, Any]) -> str | None:
     return None
 
 
+def posting_source(identity: str) -> str | None:
+    source, separator, _ = identity.partition(":")
+    if not separator or source not in BRIEFING_POSTING_SOURCES:
+        return None
+    return source
+
+
 def normalize_posting_id_value(value: Any) -> str | None:
     if value is None:
         return None
@@ -140,6 +151,74 @@ def is_ongoing_posting(posting: dict[str, Any]) -> bool:
             return True
         return str(value).strip().upper() != "N"
     return True
+
+
+def empty_briefing_postings_by_source() -> dict[str, list[BriefingPosting]]:
+    return {source: [] for source in BRIEFING_POSTING_SOURCES}
+
+
+def build_briefing_postings_by_source(
+    baseline_summary: dict[str, Any],
+    current_summary: dict[str, Any],
+    current: dict[str, Any],
+) -> dict[str, list[BriefingPosting]]:
+    """신규 채용 공고 ID를 현재 postings에서 찾아 AI 브리핑용 제목/링크로 묶는다."""
+    result = empty_briefing_postings_by_source()
+    baseline_ids = summary_id_set(baseline_summary, POSTING_IDS_FIELD)
+    current_ids = summary_id_set(current_summary, POSTING_IDS_FIELD)
+    if baseline_ids is None or current_ids is None:
+        return result
+
+    added_ids = current_ids - baseline_ids
+    if not added_ids:
+        return result
+
+    structured = current.get("structured")
+    if not isinstance(structured, dict):
+        return result
+    postings = structured.get("postings")
+    if not isinstance(postings, list):
+        return result
+
+    for posting in postings:
+        if not isinstance(posting, dict):
+            continue
+        identity = posting_identity(posting)
+        if identity not in added_ids:
+            continue
+        source = posting_source(identity)
+        if source is None:
+            continue
+        result[source].append(
+            BriefingPosting(
+                posting_id=identity,
+                title=posting_title(posting),
+                url=posting_url(posting),
+            )
+        )
+    return result
+
+
+def posting_title(posting: dict[str, Any]) -> str:
+    for key in POSTING_TITLE_KEYS:
+        value = posting.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return "(제목 없음)"
+
+
+def posting_url(posting: dict[str, Any]) -> str | None:
+    for key in POSTING_URL_KEYS:
+        value = posting.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
 
 
 class SubscriptionChangeService:
@@ -200,6 +279,7 @@ class SubscriptionChangeService:
                         current_summary=current_summary,
                         diffs=[],
                         briefing_facts=[],
+                        briefing_postings_by_source=empty_briefing_postings_by_source(),
                         condition_satisfied=None,
                         requires_ai_analysis=False,
                         condition_reason="baseline initialized",
@@ -207,6 +287,11 @@ class SubscriptionChangeService:
 
             baseline_summary = row.baseline_summary
             diffs = summary_diffs(baseline_summary, current_summary)
+            briefing_postings_by_source = build_briefing_postings_by_source(
+                baseline_summary,
+                current_summary,
+                input_model.current,
+            )
             condition_satisfied, requires_ai_analysis, condition_reason = ai_analysis_gate(
                 input_model.params,
                 diffs,
@@ -226,6 +311,7 @@ class SubscriptionChangeService:
             current_summary=current_summary,
             diffs=diffs,
             briefing_facts=_briefing_facts(diffs),
+            briefing_postings_by_source=briefing_postings_by_source,
             condition_satisfied=condition_satisfied,
             requires_ai_analysis=requires_ai_analysis,
             condition_reason=condition_reason,

--- a/mcp-server/src/mcp_server/subscriptions/change_service.py
+++ b/mcp-server/src/mcp_server/subscriptions/change_service.py
@@ -285,10 +285,10 @@ class SubscriptionChangeService:
                         condition_reason="baseline initialized",
                     )
 
-            baseline_summary = row.baseline_summary
-            diffs = summary_diffs(baseline_summary, current_summary)
+            comparison_summary = snapshot_comparison_summary(input_model.domain, row)
+            diffs = summary_diffs(comparison_summary, current_summary)
             briefing_postings_by_source = build_briefing_postings_by_source(
-                baseline_summary,
+                comparison_summary,
                 current_summary,
                 input_model.current,
             )
@@ -307,7 +307,7 @@ class SubscriptionChangeService:
             subscription_id=input_model.subscription_id,
             domain=input_model.domain,
             params_hash=params_hash,
-            baseline_summary=baseline_summary,
+            baseline_summary=comparison_summary,
             current_summary=current_summary,
             diffs=diffs,
             briefing_facts=_briefing_facts(diffs),
@@ -330,6 +330,13 @@ class SubscriptionChangeService:
             )
         )
         return result.scalar_one_or_none()
+
+
+def snapshot_comparison_summary(domain: str, row: SubscriptionSnapshotState) -> dict[str, Any]:
+    """채용은 직전 실행 대비 신규 공고를, 그 외 도메인은 최초 baseline 대비 변화를 본다."""
+    if domain == "recruitment" and isinstance(row.latest_summary, dict):
+        return row.latest_summary
+    return row.baseline_summary
 
 
 def summary_diffs(

--- a/mcp-server/src/mcp_server/subscriptions/change_service.py
+++ b/mcp-server/src/mcp_server/subscriptions/change_service.py
@@ -25,6 +25,26 @@ AVG_PRICE_KEYS = frozenset({
     "avg_deposit",
     "avg_monthly_rent",
 })
+COUNT_KEYS = frozenset({"added_count", "count"})
+ONGOING_COUNT_KEYS = frozenset({"ongoing_added_count", "ongoing_count"})
+POSTING_IDS_FIELD = "posting_ids"
+ONGOING_POSTING_IDS_FIELD = "ongoing_posting_ids"
+INTERNAL_SUMMARY_FIELDS = frozenset({POSTING_IDS_FIELD, ONGOING_POSTING_IDS_FIELD})
+
+# 현재는 ALIO/워크넷의 공식 공고 ID만 확정 계약으로 사용한다.
+# URL/id 같은 범용 fallback 은 임시 추정값이라 오탐 위험이 있어 제외한다.
+POSTING_ID_KEY_GROUPS = (
+    ("public_job", ("pblnt_sn", "pblntSn", "recrutPblntSn", "recrut_pblnt_sn")),
+    ("worknet_job", ("wanted_auth_no", "wantedAuthNo")),
+)
+POSTING_ONGOING_KEYS = ("is_ongoing", "isOngoing", "ongoing_yn", "ongoingYn")
+
+# conditionMetric 과 current summary 필드를 분리해 도메인별 비교 대상이 섞이지 않게 한다.
+METRIC_SUMMARY_KEYS = {
+    "AVG_PRICE": AVG_PRICE_KEYS,
+    "COUNT": COUNT_KEYS,
+    "ONGOING_COUNT": ONGOING_COUNT_KEYS,
+}
 
 
 def stable_params_hash(params: dict[str, Any]) -> str:
@@ -50,13 +70,88 @@ def extract_current_summary(current: dict[str, Any]) -> dict[str, Any]:
     raise ValueError("current.structured 또는 current.structured.summary 가 필요합니다.")
 
 
+def enrich_summary_with_posting_ids(
+    summary: dict[str, Any],
+    current: dict[str, Any],
+) -> dict[str, Any]:
+    """채용 응답의 공고 ID 목록을 summary 에 보강해 count 동률 교체를 감지한다."""
+    posting_id_sets = extract_posting_id_sets(current)
+    if posting_id_sets is None:
+        return dict(summary)
+
+    posting_ids, ongoing_posting_ids = posting_id_sets
+    enriched = dict(summary)
+    enriched[POSTING_IDS_FIELD] = sorted(posting_ids)
+    enriched[ONGOING_POSTING_IDS_FIELD] = sorted(ongoing_posting_ids)
+    return enriched
+
+
+def extract_posting_id_sets(current: dict[str, Any]) -> tuple[set[str], set[str]] | None:
+    """structured.postings 에서 전체/진행중 공고 ID 집합을 추출한다."""
+    structured = current.get("structured")
+    if not isinstance(structured, dict):
+        return None
+
+    postings = structured.get("postings")
+    if not isinstance(postings, list):
+        return None
+
+    posting_ids: set[str] = set()
+    ongoing_posting_ids: set[str] = set()
+    for posting in postings:
+        if not isinstance(posting, dict):
+            continue
+        posting_id = posting_identity(posting)
+        if posting_id is None:
+            continue
+        posting_ids.add(posting_id)
+        if is_ongoing_posting(posting):
+            ongoing_posting_ids.add(posting_id)
+    return posting_ids, ongoing_posting_ids
+
+
+def posting_identity(posting: dict[str, Any]) -> str | None:
+    """공고별 안정 식별자를 만든다."""
+    for namespace, keys in POSTING_ID_KEY_GROUPS:
+        for key in keys:
+            value = posting.get(key)
+            normalized = normalize_posting_id_value(value)
+            if normalized is not None:
+                return f"{namespace}:{normalized}"
+    return None
+
+
+def normalize_posting_id_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def is_ongoing_posting(posting: dict[str, Any]) -> bool:
+    """진행 여부 필드가 없으면 현재 조회 결과에 포함된 공고로 보고 진행중으로 취급한다."""
+    for key in POSTING_ONGOING_KEYS:
+        if key not in posting:
+            continue
+        value = posting[key]
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return True
+        return str(value).strip().upper() != "N"
+    return True
+
+
 class SubscriptionChangeService:
     """구독별 기준/최신 스냅샷을 저장하고 요약 변화 목록을 생성한다."""
 
     async def compare(self, input_model: SubscriptionChangeInput) -> SubscriptionChangeResult:
         now = datetime.now(UTC)
         params_hash = stable_params_hash(input_model.params)
-        current_summary = extract_current_summary(input_model.current)
+        current_summary = enrich_summary_with_posting_ids(
+            extract_current_summary(input_model.current),
+            input_model.current,
+        )
         current_content = input_model.current.get("text")
         current_content = current_content if isinstance(current_content, str) else None
 
@@ -156,14 +251,73 @@ def summary_diffs(
     current_summary: dict[str, Any],
 ) -> list[SummaryDiff]:
     """요약 dict 의 공통 필드 중 값이 달라진 항목만 변화 목록으로 반환한다."""
-    diffs: list[SummaryDiff] = []
+    diffs = posting_id_diffs(baseline_summary, current_summary)
     for field in sorted(set(baseline_summary) & set(current_summary)):
+        if field in INTERNAL_SUMMARY_FIELDS:
+            continue
         baseline_value = baseline_summary[field]
         current_value = current_summary[field]
         if baseline_value == current_value:
             continue
         diffs.append(build_diff(field, baseline_value, current_value))
     return diffs
+
+
+def posting_id_diffs(
+    baseline_summary: dict[str, Any],
+    current_summary: dict[str, Any],
+) -> list[SummaryDiff]:
+    """공고 ID 집합을 비교해 신규/제외 공고 수를 변화 목록으로 만든다."""
+    diffs: list[SummaryDiff] = []
+    diffs.extend(
+        posting_set_diffs(
+            baseline_summary,
+            current_summary,
+            POSTING_IDS_FIELD,
+            "added_count",
+            "removed_count",
+        )
+    )
+    diffs.extend(
+        posting_set_diffs(
+            baseline_summary,
+            current_summary,
+            ONGOING_POSTING_IDS_FIELD,
+            "ongoing_added_count",
+            "ongoing_removed_count",
+        )
+    )
+    return diffs
+
+
+def posting_set_diffs(
+    baseline_summary: dict[str, Any],
+    current_summary: dict[str, Any],
+    id_field: str,
+    added_field: str,
+    removed_field: str,
+) -> list[SummaryDiff]:
+    baseline_ids = summary_id_set(baseline_summary, id_field)
+    current_ids = summary_id_set(current_summary, id_field)
+    if baseline_ids is None or current_ids is None:
+        return []
+
+    # added_ids 는 baseline 에 없고 current 에 새로 등장한 공고 ID 집합이다.
+    added_ids = current_ids - baseline_ids
+    removed_ids = baseline_ids - current_ids
+    diffs: list[SummaryDiff] = []
+    if added_ids:
+        diffs.append(build_diff(added_field, 0, len(added_ids)))
+    if removed_ids:
+        diffs.append(build_diff(removed_field, 0, len(removed_ids)))
+    return diffs
+
+
+def summary_id_set(summary: dict[str, Any], field: str) -> set[str] | None:
+    value = summary.get(field)
+    if not isinstance(value, list):
+        return None
+    return {str(item) for item in value}
 
 
 def ai_analysis_gate(params: dict[str, Any], diffs: list[SummaryDiff]) -> tuple[bool | None, bool, str]:
@@ -220,9 +374,9 @@ def condition_satisfied(diffs: list[SummaryDiff], condition: StructuredCondition
 
 
 def metric_matches(field: str, metric: str) -> bool:
-    if metric == "AVG_PRICE":
-        return field in AVG_PRICE_KEYS
-    return False
+    # summary_fields는 현재 conditionMetric이 비교할 summary 필드 집합이다.
+    summary_fields = METRIC_SUMMARY_KEYS.get(metric)
+    return summary_fields is not None and field in summary_fields
 
 
 def direction_matches(delta: Decimal, direction: str) -> bool:

--- a/mcp-server/src/mcp_server/subscriptions/draft_normalizer.py
+++ b/mcp-server/src/mcp_server/subscriptions/draft_normalizer.py
@@ -10,7 +10,8 @@
 안전장치:
 - "강남구 아파트 변경"처럼 자료유형이 빠진 요청은 매매로 추정하지 않고 dealType 을 요구한다.
 - 전세/월세 요청은 search_house_price 로 변환하지 않고 unsupportedCapability 로 돌려준다.
-- 채용/법률/경매는 도메인 분류는 유지하되 planned capability 로 응답해 UX 와 실행 범위를 맞춘다.
+- 채용은 공고 수 변화 감시 계약으로 구조화한다.
+- 법률/경매는 도메인 분류는 유지하되 planned capability 로 응답해 UX 와 실행 범위를 맞춘다.
 """
 
 from __future__ import annotations
@@ -20,14 +21,20 @@ from decimal import Decimal
 
 from mcp_server.subscriptions.draft_models import (
     NormalizedSubscriptionDraft,
+    ParsedTaskDraft,
+    PreviousSubscriptionDraft,
     SubscriptionDraftNormalizationInput,
 )
 
 _TOOL_APT_TRADE = "search_house_price"
+_TOOL_PUBLIC_JOB = "search_public_job"
+_TOOL_WORKNET_JOB = "search_worknet_job"
+_INTENT_JOB_POSTING_CHANGE = "job_posting_change"
 _PENDING_DEAL_TYPE_CONFIRMATION = "pendingDealTypeConfirmation"
 
 _REGION = re.compile(r"([가-힣]+(?:특별자치시|특별자치도|특별시|광역시|시|군|구))")
 _THRESHOLD = re.compile(r"(\d+(?:\.\d+)?)\s*(%|퍼센트|프로|만원|억)?")
+_COUNT_THRESHOLD = re.compile(r"(\d+(?:\.\d+)?)\s*(?:건|개)")
 
 _SIDO_ONLY_REGIONS = {
     "서울특별시",
@@ -51,9 +58,25 @@ _REGION_ALIASES = {
 
 _PLANNED_DOMAINS = {
     "law-regulation": "법률/규제",
-    "recruitment": "채용",
     "auction": "경매/희소매물",
 }
+
+_RECRUITMENT_DEFAULT_PAGE_NO = "1"
+_RECRUITMENT_DEFAULT_PAGE_SIZE = "20"
+_RECRUITMENT_KEYWORD_PATTERNS = (
+    re.compile(r"(.+?)\s*채용(?:\s*(?:공고|알림|정보|새 공고|신규 공고|진행중 공고))?$"),
+    re.compile(r"채용\s+(.+?)(?:\s*(?:공고|알림|정보|새 공고|신규 공고|진행중 공고))?$"),
+    re.compile(r"(.+?)\s*(?:구인|일자리)(?:\s*(?:공고|알림|정보))?$"),
+)
+_RECRUITMENT_SOURCE_PREFIXES = ("공공기관", "공기업", "공공", "기관", "워크넷")
+_RECRUITMENT_KEYWORD_SUFFIXES = (
+    "새 공고",
+    "신규 공고",
+    "진행중 공고",
+    "공고",
+    "알림",
+    "정보",
+)
 
 
 # ─────────────────────────────────────────────
@@ -114,6 +137,14 @@ def normalize_subscription_draft(
             missing_fields=["unsupportedIntent"],
             question="알림 수정과 삭제는 아직 채팅 생성 플로우에서 처리하지 않아요.",
             confidence=task.confidence,
+        )
+
+    if domain_name == "recruitment":
+        return _normalize_recruitment_draft(
+            input_model=input_model,
+            query=query,
+            task=task,
+            previous=previous if can_reuse_previous else None,
         )
 
     # planned 도메인은 사용자의 의도를 보존하되 실제 MCP 조회 도구로는 연결하지 않는다.
@@ -204,6 +235,182 @@ def normalize_subscription_draft(
         question=_question_for_missing(missing),
         confidence=task.confidence,
     )
+
+
+# ─────────────────────────────────────────────
+# 채용 정규화
+# ─────────────────────────────────────────────
+
+def _normalize_recruitment_draft(
+    *,
+    input_model: SubscriptionDraftNormalizationInput,
+    query: str | None,
+    task: ParsedTaskDraft,
+    previous: PreviousSubscriptionDraft | None,
+) -> NormalizedSubscriptionDraft:
+    """채용 구독 요청을 공고 수 변화 감시 계약으로 변환한다."""
+    text = _joined_text(input_model.user_message, query, task.condition, task.target)
+    previous_params = previous.monitoring_params if previous is not None else {}
+    tool_name = _recruitment_tool_name(text, previous)
+    keyword = (
+        _extract_recruitment_keyword(query, task.target)
+        or previous_params.get("keyword")
+    )
+    condition = (
+        _parse_recruitment_condition(task.condition, text)
+        or _condition_from_parameters(previous_params)
+    )
+
+    params: dict[str, str] = {
+        "dataToolName": tool_name,
+    }
+    missing: list[str] = []
+
+    if keyword:
+        params["keyword"] = keyword
+    else:
+        missing.append("keyword")
+
+    if tool_name == _TOOL_PUBLIC_JOB:
+        params["page_no"] = _RECRUITMENT_DEFAULT_PAGE_NO
+        params["num_of_rows"] = _RECRUITMENT_DEFAULT_PAGE_SIZE
+        if keyword:
+            params["recrut_pbanc_ttl"] = keyword
+        # 채용 구독은 사용자가 "마감 포함"을 명시하지 않는 한 현재 지원 가능한 공고만 감시한다.
+        params["ongoing_yn"] = "Y"
+    else:
+        params["start_page"] = _RECRUITMENT_DEFAULT_PAGE_NO
+        params["display"] = _RECRUITMENT_DEFAULT_PAGE_SIZE
+
+    if condition is None:
+        missing.append("condition")
+    else:
+        params.update(condition)
+
+    return _draft(
+        query=_recruitment_query(query, keyword) if not missing else query,
+        domain_name="recruitment",
+        intent=_INTENT_JOB_POSTING_CHANGE,
+        tool_name=tool_name,
+        parameters=params,
+        missing_fields=missing,
+        question=_recruitment_question_for_missing(missing),
+        confidence=task.confidence,
+    )
+
+
+def _recruitment_tool_name(
+    text: str,
+    previous: PreviousSubscriptionDraft | None,
+) -> str:
+    previous_tool = None
+    if previous is not None:
+        previous_tool = previous.monitoring_params.get("dataToolName") or previous.tool_name
+    if previous_tool in {_TOOL_PUBLIC_JOB, _TOOL_WORKNET_JOB}:
+        return previous_tool
+
+    # 워크넷을 명시한 요청만 Worknet 으로 보낸다. 기본은 권한 이슈가 없는 공공 채용 캐시다.
+    if "워크넷" in text:
+        return _TOOL_WORKNET_JOB
+    return _TOOL_PUBLIC_JOB
+
+
+def _extract_recruitment_keyword(query: str | None, target: str | None) -> str | None:
+    """파서가 구조화한 query/target 에서 채용 검색어를 추출한다."""
+    return _extract_recruitment_keyword_from_text(query) or _extract_recruitment_keyword_from_text(target)
+
+
+def _extract_recruitment_keyword_from_text(text: str | None) -> str | None:
+    if not text:
+        return None
+    normalized = _normalize_recruitment_text(text)
+    for pattern in _RECRUITMENT_KEYWORD_PATTERNS:
+        match = pattern.fullmatch(normalized)
+        if match is None:
+            continue
+        keyword = _clean_recruitment_keyword(match.group(1))
+        if keyword:
+            return keyword
+    return None
+
+
+def _normalize_recruitment_text(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip(" .,!?~"))
+
+
+def _clean_recruitment_keyword(value: str) -> str | None:
+    keyword = _normalize_recruitment_text(value)
+    # 공공기관/워크넷 같은 출처 단서는 tool 선택용이고, API 검색어에는 넣지 않는다.
+    for prefix in _RECRUITMENT_SOURCE_PREFIXES:
+        if keyword == prefix:
+            return None
+        if keyword.startswith(f"{prefix} "):
+            keyword = keyword.removeprefix(prefix).strip()
+            break
+    for suffix in _RECRUITMENT_KEYWORD_SUFFIXES:
+        if keyword.endswith(f" {suffix}"):
+            keyword = keyword.removesuffix(suffix).strip()
+            break
+    return keyword or None
+
+
+def _parse_recruitment_condition(raw_condition: str | None, text: str) -> dict[str, str] | None:
+    """채용의 자연어 이벤트 조건을 공고 수 delta 조건으로 바꾼다."""
+    merged = _joined_text(raw_condition, text)
+    if not _has_recruitment_change_condition(merged):
+        return None
+
+    # 채용 조건은 "3건" 같은 수량만 threshold 로 본다. 시간/연도 숫자는 공고 수가 아니다.
+    match = _COUNT_THRESHOLD.search(merged)
+    threshold = Decimal(match.group(1)).normalize() if match else Decimal("1")
+    return {
+        "conditionMetric": "ONGOING_COUNT" if "진행중" in merged else "COUNT",
+        "conditionDirection": _recruitment_condition_direction(merged),
+        "conditionOperator": _condition_operator(merged),
+        "conditionThreshold": format(threshold, "f"),
+        "conditionUnit": "COUNT",
+    }
+
+
+def _has_recruitment_change_condition(text: str) -> bool:
+    return any(
+        word in text
+        for word in [
+            "새 공고",
+            "신규",
+            "새로",
+            "뜨면",
+            "올라오면",
+            "등록",
+            "변화",
+            "변동",
+            "늘면",
+            "증가",
+            "이상",
+        ]
+    )
+
+
+def _recruitment_condition_direction(text: str) -> str:
+    if any(word in text for word in ["감소", "줄면", "줄어", "마감"]):
+        return "DOWN"
+    return "UP"
+
+
+def _recruitment_query(query: str | None, keyword: str | None) -> str | None:
+    if query:
+        return query
+    if keyword:
+        return f"{keyword} 채용 공고"
+    return query
+
+
+def _recruitment_question_for_missing(missing: list[str]) -> str:
+    if "keyword" in missing:
+        return "어떤 채용 공고를 확인할까요? 예: 백엔드, 데이터, 공공기관 인턴 등"
+    if "condition" in missing:
+        return "어떤 변화가 있을 때 알림을 받을까요? 예: 새 공고가 1건 이상 올라오면"
+    return ""
 
 
 # ─────────────────────────────────────────────

--- a/mcp-server/src/mcp_server/subscriptions/recruitment_keyword_validation.py
+++ b/mcp-server/src/mcp_server/subscriptions/recruitment_keyword_validation.py
@@ -1,0 +1,202 @@
+"""채용 구독 검색어 0건 검증과 후보 추천.
+
+normalize_subscription_draft 자체는 문장 구조화가 책임이다. 이 모듈은 구조화된
+채용 keyword 를 현재 채용 캐시/응답과 대조해 오타 가능성이 큰 경우에만
+사용자 확인용 missing field 를 보강한다.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Iterable
+
+from mcp_server.config import get_settings
+from mcp_server.domains.jobs.normalizer import PublicJobPosting, normalize_public_job
+from mcp_server.sources import api_source_service
+from mcp_server.subscriptions.draft_models import NormalizedSubscriptionDraft
+
+_KEYWORD_CONFIRMATION = "keywordConfirmation"
+_ZERO_RESULTS = "ZERO_RESULTS"
+_TOOL_PUBLIC_JOB = "search_public_job"
+_TOKEN = re.compile(r"[0-9A-Za-z가-힣+#.]{2,}")
+_MIN_SIMILARITY = 0.66
+_STOPWORDS = {
+    "공개",
+    "공개채용",
+    "공고",
+    "계약직",
+    "기간제",
+    "모집",
+    "신입",
+    "인턴",
+    "정규직",
+    "직원",
+    "채용",
+}
+
+
+@dataclass(frozen=True)
+class RecruitmentKeywordValidationResult:
+    """채용 검색어 검증 결과."""
+
+    keyword: str
+    result_count: int
+    suggested_keyword: str | None = None
+
+
+async def validate_recruitment_keyword_for_draft(
+    draft: NormalizedSubscriptionDraft,
+) -> NormalizedSubscriptionDraft:
+    """채용 초안에 0건 후보 추천 결과를 best-effort 로 반영한다."""
+    if draft.domain_name != "recruitment":
+        return draft
+    if _KEYWORD_CONFIRMATION in draft.missing_fields:
+        return draft
+    if "keyword" in draft.missing_fields:
+        return draft
+
+    tool_name = draft.parameters.get("dataToolName") or draft.tool_name
+    if tool_name != _TOOL_PUBLIC_JOB:
+        return draft
+
+    keyword = (draft.parameters.get("keyword") or "").strip()
+    if not keyword:
+        return draft
+
+    validation = await validate_public_job_keyword(keyword)
+    if validation is None:
+        return draft
+    return apply_recruitment_keyword_validation(draft, validation)
+
+
+async def validate_public_job_keyword(
+    keyword: str,
+) -> RecruitmentKeywordValidationResult | None:
+    """공공기관 채용 캐시에서 현재 검색어 결과 수와 후보를 계산한다.
+
+    외부 API/캐시 접근 실패는 구독 등록 전체 실패가 아니라 검증 생략으로 처리한다.
+    """
+    keyword = keyword.strip()
+    if not keyword:
+        return None
+
+    try:
+        # tools.jobs 는 tools 패키지 로딩 중 subscriptions 도구를 함께 import 하므로 지연 import 한다.
+        from mcp_server.tools.jobs import _resolve_source_id
+
+        settings = get_settings()
+        if not settings.moef_public_job_api_key:
+            return None
+
+        source_id = await _resolve_source_id(_TOOL_PUBLIC_JOB)
+        raw = await api_source_service.fetch(
+            source_id=source_id,
+            params={
+                "serviceKey": settings.moef_public_job_api_key,
+                "pageNo": 1,
+                "numOfRows": 100,
+                "resultType": "json",
+            },
+        )
+        postings = normalize_public_job(raw.content)
+    except Exception:
+        return None
+
+    matched = [
+        posting for posting in postings
+        if _is_ongoing(posting) and keyword in (posting.title or "")
+    ]
+    if matched:
+        return RecruitmentKeywordValidationResult(
+            keyword=keyword,
+            result_count=len(matched),
+        )
+
+    return RecruitmentKeywordValidationResult(
+        keyword=keyword,
+        result_count=0,
+        suggested_keyword=suggest_recruitment_keyword(keyword, postings),
+    )
+
+
+def apply_recruitment_keyword_validation(
+    draft: NormalizedSubscriptionDraft,
+    validation: RecruitmentKeywordValidationResult | None,
+) -> NormalizedSubscriptionDraft:
+    """0건 + 후보가 있을 때 백엔드 확인용 missing field 를 추가한다."""
+    if validation is None or validation.result_count > 0:
+        return draft
+
+    suggested = (validation.suggested_keyword or "").strip()
+    if not suggested or suggested == validation.keyword:
+        return draft
+
+    parameters = dict(draft.parameters)
+    parameters["keywordValidationStatus"] = _ZERO_RESULTS
+    parameters["keywordOriginal"] = validation.keyword
+    parameters["suggestedKeyword"] = suggested
+
+    missing_fields = list(draft.missing_fields)
+    if _KEYWORD_CONFIRMATION not in missing_fields:
+        missing_fields.append(_KEYWORD_CONFIRMATION)
+
+    question = (
+        f"현재 '{validation.keyword}' 검색 결과가 없어요. "
+        f"'{suggested}'를 뜻한 걸까요? 맞으면 '응', 아니면 원하는 채용 검색어를 다시 입력해 주세요."
+    )
+    return draft.model_copy(
+        update={
+            "parameters": parameters,
+            "missing_fields": missing_fields,
+            "question": question,
+        }
+    )
+
+
+def suggest_recruitment_keyword(
+    keyword: str,
+    postings: Iterable[PublicJobPosting],
+) -> str | None:
+    """현재 공고 제목/NCS 토큰 중 오타 가능성이 가장 높은 후보를 찾는다."""
+    normalized_keyword = _normalize_keyword(keyword)
+    if not normalized_keyword:
+        return None
+
+    best_term: str | None = None
+    best_score = 0.0
+    for term in sorted(_candidate_terms(postings)):
+        normalized_term = _normalize_keyword(term)
+        if not normalized_term or normalized_term == normalized_keyword:
+            continue
+        if abs(len(normalized_term) - len(normalized_keyword)) > 2:
+            continue
+        score = SequenceMatcher(None, normalized_keyword, normalized_term).ratio()
+        if score > best_score:
+            best_score = score
+            best_term = term
+
+    if best_score < _MIN_SIMILARITY:
+        return None
+    return best_term
+
+
+def _candidate_terms(postings: Iterable[PublicJobPosting]) -> set[str]:
+    terms: set[str] = set()
+    for posting in postings:
+        if not _is_ongoing(posting):
+            continue
+        for source in [posting.title, *posting.ncs_categories]:
+            for token in _TOKEN.findall(source or ""):
+                if token not in _STOPWORDS:
+                    terms.add(token)
+    return terms
+
+
+def _normalize_keyword(value: str) -> str:
+    return re.sub(r"\s+", "", value.strip().lower())
+
+
+def _is_ongoing(posting: PublicJobPosting) -> bool:
+    return posting.is_ongoing is not False

--- a/mcp-server/src/mcp_server/tools/cache_check.py
+++ b/mcp-server/src/mcp_server/tools/cache_check.py
@@ -216,6 +216,7 @@ def _format_bill_info(content: str, cached_at: datetime, params: dict) -> dict[s
 def _format_public_job(content: str, cached_at: datetime, params: dict) -> dict[str, Any]:
     records = normalize_public_job(content)
     filtered = records
+    # 채용 캐시는 bulk 원천 데이터라 구독 조건 필터를 formatter에서 재적용한다.
     ongoing_yn = _optional_text(params.get("ongoing_yn") or params.get("ongoingYn"))
     keyword = _optional_text(params.get("recrut_pbanc_ttl") or params.get("recrutPbancTtl"))
     if ongoing_yn == "Y":
@@ -271,6 +272,7 @@ def _format_worknet_job(content: str, cached_at: datetime, params: dict) -> dict
     try:
         records = normalize_worknet_job(content)
     except WorknetPermissionDeniedError:
+        # 권한 거부 캐시는 Worknet source만 제외할 수 있도록 structured에도 표시한다.
         return {
             "text": "워크넷 채용공고: 사업자/기관 회원 권한 필요 (캐시된 권한 거부 응답).",
             "structured": {
@@ -296,6 +298,7 @@ def _format_worknet_job(content: str, cached_at: datetime, params: dict) -> dict
         }
 
     filtered = records
+    # Worknet도 API 호출은 wide fetch이고, 구독 keyword는 캐시 읽기 단계에서 적용한다.
     keyword = _optional_text(params.get("keyword"))
     if keyword:
         filtered = [

--- a/mcp-server/src/mcp_server/tools/cache_check.py
+++ b/mcp-server/src/mcp_server/tools/cache_check.py
@@ -213,19 +213,29 @@ def _format_bill_info(content: str, cached_at: datetime, params: dict) -> dict[s
     }
 
 
-def _format_public_job(content: str, cached_at: datetime, _params: dict) -> dict[str, Any]:
+def _format_public_job(content: str, cached_at: datetime, params: dict) -> dict[str, Any]:
     records = normalize_public_job(content)
-    ongoing_count = sum(1 for r in records if r.is_ongoing)
-    institutes = sorted({r.institute for r in records if r.institute})
-    begin_dates = [r.pbanc_begin_date for r in records if r.pbanc_begin_date]
+    filtered = records
+    ongoing_yn = _optional_text(params.get("ongoing_yn") or params.get("ongoingYn"))
+    keyword = _optional_text(params.get("recrut_pbanc_ttl") or params.get("recrutPbancTtl"))
+    if ongoing_yn == "Y":
+        filtered = [r for r in filtered if r.is_ongoing]
+    if keyword:
+        filtered = [r for r in filtered if keyword in (r.title or "")]
+
+    ongoing_count = sum(1 for r in filtered if r.is_ongoing)
+    institutes = sorted({r.institute for r in filtered if r.institute})
+    begin_dates = [r.pbanc_begin_date for r in filtered if r.pbanc_begin_date]
     summary = {
-        "count": len(records),
+        "count": len(filtered),
         "ongoing_count": ongoing_count,
         "institutes": institutes,
         "latest_pbanc_begin_date": max(begin_dates).isoformat() if begin_dates else None,
     }
-    sorted_records = sorted(records, key=lambda r: r.pbanc_begin_date or date.min, reverse=True)
-    returned = sorted_records[:_MAX_RESULTS]
+    sorted_records = sorted(filtered, key=lambda r: r.pbanc_begin_date or date.min, reverse=True)
+    page_no = _positive_int(params.get("page_no") or params.get("pageNo"), 1)
+    num_of_rows = _positive_int(params.get("num_of_rows") or params.get("numOfRows"), _MAX_RESULTS)
+    returned = _page_records(sorted_records, page_no, num_of_rows)
 
     count = summary["count"]
     text = (
@@ -239,7 +249,12 @@ def _format_public_job(content: str, cached_at: datetime, _params: dict) -> dict
             "summary": summary,
             "postings": [r.model_dump(mode="json") for r in returned],
             "postings_truncated": len(sorted_records) > _MAX_RESULTS,
-            "query": {"page_no": 1, "num_of_rows": _MAX_RESULTS, "ongoing_yn": None, "recrut_pbanc_ttl": None},
+            "query": {
+                "page_no": page_no,
+                "num_of_rows": num_of_rows,
+                "ongoing_yn": ongoing_yn,
+                "recrut_pbanc_ttl": keyword,
+            },
         },
         "source_url": None,
         "metadata": {
@@ -252,13 +267,23 @@ def _format_public_job(content: str, cached_at: datetime, _params: dict) -> dict
     }
 
 
-def _format_worknet_job(content: str, cached_at: datetime, _params: dict) -> dict[str, Any]:
+def _format_worknet_job(content: str, cached_at: datetime, params: dict) -> dict[str, Any]:
     try:
         records = normalize_worknet_job(content)
     except WorknetPermissionDeniedError:
         return {
             "text": "워크넷 채용공고: 사업자/기관 회원 권한 필요 (캐시된 권한 거부 응답).",
-            "structured": {"summary": {"count": 0}, "postings": [], "postings_truncated": False},
+            "structured": {
+                "summary": {"count": 0},
+                "postings": [],
+                "postings_truncated": False,
+                "permission_denied": True,
+                "query": {
+                    "keyword": _optional_text(params.get("keyword")),
+                    "page_no": _positive_int(params.get("start_page") or params.get("page_no"), 1),
+                    "display": _positive_int(params.get("display"), _MAX_RESULTS),
+                },
+            },
             "source_url": None,
             "metadata": {
                 "fetched_at": cached_at.isoformat(),
@@ -270,15 +295,25 @@ def _format_worknet_job(content: str, cached_at: datetime, _params: dict) -> dic
             },
         }
 
-    reg_dates = [r.reg_date for r in records if r.reg_date]
-    emp_types = sorted({r.emp_type for r in records if r.emp_type})
+    filtered = records
+    keyword = _optional_text(params.get("keyword"))
+    if keyword:
+        filtered = [
+            r for r in filtered
+            if keyword in (r.title or "") or keyword in (r.company or "")
+        ]
+
+    reg_dates = [r.reg_date for r in filtered if r.reg_date]
+    emp_types = sorted({r.emp_type for r in filtered if r.emp_type})
     summary = {
-        "count": len(records),
+        "count": len(filtered),
         "latest_reg_date": max(reg_dates).isoformat() if reg_dates else None,
         "emp_types": emp_types,
     }
-    sorted_records = sorted(records, key=lambda r: r.reg_date or date.min, reverse=True)
-    returned = sorted_records[:_MAX_RESULTS]
+    sorted_records = sorted(filtered, key=lambda r: r.reg_date or date.min, reverse=True)
+    start_page = _positive_int(params.get("start_page") or params.get("page_no"), 1)
+    display = _positive_int(params.get("display"), _MAX_RESULTS)
+    returned = _page_records(sorted_records, start_page, display)
 
     count = summary["count"]
     text = (
@@ -291,7 +326,8 @@ def _format_worknet_job(content: str, cached_at: datetime, _params: dict) -> dic
             "summary": summary,
             "postings": [r.model_dump(mode="json") for r in returned],
             "postings_truncated": len(sorted_records) > _MAX_RESULTS,
-            "query": {"page_no": 1, "num_of_rows": _MAX_RESULTS},
+            "permission_denied": False,
+            "query": {"keyword": keyword, "page_no": start_page, "display": display},
         },
         "source_url": None,
         "metadata": {
@@ -302,6 +338,27 @@ def _format_worknet_job(content: str, cached_at: datetime, _params: dict) -> dic
             "cache_used": True,
         },
     }
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _page_records(records: list[Any], page_no: int, page_size: int) -> list[Any]:
+    start = (page_no - 1) * page_size
+    end = start + page_size
+    return records[start:end][:_MAX_RESULTS]
 
 
 def _to_eok(amount_won: int | None) -> str:

--- a/mcp-server/src/mcp_server/tools/subscriptions.py
+++ b/mcp-server/src/mcp_server/tools/subscriptions.py
@@ -20,6 +20,9 @@ from mcp_server.subscriptions.draft_models import SubscriptionDraftNormalization
 from mcp_server.subscriptions.draft_normalizer import (
     normalize_subscription_draft as normalize_subscription_draft_service,
 )
+from mcp_server.subscriptions.recruitment_keyword_validation import (
+    validate_recruitment_keyword_for_draft,
+)
 
 _TOOL_COMPARE_SUBSCRIPTION_CHANGE = "compare_subscription_change"
 _TOOL_NORMALIZE_SUBSCRIPTION_DRAFT = "normalize_subscription_draft"
@@ -58,6 +61,7 @@ async def normalize_subscription_draft(input: SubscriptionDraftNormalizationInpu
     합성한 뒤, missingFields 가 비어 있을 때만 확인 화면으로 넘긴다.
     """
     result = normalize_subscription_draft_service(input)
+    result = await validate_recruitment_keyword_for_draft(result)
     text = (
         "구독 초안 구조화 완료."
         if not result.missing_fields

--- a/mcp-server/tests/domains/jobs/test_normalizer.py
+++ b/mcp-server/tests/domains/jobs/test_normalizer.py
@@ -199,6 +199,35 @@ def test_normalize_worknet_job_normal_response_extracts_records():
     assert records[0].reg_date == date(2026, 4, 20)
 
 
+def test_normalize_worknet_job_official_list_fields_extracts_record_id():
+    """고용24 공식 목록 응답 필드명(title/company/wantedAuthNo) 정규화."""
+    xml = """<?xml version="1.0"?>
+<wantedRoot>
+  <total>1</total>
+  <startPage>1</startPage>
+  <display>10</display>
+  <wanted>
+    <wantedAuthNo>K120032605010001</wantedAuthNo>
+    <company>테스트회사</company>
+    <title>백엔드 개발자</title>
+    <salTpNm>연봉</salTpNm>
+    <region>서울 강남구</region>
+    <minEdubg>대졸(4년)</minEdubg>
+    <regDt>20260425</regDt>
+    <closeDt>20260525</closeDt>
+    <wantedInfoUrl>https://www.work24.go.kr/wk/a/b/1200/retriveDtlEmpSrchList.do</wantedInfoUrl>
+  </wanted>
+</wantedRoot>"""
+    records = normalize_worknet_job(xml)
+
+    assert len(records) == 1
+    assert records[0].wanted_auth_no == "K120032605010001"
+    assert records[0].title == "백엔드 개발자"
+    assert records[0].company == "테스트회사"
+    assert records[0].region == "서울 강남구"
+    assert records[0].min_education == "대졸(4년)"
+
+
 def test_normalize_worknet_job_empty_pub_jobs_returns_empty_list():
     """<wanted> 노드 없음 → 빈 리스트 (에러 아님)."""
     xml = """<?xml version="1.0"?>

--- a/mcp-server/tests/subscriptions/test_change_service.py
+++ b/mcp-server/tests/subscriptions/test_change_service.py
@@ -96,6 +96,7 @@ def _posting(posting_id: str, *, is_ongoing: bool = True) -> dict:
         "pblnt_sn": posting_id,
         "title": f"{posting_id} 백엔드 개발자",
         "is_ongoing": is_ongoing,
+        "src_url": f"https://public.example/jobs/{posting_id}",
     }
 
 
@@ -281,6 +282,15 @@ async def test_recruitment_detects_new_posting_ids_when_count_is_unchanged(
     assert result.condition_reason == "condition satisfied"
     assert result.diffs[0].field == "added_count"
     assert result.diffs[0].delta == 1
+    assert [
+        posting.model_dump() for posting in result.briefing_postings_by_source["public_job"]
+    ] == [
+        {
+            "posting_id": "public_job:C",
+            "title": "C 백엔드 개발자",
+            "url": "https://public.example/jobs/C",
+        }
+    ]
 
 
 async def test_recruitment_detects_new_ongoing_posting_ids_when_ongoing_count_is_unchanged(
@@ -332,7 +342,11 @@ async def test_recruitment_detects_new_worknet_posting_ids_when_count_is_unchang
             count=1,
             ongoing_count=1,
             metric="COUNT",
-            postings=[{"wanted_auth_no": "K120032605020002", "title": "서버 개발자"}],
+            postings=[{
+                "wanted_auth_no": "K120032605020002",
+                "title": "서버 개발자",
+                "info_url": "https://work.example/jobs/K120032605020002",
+            }],
         )
     )
 
@@ -343,6 +357,15 @@ async def test_recruitment_detects_new_worknet_posting_ids_when_count_is_unchang
     assert result.condition_reason == "condition satisfied"
     assert result.diffs[0].field == "added_count"
     assert result.diffs[0].delta == 1
+    assert [
+        posting.model_dump() for posting in result.briefing_postings_by_source["worknet_job"]
+    ] == [
+        {
+            "posting_id": "worknet_job:K120032605020002",
+            "title": "서버 개발자",
+            "url": "https://work.example/jobs/K120032605020002",
+        }
+    ]
 
 
 async def test_recruitment_ignores_unconfirmed_posting_id_fallback_keys(

--- a/mcp-server/tests/subscriptions/test_change_service.py
+++ b/mcp-server/tests/subscriptions/test_change_service.py
@@ -293,6 +293,41 @@ async def test_recruitment_detects_new_posting_ids_when_count_is_unchanged(
     ]
 
 
+async def test_recruitment_added_posting_is_not_reported_again_after_latest_update(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _recruitment_input(
+            count=1,
+            ongoing_count=1,
+            postings=[_posting("A")],
+        )
+    )
+    first = await service.compare(
+        _recruitment_input(
+            count=2,
+            ongoing_count=2,
+            postings=[_posting("A"), _posting("B")],
+        )
+    )
+    second = await service.compare(
+        _recruitment_input(
+            count=2,
+            ongoing_count=2,
+            postings=[_posting("A"), _posting("B")],
+        )
+    )
+
+    assert first.changed is True
+    assert first.condition_satisfied is True
+    assert second.changed is False
+    assert second.condition_satisfied is None
+    assert second.requires_ai_analysis is False
+    assert second.condition_reason == "no diff"
+
+
 async def test_recruitment_detects_new_ongoing_posting_ids_when_ongoing_count_is_unchanged(
     patched_session_factory,
 ) -> None:

--- a/mcp-server/tests/subscriptions/test_change_service.py
+++ b/mcp-server/tests/subscriptions/test_change_service.py
@@ -51,6 +51,54 @@ def _structured_condition_input(avg_deal_amount: int) -> SubscriptionChangeInput
     return input_model
 
 
+def _recruitment_input(
+    count: int,
+    ongoing_count: int,
+    *,
+    metric: str = "COUNT",
+    direction: str = "UP",
+    threshold: str = "1",
+    postings: list[dict] | None = None,
+) -> SubscriptionChangeInput:
+    # 채용 구독 조건은 current summary 의 공고 수 delta 를 기준으로 판별한다.
+    structured = {
+        "summary": {
+            "count": count,
+            "ongoing_count": ongoing_count,
+        }
+    }
+    if postings is not None:
+        structured["postings"] = postings
+
+    return SubscriptionChangeInput.model_validate(
+        {
+            "subscriptionId": "job-42",
+            "domain": "recruitment",
+            "query": "백엔드 채용 공고",
+            "params": {
+                "keyword": "백엔드",
+                "conditionMetric": metric,
+                "conditionDirection": direction,
+                "conditionOperator": "GTE",
+                "conditionThreshold": threshold,
+                "conditionUnit": "COUNT",
+            },
+            "current": {
+                "text": f"채용 공고 {count}건",
+                "structured": structured,
+            },
+        }
+    )
+
+
+def _posting(posting_id: str, *, is_ongoing: bool = True) -> dict:
+    return {
+        "pblnt_sn": posting_id,
+        "title": f"{posting_id} 백엔드 개발자",
+        "is_ongoing": is_ongoing,
+    }
+
+
 def test_stable_params_hash_ignores_key_order() -> None:
     left = stable_params_hash({"region": "강남구", "condition": "5% 상승"})
     right = stable_params_hash({"condition": "5% 상승", "region": "강남구"})
@@ -151,6 +199,179 @@ async def test_diff_meeting_structured_condition_requires_ai_analysis(
     assert result.requires_ai_analysis is True
     assert result.condition_reason == "condition satisfied"
     assert result.diffs[0].change_rate == 6.0
+
+
+async def test_recruitment_count_increase_meeting_condition_requires_ai_analysis(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(_recruitment_input(count=1, ongoing_count=1, metric="COUNT"))
+    result = await service.compare(_recruitment_input(count=2, ongoing_count=1, metric="COUNT"))
+
+    assert result.baseline_initialized is False
+    assert result.changed is True
+    assert result.condition_satisfied is True
+    assert result.requires_ai_analysis is True
+    assert result.condition_reason == "condition satisfied"
+    assert result.diffs[0].field == "count"
+    assert result.diffs[0].delta == 1
+
+
+async def test_recruitment_ongoing_count_increase_meeting_condition_requires_ai_analysis(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(_recruitment_input(count=3, ongoing_count=1, metric="ONGOING_COUNT", threshold="2"))
+    result = await service.compare(_recruitment_input(count=3, ongoing_count=3, metric="ONGOING_COUNT", threshold="2"))
+
+    assert result.baseline_initialized is False
+    assert result.changed is True
+    assert result.condition_satisfied is True
+    assert result.requires_ai_analysis is True
+    assert result.condition_reason == "condition satisfied"
+    assert result.diffs[0].field == "ongoing_count"
+    assert result.diffs[0].delta == 2
+
+
+async def test_recruitment_count_decrease_does_not_satisfy_up_condition(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(_recruitment_input(count=2, ongoing_count=2, metric="COUNT"))
+    result = await service.compare(_recruitment_input(count=1, ongoing_count=1, metric="COUNT"))
+
+    assert result.baseline_initialized is False
+    assert result.changed is True
+    assert result.condition_satisfied is False
+    assert result.requires_ai_analysis is False
+    assert result.condition_reason == "condition not satisfied"
+    assert result.diffs[0].field == "count"
+    assert result.diffs[0].direction == "decrease"
+
+
+async def test_recruitment_detects_new_posting_ids_when_count_is_unchanged(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _recruitment_input(
+            count=2,
+            ongoing_count=2,
+            metric="COUNT",
+            postings=[_posting("A"), _posting("B")],
+        )
+    )
+    result = await service.compare(
+        _recruitment_input(
+            count=2,
+            ongoing_count=2,
+            metric="COUNT",
+            postings=[_posting("B"), _posting("C")],
+        )
+    )
+
+    assert result.baseline_initialized is False
+    assert result.changed is True
+    assert result.condition_satisfied is True
+    assert result.requires_ai_analysis is True
+    assert result.condition_reason == "condition satisfied"
+    assert result.diffs[0].field == "added_count"
+    assert result.diffs[0].delta == 1
+
+
+async def test_recruitment_detects_new_ongoing_posting_ids_when_ongoing_count_is_unchanged(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _recruitment_input(
+            count=2,
+            ongoing_count=1,
+            metric="ONGOING_COUNT",
+            postings=[_posting("A", is_ongoing=True), _posting("B", is_ongoing=False)],
+        )
+    )
+    result = await service.compare(
+        _recruitment_input(
+            count=2,
+            ongoing_count=1,
+            metric="ONGOING_COUNT",
+            postings=[_posting("B", is_ongoing=False), _posting("C", is_ongoing=True)],
+        )
+    )
+
+    assert result.baseline_initialized is False
+    assert result.changed is True
+    assert result.condition_satisfied is True
+    assert result.requires_ai_analysis is True
+    assert result.condition_reason == "condition satisfied"
+    ongoing_added_diff = next(diff for diff in result.diffs if diff.field == "ongoing_added_count")
+    assert ongoing_added_diff.delta == 1
+
+
+async def test_recruitment_detects_new_worknet_posting_ids_when_count_is_unchanged(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _recruitment_input(
+            count=1,
+            ongoing_count=1,
+            metric="COUNT",
+            postings=[{"wanted_auth_no": "K120032605010001", "title": "백엔드 개발자"}],
+        )
+    )
+    result = await service.compare(
+        _recruitment_input(
+            count=1,
+            ongoing_count=1,
+            metric="COUNT",
+            postings=[{"wanted_auth_no": "K120032605020002", "title": "서버 개발자"}],
+        )
+    )
+
+    assert result.baseline_initialized is False
+    assert result.changed is True
+    assert result.condition_satisfied is True
+    assert result.requires_ai_analysis is True
+    assert result.condition_reason == "condition satisfied"
+    assert result.diffs[0].field == "added_count"
+    assert result.diffs[0].delta == 1
+
+
+async def test_recruitment_ignores_unconfirmed_posting_id_fallback_keys(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _recruitment_input(
+            count=1,
+            ongoing_count=1,
+            metric="COUNT",
+            postings=[{"id": "A", "src_url": "https://example.com/a"}],
+        )
+    )
+    result = await service.compare(
+        _recruitment_input(
+            count=1,
+            ongoing_count=1,
+            metric="COUNT",
+            postings=[{"id": "B", "src_url": "https://example.com/b"}],
+        )
+    )
+
+    assert result.baseline_initialized is False
+    assert result.changed is False
+    assert result.condition_satisfied is None
+    assert result.requires_ai_analysis is False
+    assert result.condition_reason == "no diff"
 
 
 async def test_insert_race_rereads_row_and_compares(monkeypatch) -> None:

--- a/mcp-server/tests/subscriptions/test_change_service.py
+++ b/mcp-server/tests/subscriptions/test_change_service.py
@@ -100,6 +100,52 @@ def _posting(posting_id: str, *, is_ongoing: bool = True) -> dict:
     }
 
 
+def _worknet_posting(posting_id: str, title: str | None = None) -> dict:
+    return {
+        "wanted_auth_no": posting_id,
+        "title": title or f"{posting_id} 백엔드 워크넷 채용",
+        "info_url": f"https://work.example/jobs/{posting_id}",
+    }
+
+
+def _recruitment_source(
+    tool_name: str,
+    postings: list[dict],
+    *,
+    ongoing_count: int | None = None,
+) -> dict:
+    summary = {"count": len(postings)}
+    if ongoing_count is not None:
+        summary["ongoing_count"] = ongoing_count
+    return {
+        "text": f"{tool_name} {len(postings)}건",
+        "structured": {
+            "summary": summary,
+            "postings": postings,
+        },
+        "metadata": {"tool_name": tool_name},
+    }
+
+
+def _multi_source_recruitment_input(sources: list[dict]) -> SubscriptionChangeInput:
+    return SubscriptionChangeInput.model_validate(
+        {
+            "subscriptionId": "job-42",
+            "domain": "recruitment",
+            "query": "백엔드 채용 공고",
+            "params": {
+                "keyword": "백엔드",
+                "conditionMetric": "COUNT",
+                "conditionDirection": "UP",
+                "conditionOperator": "GTE",
+                "conditionThreshold": "1",
+                "conditionUnit": "COUNT",
+            },
+            "current": {"sources": sources},
+        }
+    )
+
+
 def test_stable_params_hash_ignores_key_order() -> None:
     left = stable_params_hash({"region": "강남구", "condition": "5% 상승"})
     right = stable_params_hash({"condition": "5% 상승", "region": "강남구"})
@@ -399,6 +445,103 @@ async def test_recruitment_detects_new_worknet_posting_ids_when_count_is_unchang
             "posting_id": "worknet_job:K120032605020002",
             "title": "서버 개발자",
             "url": "https://work.example/jobs/K120032605020002",
+        }
+    ]
+
+
+async def test_recruitment_merges_public_and_worknet_sources_for_change_compare(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _multi_source_recruitment_input([
+            _recruitment_source("search_public_job", [_posting("A")], ongoing_count=1),
+            _recruitment_source("search_worknet_job", []),
+        ])
+    )
+    result = await service.compare(
+        _multi_source_recruitment_input([
+            _recruitment_source(
+                "search_public_job",
+                [_posting("A"), _posting("P1")],
+                ongoing_count=2,
+            ),
+            _recruitment_source(
+                "search_worknet_job",
+                [_worknet_posting("W1", "백엔드 워크넷 채용")],
+            ),
+        ])
+    )
+
+    assert result.changed is True
+    assert result.condition_satisfied is True
+    assert result.current_summary["count"] == 3
+    assert result.current_summary["ongoing_count"] == 3
+    assert result.diffs[0].field == "added_count"
+    assert result.diffs[0].delta == 2
+    assert [
+        posting.model_dump() for posting in result.briefing_postings_by_source["public_job"]
+    ] == [
+        {
+            "posting_id": "public_job:P1",
+            "title": "P1 백엔드 개발자",
+            "url": "https://public.example/jobs/P1",
+        }
+    ]
+    assert [
+        posting.model_dump() for posting in result.briefing_postings_by_source["worknet_job"]
+    ] == [
+        {
+            "posting_id": "worknet_job:W1",
+            "title": "백엔드 워크넷 채용",
+            "url": "https://work.example/jobs/W1",
+        }
+    ]
+
+
+async def test_recruitment_multi_source_skips_worknet_permission_denied(
+    patched_session_factory,
+) -> None:
+    service = SubscriptionChangeService()
+
+    await service.compare(
+        _multi_source_recruitment_input([
+            _recruitment_source("search_public_job", [_posting("A")], ongoing_count=1),
+        ])
+    )
+    result = await service.compare(
+        _multi_source_recruitment_input([
+            _recruitment_source(
+                "search_public_job",
+                [_posting("A"), _posting("B")],
+                ongoing_count=2,
+            ),
+            {
+                "text": "워크넷 권한 거부",
+                "structured": {
+                    "summary": {"count": 0},
+                    "postings": [],
+                    "permission_denied": True,
+                },
+                "metadata": {
+                    "tool_name": "search_worknet_job",
+                    "api_status": "permission_denied",
+                },
+            },
+        ])
+    )
+
+    assert result.changed is True
+    assert result.current_summary["count"] == 2
+    assert result.briefing_postings_by_source["worknet_job"] == []
+    assert [
+        posting.model_dump() for posting in result.briefing_postings_by_source["public_job"]
+    ] == [
+        {
+            "posting_id": "public_job:B",
+            "title": "B 백엔드 개발자",
+            "url": "https://public.example/jobs/B",
         }
     ]
 

--- a/mcp-server/tests/subscriptions/test_draft_normalizer.py
+++ b/mcp-server/tests/subscriptions/test_draft_normalizer.py
@@ -108,6 +108,108 @@ def test_apartment_trade_request_returns_search_house_price_contract() -> None:
     assert result.missing_fields == []
 
 
+def test_recruitment_new_job_request_returns_job_posting_change_contract() -> None:
+    result = normalize_subscription_draft(
+        SubscriptionDraftNormalizationInput(
+            userMessage="백엔드 채용 새 공고 뜨면 텔레그램으로 알려줘",
+            task=ParsedTaskDraft(
+                intent="create",
+                domainName="채용",
+                query="백엔드 채용 새 공고",
+                condition="새 공고 등록",
+                cronExpr="0 9 * * *",
+                channel="telegram",
+                target="백엔드 채용 공고",
+                confidence=0.9,
+            ),
+        )
+    )
+
+    assert result.domain_name == "recruitment"
+    assert result.intent == "job_posting_change"
+    assert result.tool_name in {"search_public_job", "search_worknet_job"}
+    assert result.parameters["dataToolName"] == result.tool_name
+    assert result.parameters["keyword"] == "백엔드"
+    assert result.parameters["conditionMetric"] == "COUNT"
+    assert result.parameters["conditionDirection"] == "UP"
+    assert result.parameters["conditionOperator"] == "GTE"
+    assert result.parameters["conditionThreshold"] == "1"
+    assert result.parameters["conditionUnit"] == "COUNT"
+    assert result.missing_fields == []
+
+
+def test_recruitment_time_number_does_not_override_default_count_threshold() -> None:
+    result = normalize_subscription_draft(
+        SubscriptionDraftNormalizationInput(
+            userMessage="백엔드 채용 새 공고 뜨면 매일 오전 9시에 알려줘",
+            task=ParsedTaskDraft(
+                intent="create",
+                domainName="채용",
+                query="백엔드 채용 새 공고",
+                condition="새 공고 등록",
+                cronExpr="0 9 * * *",
+                channel="telegram",
+                target="백엔드 채용 공고",
+                confidence=0.9,
+            ),
+        )
+    )
+
+    assert result.parameters["keyword"] == "백엔드"
+    assert result.parameters["conditionMetric"] == "COUNT"
+    assert result.parameters["conditionThreshold"] == "1"
+
+
+def test_public_recruitment_ongoing_request_uses_public_job_and_ongoing_count() -> None:
+    result = normalize_subscription_draft(
+        SubscriptionDraftNormalizationInput(
+            userMessage="공공기관 데이터 채용 진행중 공고가 늘면 알려줘",
+            task=ParsedTaskDraft(
+                intent="create",
+                domainName="채용",
+                query="공공기관 데이터 채용",
+                condition="진행중 공고 증가",
+                target="공공기관 데이터 채용 진행중 공고",
+                confidence=0.9,
+            ),
+        )
+    )
+
+    assert result.domain_name == "recruitment"
+    assert result.intent == "job_posting_change"
+    assert result.tool_name == "search_public_job"
+    assert result.parameters["dataToolName"] == "search_public_job"
+    assert result.parameters["keyword"] == "데이터"
+    assert result.parameters["recrut_pbanc_ttl"] == "데이터"
+    assert result.parameters["ongoing_yn"] == "Y"
+    assert result.parameters["conditionMetric"] == "ONGOING_COUNT"
+    assert result.parameters["conditionThreshold"] == "1"
+    assert result.parameters["conditionUnit"] == "COUNT"
+    assert result.missing_fields == []
+
+
+def test_recruitment_request_without_target_or_condition_asks_for_more_details() -> None:
+    result = normalize_subscription_draft(
+        SubscriptionDraftNormalizationInput(
+            userMessage="채용 알려줘",
+            task=ParsedTaskDraft(
+                intent="create",
+                domainName="채용",
+                query="채용",
+                condition="",
+                target="채용",
+                confidence=0.7,
+                needsConfirmation=True,
+            ),
+        )
+    )
+
+    assert result.domain_name == "recruitment"
+    assert result.intent == "job_posting_change"
+    assert result.missing_fields == ["keyword", "condition"]
+    assert "어떤 채용" in result.question
+
+
 def test_apartment_rent_request_is_not_normalized_as_trade() -> None:
     result = normalize_subscription_draft(
         SubscriptionDraftNormalizationInput(

--- a/mcp-server/tests/subscriptions/test_recruitment_keyword_validation.py
+++ b/mcp-server/tests/subscriptions/test_recruitment_keyword_validation.py
@@ -1,0 +1,71 @@
+"""채용 검색어 0건 검증/후보 추천 테스트."""
+
+from datetime import date
+
+from mcp_server.domains.jobs.normalizer import PublicJobPosting
+from mcp_server.subscriptions.draft_models import NormalizedSubscriptionDraft
+from mcp_server.subscriptions.recruitment_keyword_validation import (
+    RecruitmentKeywordValidationResult,
+    apply_recruitment_keyword_validation,
+    suggest_recruitment_keyword,
+)
+
+
+def test_suggest_recruitment_keyword_from_similar_public_job_titles() -> None:
+    postings = [
+        _posting("백엔드 개발자 채용"),
+        _posting("간호사 모집"),
+        _posting("데이터 분석가 공개채용"),
+    ]
+
+    assert suggest_recruitment_keyword("벡엔드", postings) == "백엔드"
+    assert suggest_recruitment_keyword("관호사", postings) == "간호사"
+
+
+def test_apply_zero_result_suggestion_requires_keyword_confirmation() -> None:
+    draft = NormalizedSubscriptionDraft(
+        query="벡엔드 채용 공고",
+        domain_name="recruitment",
+        intent="job_posting_change",
+        tool_name="search_public_job",
+        parameters={
+            "dataToolName": "search_public_job",
+            "keyword": "벡엔드",
+            "recrut_pbanc_ttl": "벡엔드",
+            "conditionMetric": "COUNT",
+            "conditionDirection": "UP",
+            "conditionOperator": "GTE",
+            "conditionThreshold": "1",
+            "conditionUnit": "COUNT",
+        },
+        missing_fields=[],
+        question="",
+        confidence=0.9,
+    )
+
+    result = apply_recruitment_keyword_validation(
+        draft,
+        RecruitmentKeywordValidationResult(
+            keyword="벡엔드",
+            result_count=0,
+            suggested_keyword="백엔드",
+        ),
+    )
+
+    assert result.missing_fields == ["keywordConfirmation"]
+    assert result.parameters["keyword"] == "벡엔드"
+    assert result.parameters["keywordValidationStatus"] == "ZERO_RESULTS"
+    assert result.parameters["suggestedKeyword"] == "백엔드"
+    assert "벡엔드" in result.question
+    assert "백엔드" in result.question
+
+
+def _posting(title: str) -> PublicJobPosting:
+    return PublicJobPosting(
+        pblnt_sn=1,
+        title=title,
+        institute="테스트기관",
+        pbanc_begin_date=date(2026, 5, 1),
+        pbanc_end_date=date(2026, 5, 31),
+        is_ongoing=True,
+    )

--- a/mcp-server/tests/tools/test_cache_check.py
+++ b/mcp-server/tests/tools/test_cache_check.py
@@ -4,13 +4,17 @@
 check_api_cache / get_cached_data 의 동작을 격리 검증한다.
 """
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from sqlalchemy import select
 
 from mcp_server.db.models import ApiCache, ApiSource
 from mcp_server.db.session import get_session
+from mcp_server.subscriptions.change_models import SubscriptionChangeInput
+from mcp_server.subscriptions.change_service import SubscriptionChangeService
 from mcp_server.tools.cache_check import check_api_cache, get_cached_data
 
 _FIXTURE_LAW = Path(__file__).resolve().parents[1] / "data" / "law"
@@ -120,6 +124,36 @@ async def _seed_cache(tool_name: str, content: str, site_url: str | None = None)
         )
         session.add(cache)
         await session.commit()
+
+
+async def _replace_cache_content(tool_name: str, content: str, site_url: str | None = None) -> None:
+    """동일 cache row의 원천 응답만 갱신해 스케줄 재실행 상황을 만든다."""
+    async with get_session() as session:
+        result = await session.execute(
+            select(ApiCache).where(ApiCache.site_url == (site_url or f"cache://{tool_name}"))
+        )
+        cache = result.scalar_one()
+        cache.content = content
+        await session.commit()
+
+
+def _recruitment_change_input(current: dict) -> SubscriptionChangeInput:
+    return SubscriptionChangeInput.model_validate(
+        {
+            "subscriptionId": "job-cache-1",
+            "domain": "recruitment",
+            "query": "백엔드 채용 공고",
+            "params": {
+                "keyword": "백엔드",
+                "conditionMetric": "COUNT",
+                "conditionDirection": "UP",
+                "conditionOperator": "GTE",
+                "conditionThreshold": "1",
+                "conditionUnit": "COUNT",
+            },
+            "current": current,
+        }
+    )
 
 
 # ─────────────────────────────────────────────
@@ -282,6 +316,54 @@ async def test_get_public_job_cache_filters_by_subscription_params(patched_sessi
     assert all(posting["is_ongoing"] is True for posting in postings)
     assert result["metadata"]["raw_count"] == 3
     assert result["metadata"]["returned_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_public_job_output_drives_subscription_change_detection(patched_session_factory):
+    """채용 캐시 구조화 결과가 subscription snapshot 비교까지 이어지는 회귀 경로."""
+    await _seed_cache("search_public_job", PUBLIC_JOB_MIXED_JSON)
+    service = SubscriptionChangeService()
+
+    baseline_current = await get_cached_data(
+        "search_public_job",
+        params={"recrut_pbanc_ttl": "백엔드", "ongoing_yn": "Y"},
+    )
+    baseline = await service.compare(_recruitment_change_input(baseline_current))
+
+    updated_payload = json.loads(PUBLIC_JOB_MIXED_JSON)
+    updated_payload["result"].append({
+        "recrutPblntSn": 104,
+        "recrutPbancTtl": "백엔드 API 개발자 채용",
+        "instNm": "한국테스트공단",
+        "ongoingYn": "Y",
+        "pbancBgngYmd": "20260501",
+        "pbancEndYmd": "20260515",
+        "srcUrl": "https://public.example/jobs/104",
+    })
+    await _replace_cache_content(
+        "search_public_job",
+        json.dumps(updated_payload, ensure_ascii=False),
+    )
+    changed_current = await get_cached_data(
+        "search_public_job",
+        params={"recrut_pbanc_ttl": "백엔드", "ongoing_yn": "Y"},
+    )
+    changed = await service.compare(_recruitment_change_input(changed_current))
+    repeated = await service.compare(_recruitment_change_input(changed_current))
+
+    assert baseline.baseline_initialized is True
+    assert changed.changed is True
+    assert changed.condition_satisfied is True
+    assert changed.current_summary["count"] == 2
+    assert [
+        posting.model_dump() for posting in changed.briefing_postings_by_source["public_job"]
+    ] == [{
+        "posting_id": "public_job:104",
+        "title": "백엔드 API 개발자 채용",
+        "url": "https://public.example/jobs/104",
+    }]
+    assert repeated.changed is False
+    assert repeated.condition_reason == "no diff"
 
 
 @pytest.mark.asyncio

--- a/mcp-server/tests/tools/test_cache_check.py
+++ b/mcp-server/tests/tools/test_cache_check.py
@@ -24,6 +24,78 @@ G2B_BID_JSON = (_FIXTURE_AUCTION / "search_g2b_bid.json").read_text(encoding="ut
 PUBLIC_JOB_JSON = (_FIXTURE_JOBS / "search_public_job.json").read_text(encoding="utf-8")
 WORKNET_PERMISSION_DENIED_XML = (_FIXTURE_JOBS / "search_worknet_job.xml").read_text(encoding="utf-8")
 APT_TRADE_XML = (_FIXTURE_RE / "molit_apt_trade_sample.xml").read_text(encoding="utf-8")
+PUBLIC_JOB_MIXED_JSON = """
+{
+  "result": [
+    {
+      "recrutPblntSn": 101,
+      "recrutPbancTtl": "백엔드 개발자 채용",
+      "instNm": "한국테스트공단",
+      "ongoingYn": "Y",
+      "pbancBgngYmd": "20260430",
+      "pbancEndYmd": "20260510",
+      "srcUrl": "https://public.example/jobs/101"
+    },
+    {
+      "recrutPblntSn": 102,
+      "recrutPbancTtl": "프론트엔드 개발자 채용",
+      "instNm": "한국테스트공단",
+      "ongoingYn": "Y",
+      "pbancBgngYmd": "20260429",
+      "pbancEndYmd": "20260509",
+      "srcUrl": "https://public.example/jobs/102"
+    },
+    {
+      "recrutPblntSn": 103,
+      "recrutPbancTtl": "백엔드 플랫폼 엔지니어 모집",
+      "instNm": "테스트진흥원",
+      "ongoingYn": "N",
+      "pbancBgngYmd": "20260428",
+      "pbancEndYmd": "20260429",
+      "srcUrl": "https://public.example/jobs/103"
+    }
+  ],
+  "resultCode": 200,
+  "resultMsg": "성공했습니다.",
+  "totalCount": 3
+}
+"""
+WORKNET_JOB_MIXED_XML = """<?xml version='1.0' encoding='UTF-8'?>
+<wantedRoot>
+  <pubJobs>
+    <wanted>
+      <wantedAuthNo>W001</wantedAuthNo>
+      <wantedTitle>백엔드 서버 개발자</wantedTitle>
+      <busplaName>테스트소프트</busplaName>
+      <regionNm>서울</regionNm>
+      <empTpNm>정규직</empTpNm>
+      <regDt>20260430</regDt>
+      <closeDt>20260530</closeDt>
+      <wantedInfoUrl>https://work.example/jobs/W001</wantedInfoUrl>
+    </wanted>
+    <wanted>
+      <wantedAuthNo>W002</wantedAuthNo>
+      <wantedTitle>프론트엔드 개발자</wantedTitle>
+      <busplaName>백엔드랩스</busplaName>
+      <regionNm>서울</regionNm>
+      <empTpNm>계약직</empTpNm>
+      <regDt>20260429</regDt>
+      <closeDt>20260529</closeDt>
+      <wantedInfoUrl>https://work.example/jobs/W002</wantedInfoUrl>
+    </wanted>
+    <wanted>
+      <wantedAuthNo>W003</wantedAuthNo>
+      <wantedTitle>데이터 엔지니어</wantedTitle>
+      <busplaName>테스트데이터</busplaName>
+      <regionNm>부산</regionNm>
+      <empTpNm>정규직</empTpNm>
+      <regDt>20260428</regDt>
+      <closeDt>20260528</closeDt>
+      <wantedInfoUrl>https://work.example/jobs/W003</wantedInfoUrl>
+    </wanted>
+  </pubJobs>
+</wantedRoot>
+"""
 
 _CACHED_AT = datetime(2026, 4, 30, 10, 0, tzinfo=UTC)
 
@@ -184,6 +256,60 @@ async def test_get_public_job_structured_key(patched_session_factory):
 
 
 @pytest.mark.asyncio
+async def test_get_public_job_cache_filters_by_subscription_params(patched_session_factory):
+    """공공 채용 캐시도 fetch tool과 동일하게 구독 keyword/진행중 조건으로 추린다."""
+    await _seed_cache("search_public_job", PUBLIC_JOB_MIXED_JSON)
+
+    result = await get_cached_data(
+        "search_public_job",
+        params={
+            "recrut_pbanc_ttl": "백엔드",
+            "ongoing_yn": "Y",
+            "page_no": 1,
+            "num_of_rows": 20,
+        },
+    )
+
+    structured = result["structured"]
+    postings = structured["postings"]
+
+    assert structured["query"]["recrut_pbanc_ttl"] == "백엔드"
+    assert structured["query"]["ongoing_yn"] == "Y"
+    assert structured["summary"]["count"] == 1
+    assert structured["summary"]["ongoing_count"] == 1
+    assert len(postings) == 1
+    assert all("백엔드" in posting["title"] for posting in postings)
+    assert all(posting["is_ongoing"] is True for posting in postings)
+    assert result["metadata"]["raw_count"] == 3
+    assert result["metadata"]["returned_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_worknet_job_cache_filters_by_subscription_params(patched_session_factory):
+    """워크넷 채용 캐시도 fetch tool과 동일하게 keyword 조건으로 추린다."""
+    await _seed_cache("search_worknet_job", WORKNET_JOB_MIXED_XML)
+
+    result = await get_cached_data(
+        "search_worknet_job",
+        params={"keyword": "백엔드", "start_page": 1, "display": 20},
+    )
+
+    structured = result["structured"]
+    postings = structured["postings"]
+
+    assert structured["query"]["keyword"] == "백엔드"
+    assert structured["summary"]["count"] == 2
+    assert len(postings) == 2
+    assert all(
+        "백엔드" in (posting.get("title") or "")
+        or "백엔드" in (posting.get("company") or "")
+        for posting in postings
+    )
+    assert result["metadata"]["raw_count"] == 3
+    assert result["metadata"]["returned_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_get_g2b_bid_structured_key(patched_session_factory):
     """경매 캐시 → structured.notices 키."""
     await _seed_cache("search_g2b_bid", G2B_BID_JSON)
@@ -208,6 +334,7 @@ async def test_get_worknet_permission_denied(patched_session_factory):
     assert result["metadata"]["api_status"] == "permission_denied"
     assert result["metadata"]["cache_used"] is True
     assert result["structured"]["summary"]["count"] == 0
+    assert result["structured"]["permission_denied"] is True
 
 
 # ─────────────────────────────────────────────

--- a/mcp-server/tests/tools/test_jobs.py
+++ b/mcp-server/tests/tools/test_jobs.py
@@ -370,6 +370,7 @@ async def test_search_worknet_job_normal_response_returns_postings(
     assert result["metadata"]["api_status"] == "ok"
     assert result["structured"]["summary"]["count"] == 1
     assert result["structured"]["postings"][0]["title"] == "백엔드 개발자"
+    assert result["structured"]["postings"][0]["wanted_auth_no"] is None
     # #3 bulk fetch — keyword 는 API params 에 포함되지 않음 (추후 적용 예정)
     assert "keyword" not in captured["params"]
     assert captured["params"]["startPage"] == 1

--- a/mcp-server/tests/tools/test_subscriptions.py
+++ b/mcp-server/tests/tools/test_subscriptions.py
@@ -71,6 +71,49 @@ async def test_compare_subscription_change_returns_common_schema(monkeypatch) ->
     }
 
 
+async def test_compare_subscription_change_accepts_current_sources_contract(monkeypatch) -> None:
+    captured_sources: list[dict] = []
+
+    async def fake_compare(_, input_model: SubscriptionChangeInput) -> SubscriptionChangeResult:
+        captured_sources.extend(input_model.current["sources"])
+        return SubscriptionChangeResult(
+            baseline_initialized=False,
+            changed=False,
+            subscription_id=input_model.subscription_id,
+            domain=input_model.domain,
+            params_hash="hash-job",
+            baseline_summary={"count": 1},
+            current_summary={"count": 1},
+            diffs=[],
+            briefing_facts=[],
+            briefing_postings_by_source={"public_job": [], "worknet_job": []},
+        )
+
+    monkeypatch.setattr(subscriptions.SubscriptionChangeService, "compare", fake_compare)
+
+    response = await subscriptions.compare_subscription_change(
+        SubscriptionChangeInput.model_validate(
+            {
+                "subscriptionId": "job-42",
+                "domain": "recruitment",
+                "query": "백엔드 채용 공고",
+                "params": {"keyword": "백엔드"},
+                "current": {
+                    "sources": [{
+                        "text": "공공채용 1건",
+                        "structured": {"summary": {"count": 1}, "postings": []},
+                        "metadata": {"tool_name": "search_public_job"},
+                    }],
+                },
+            }
+        )
+    )
+
+    assert captured_sources[0]["metadata"]["tool_name"] == "search_public_job"
+    assert response["structured"]["changed"] is False
+    assert response["metadata"]["params_hash"] == "hash-job"
+
+
 async def test_normalize_subscription_draft_returns_common_schema() -> None:
     response = await subscriptions.normalize_subscription_draft(
         SubscriptionDraftNormalizationInput(

--- a/mcp-server/tests/tools/test_subscriptions.py
+++ b/mcp-server/tests/tools/test_subscriptions.py
@@ -23,6 +23,14 @@ async def test_compare_subscription_change_returns_common_schema(monkeypatch) ->
             current_summary={"avg_deal_amount": 106000},
             diffs=[],
             briefing_facts=["avg_deal_amount 값이 100000에서 106000으로 증가했습니다."],
+            briefing_postings_by_source={
+                "public_job": [{
+                    "posting_id": "public_job:1",
+                    "title": "백엔드 개발자",
+                    "url": "https://public.example/jobs/1",
+                }],
+                "worknet_job": [],
+            },
         )
 
     monkeypatch.setattr(subscriptions.SubscriptionChangeService, "compare", fake_compare)
@@ -46,6 +54,14 @@ async def test_compare_subscription_change_returns_common_schema(monkeypatch) ->
     assert response["structured"]["subscriptionId"] == "42"
     assert response["structured"]["changed"] is True
     assert response["structured"]["requires_ai_analysis"] is False
+    assert response["structured"]["briefing_postings_by_source"] == {
+        "public_job": [{
+            "posting_id": "public_job:1",
+            "title": "백엔드 개발자",
+            "url": "https://public.example/jobs/1",
+        }],
+        "worknet_job": [],
+    }
     assert response["structured"]["params_hash"] == "hash-42"
     assert response["source_url"] is None
     assert response["metadata"] == {


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #116 

**🛠 작업 내역**

- Worknet 권한 거부 응답을 전체 구독 실패가 아닌 Worknet source 제외로 처리
- 채용 변화 감지 기준을 최신 스냅샷으로 변경해 동일 신규 공고 반복 알림 방지
- AI 브리핑에서 공공채용/워크넷 공고 제목과 링크를 출처별로 분리하도록 프롬프트 보강
- Spring AI 실행 경로에서 부동산 `dealYmdPolicy=LATEST_AVAILABLE_MONTH`를 실제 `deal_ymd`로 보정
- 채용 캐시 → 구조화 → 변화 비교 → 브리핑 데이터 생성 흐름 회귀 테스트 추가

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?