### PR TITLE
fix : application.yml이 아니라 os레벨에서 vertex.json 수정

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -108,7 +108,7 @@ AI_TEMPERATURE=0.3
 # 키 파일 절대 경로 (gitignore에 vertex-key*.json 등록됨)
 # Windows: C:/Users/yourname/IdeaProjects/INT1-Project-Team04/vertex-key.json
 # Mac/Linux: /home/yourname/projects/INT1-Project-Team04/vertex-key.json
-# etx GOOGLE_APPLICATION_CREDENTIALS "C:\본인의\실제\프로젝트경로\vertex-key.json" 로 OS레벨 등록필요
+# setx GOOGLE_APPLICATION_CREDENTIALS "C:\본인의\실제\프로젝트경로\vertex-key.json" 로 OS레벨 등록필요
 # GOOGLE_APPLICATION_CREDENTIALS=
 GOOGLE_CLOUD_PROJECT_ID=
 VERTEX_AI_LOCATION=us-central1

--- a/back/src/main/resources/application-dev.yml
+++ b/back/src/main/resources/application-dev.yml
@@ -21,8 +21,8 @@ spring:
         gemini:
           project-id: ${GOOGLE_CLOUD_PROJECT_ID:project-0642120c-b67a-4a76-a64}
           location: ${VERTEX_AI_LOCATION:us-central1}
-          # 💡 .env.dev 의 GOOGLE_APPLICATION_CREDENTIALS(절대 경로, 슬래시 권장) + file:/// 로 Vertex 자격 증명 전달
-          credentials-uri: "file:///${GOOGLE_APPLICATION_CREDENTIALS}"
+          # Google SDK가 GOOGLE_APPLICATION_CREDENTIALS OS 환경변수를 ADC로 직접 읽으므로 credentials-uri 불필요
+          # (credentials-uri에 Windows 백슬래시 경로가 들어가면 RFC 3986 URI 파싱 오류)
           chat:
             options:
               model: gemini-2.5-flash


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #

**🛠 작업 내역**
application.yml에서 credential-url을 읽는 방식은 작동하지 않음.
따라서 os레벨에서 vertex.json을 넣어줘야할 필요가 있다.

setx GOOGLE_APPLICATION_CREDENTIALS "C:\본인의\실제\프로젝트경로\vertex-key.json" 로 OS레벨 등록필요
-

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?