### PR TITLE
fix: 백엔드 배포 전 MCP 서버 기동 보장

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "back/**"
       - "front/**"
+      - "mcp-server/**"
       - "infra/**"
       - ".github/workflows/**"
   workflow_dispatch:
@@ -18,6 +19,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_BE: ${{ github.repository }}-backend
   IMAGE_FE: ${{ github.repository }}-frontend
+  IMAGE_MCP: ${{ github.repository_owner }}/mcp-server
 
 # ─────────────────────────────────────────────────────────────
 # Required Secrets:
@@ -64,6 +66,7 @@ jobs:
         run: |
           echo "BE_IMAGE=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_BE }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           echo "FE_IMAGE=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_FE }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "MCP_IMAGE=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_MCP }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Parse frontend build env
         env:
@@ -102,6 +105,18 @@ jobs:
             NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
+
+      - name: Build and push MCP Server
+        uses: docker/build-push-action@v6
+        with:
+          context: ./mcp-server
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.MCP_IMAGE }}:${{ needs.calculate-tag.outputs.tag_name }}
+            ${{ env.MCP_IMAGE }}:latest
+          cache-from: type=gha,scope=mcp-server
+          cache-to: type=gha,mode=max,scope=mcp-server
 
   # ── 3. Blue/Green 배포 ────────────────────────────────────
   deploy:
@@ -202,14 +217,41 @@ jobs:
             # ── 이미지 경로 ────────────────────────────────────
             BE_IMAGE=$(echo "ghcr.io/${REPO_OWNER}/${REPO_NAME}-backend" | tr '[:upper:]' '[:lower:]')
             FE_IMAGE=$(echo "ghcr.io/${REPO_OWNER}/${REPO_NAME}-frontend" | tr '[:upper:]' '[:lower:]')
+            MCP_IMAGE=$(echo "ghcr.io/${REPO_OWNER}/mcp-server" | tr '[:upper:]' '[:lower:]')
+            export GITHUB_ORG=$(echo "${REPO_OWNER}" | tr '[:upper:]' '[:lower:]')
+            export TAG="${IMAGE_TAG}"
 
             # ── GHCR 로그인 ────────────────────────────────────
             echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
-            # ── Langfuse 기동 ──────────────────────────────────
+            # ── MCP 이미지 Pull + 인프라 기동 ───────────────────
+            docker pull "${MCP_IMAGE}:${IMAGE_TAG}"
+
             docker compose -f ~/app/infra/docker/prod/docker-compose.yml \
               --env-file ~/app/infra/docker/prod/.env \
-              up -d langfuse-clickhouse langfuse-web langfuse-worker
+              up -d postgres redis minio langfuse-clickhouse langfuse-web langfuse-worker mcp-server
+
+            # ── MCP 헬스체크 ───────────────────────────────────
+            echo "MCP 서버 헬스체크 대기..."
+            MCP_MAX_WAIT=90; MCP_INTERVAL=5; MCP_ELAPSED=0
+            MCP_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' prod-mcp 2>/dev/null || true)
+            if [ -z "$MCP_IP" ]; then
+              echo "MCP 컨테이너 IP 확인 실패"
+              docker ps -a --filter name=prod-mcp
+              docker logs prod-mcp --tail 200 2>/dev/null || true
+              exit 1
+            fi
+            until curl -sf "http://${MCP_IP}:8090/health" | grep -q '"status":"ok"'; do
+              if [ "$MCP_ELAPSED" -ge "$MCP_MAX_WAIT" ]; then
+                echo "MCP 헬스체크 실패 (${MCP_MAX_WAIT}s 초과)"
+                docker logs prod-mcp --tail 200
+                exit 1
+              fi
+              echo "MCP ${MCP_ELAPSED}s 경과, ${MCP_INTERVAL}s 후 재시도..."
+              sleep $MCP_INTERVAL
+              MCP_ELAPSED=$((MCP_ELAPSED + MCP_INTERVAL))
+            done
+            echo "MCP 서버 정상 확인"
 
             # ── Blue/Green 슬롯 판정 ───────────────────────────
             if docker ps --format '{{.Names}}' | grep -q "^be_a$"; then
@@ -263,7 +305,7 @@ jobs:
             until curl -sf "http://${GREEN_BE_IP}:8080/actuator/health" | grep -q '"status":"UP"'; do
               if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
                 echo "헬스체크 실패 (${MAX_WAIT}s 초과)"
-                docker logs "$GREEN_BE" --tail 50
+                docker logs "$GREEN_BE" --tail 200
                 docker rm -f "$GREEN_BE" "$GREEN_FE"
                 exit 1
               fi

--- a/infra/docker/prod/docker-compose.yml
+++ b/infra/docker/prod/docker-compose.yml
@@ -103,6 +103,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8090/health', timeout=5).read()"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   # ── ClickHouse (Langfuse V3) ──────────────────────────────────
   langfuse-clickhouse:

--- a/mcp-server/.dockerignore
+++ b/mcp-server/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+.pytest_cache
+.ruff_cache
+__pycache__
+*.pyc
+.coverage
+htmlcov

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/astral-sh/uv:0.5.29 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY src ./src
+COPY data ./data
+RUN uv sync --frozen --no-dev
+
+EXPOSE 8090
+
+CMD ["mcp-server"]


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #137 

**🛠 작업 내역**

- 백엔드 Green 기동 전 `prod-mcp` 기동 및 `/health` 헬스체크 추가
- CD 워크플로우에서 MCP 서버 이미지를 빌드/푸시하도록 추가

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?