### PR TITLE
Refactor/parrallel fix

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/ai/SpringAiMonitorAdapter.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/SpringAiMonitorAdapter.java
@@ -16,11 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -56,6 +52,8 @@ public class SpringAiMonitorAdapter implements RunAiMonitorPort, RunSubscription
     @Nullable
     private final ChatClient monitorChatClient;
     private final ObjectMapper objectMapper;
+    // bean 필드로 선언해 모든 서비스 VT가 동일한 permit pool을 공유한다.
+    // 호출 단위로 new Semaphore()를 만들면 VT마다 별도 제한이 생겨 전역 제어가 풀린다.
     private final Semaphore semaphore;
 
     // [레버 1] system prompt로 tool 호출 순서/조건 유도
@@ -94,48 +92,30 @@ public class SpringAiMonitorAdapter implements RunAiMonitorPort, RunSubscription
                 .content();
     }
 
-    // 구독 실행 흐름: 스케줄러가 due 구독 목록을 넘기면 MCP server에 위임
+    // 서비스 레이어 VT에서 1건씩 호출된다.
+    // Semaphore: proactive guard — 동시 세션 수를 제한해 429 발생 자체를 줄인다.
+    // requestMonitorExecution() retry: reactive fallback — 429가 나면 backoff 후 재시도.
+    // 둘은 역할이 다르다. retry만으로는 동시 구독이 많을 때 thundering herd를 막지 못한다.
     @Override
-    public void execute(List<SubscriptionContext> subscriptions) {
+    public void execute(SubscriptionContext subscription) {
         if (monitorChatClient == null) {
-            log.warn("[SpringAiMonitorAdapter] ChatClient 미구성 — 구독 실행 스킵 ({}건)", subscriptions.size());
+            log.warn("[SpringAiMonitorAdapter] ChatClient 미구성 — 구독 실행 스킵. subscriptionId={}", subscription.subscriptionId());
             throw new ApiException(ErrorCode.MCP_REQUEST_FAILED);
         }
-        if (subscriptions.isEmpty()) {
-            return;
-        }
-        log.info("[SpringAiMonitorAdapter] 구독 실행 요청 - {}건", subscriptions.size());
-        AtomicBoolean cancelled = new AtomicBoolean(false);
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
-        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-            for (SubscriptionContext subscription : subscriptions) {
-                futures.add(CompletableFuture.runAsync(
-                        () -> processSubscription(subscription, cancelled),
-                        executor
-                ));
-            }
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-        } catch (CompletionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof ApiException ae) throw ae;
-            throw new ApiException(ErrorCode.MCP_REQUEST_FAILED);
+        // acquireUninterruptibly: 서비스 VT의 Runnable 람다는 checked exception 불가
+        semaphore.acquireUninterruptibly();
+        try {
+            processSubscription(subscription);
+        } finally {
+            semaphore.release();
         }
     }
 
+    // AI 실행 로직만 담당. 동시성 관련 코드 없음 — Semaphore는 execute()가 처리.
     // package-private: 테스트에서 동기 직접 호출 가능
-    void processSubscription(SubscriptionContext subscription, AtomicBoolean cancelled) {
-        if (cancelled.get()) {
-            log.info("[SpringAiMonitorAdapter] 구독 {} 취소 플래그 확인 — 스킵", subscription.subscriptionId());
-            return;
-        }
-        // acquireUninterruptibly: Runnable 람다는 checked exception 불가, soft-cancel은 AtomicBoolean으로 처리
-        semaphore.acquireUninterruptibly();
+    void processSubscription(SubscriptionContext subscription) {
+        log.info("[SpringAiMonitorAdapter] 구독 {} 실행", subscription.subscriptionId());
         try {
-            if (cancelled.get()) {
-                log.info("[SpringAiMonitorAdapter] 구독 {} 취소 플래그 확인 — 스킵", subscription.subscriptionId());
-                return;
-            }
-            log.info("[SpringAiMonitorAdapter] 구독 {} 실행", subscription.subscriptionId());
             List<SubscriptionContext> asList = List.of(subscription);
             String payload = objectMapper.writeValueAsString(asList);
             ExecutionResult result = requestMonitorExecution(payload);
@@ -201,19 +181,14 @@ public class SpringAiMonitorAdapter implements RunAiMonitorPort, RunSubscription
             verifyExecutionResponse(content, asList, executions);
         } catch (JsonProcessingException e) {
             log.error("[SpringAiMonitorAdapter] 구독 {} 직렬화 실패", subscription.subscriptionId(), e);
-            cancelled.set(true);
             throw new ApiException(ErrorCode.AI_PARSE_FAILED);
-        } catch (ApiException e) {
-            cancelled.set(true);
-            throw e;
-        } finally {
-            semaphore.release();
         }
     }
 
+    // Semaphore를 유지하면서도 rate limit이 발생하면 해당 호출만 재시도한다.
+    // 이전 tool 실행 결과는 보존되므로 retry가 처음부터 다시 시작하지 않는다.
+    // Gemini가 도구 호출 후 최종 text를 비우는 경우가 있어 MCP 콜백 실행 기록도 함께 본다.
     private ExecutionResult requestMonitorExecution(String userPrompt) {
-        // Gemini가 도구 호출 후 최종 text를 비우는 경우가 있어 MCP 콜백 실행 기록도 함께 본다.
-        // rate limit 시 해당 호출만 재시도 — 이전 호출 결과는 보존
         for (int attempt = 0; ; attempt++) {
             McpToolExecutionRecorder.start();
             String content = null;

--- a/back/src/main/java/com/back/domain/application/port/out/RunSubscriptionExecutionPort.java
+++ b/back/src/main/java/com/back/domain/application/port/out/RunSubscriptionExecutionPort.java
@@ -1,7 +1,6 @@
 package com.back.domain.application.port.out;
 
 import com.back.domain.application.service.SubscriptionContext;
-import java.util.List;
 
 /**
  * [Outgoing Port] 구독 실행 요청 포트.
@@ -9,5 +8,5 @@ import java.util.List;
  * 검색(RunAiMonitorPort)과 구독 실행은 별개 흐름이므로 분리.
  */
 public interface RunSubscriptionExecutionPort {
-    void execute(List<SubscriptionContext> subscriptions);
+    void execute(SubscriptionContext subscription);
 }

--- a/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
+++ b/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -62,7 +63,10 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
         }
         log.info("[SubscriptionMonitorService] 구독 실행 시작 - {}건", dueSchedules.size());
 
-        dueSchedules.forEach(schedule -> executeSchedule(schedule, now));
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            dueSchedules.forEach(schedule ->
+                    executor.submit(() -> executeSchedule(schedule, now)));
+        }
     }
 
     private void executeSchedule(Schedule schedule, LocalDateTime now) {

--- a/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
+++ b/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
@@ -63,6 +63,9 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
         }
         log.info("[SubscriptionMonitorService] 구독 실행 시작 - {}건", dueSchedules.size());
 
+        // VT per subscription: I/O 대기(Gemini API) 중 carrier thread를 반납해 병렬도를 높인다.
+        // try-with-resources: executor.close()가 모든 VT 완료를 기다린 뒤 반환한다.
+        // 동시 Gemini 호출 수 제한은 어댑터 Semaphore가 담당한다.
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             dueSchedules.forEach(schedule ->
                     executor.submit(() -> executeSchedule(schedule, now)));
@@ -74,7 +77,7 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
                 loadSubscriptionMonitoringConfigPort.loadBySubscriptionId(schedule.subscription().id());
         SubscriptionContext context = buildContext(schedule, config, now);
         try {
-            runSubscriptionExecutionPort.execute(List.of(context));
+            runSubscriptionExecutionPort.execute(context);
             advanceSchedule(schedule, now);
         } catch (RuntimeException e) {
             log.warn(

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -355,7 +355,7 @@ public class SubscriptionConversationService {
             SubscriptionResult result
     ) {
         // 구독 확정 응답은 첫 baseline 수집까지 성공해야 실제로 감시가 시작됐다고 본다.
-        runSubscriptionExecutionPort.execute(List.of(new SubscriptionContext(
+        runSubscriptionExecutionPort.execute(new SubscriptionContext(
                 result.id(),
                 conversation.getDraftDomainName(),
                 result.query(),
@@ -364,7 +364,7 @@ public class SubscriptionConversationService {
                         ? conversation.getDraftNotificationChannel().name()
                         : null,
                 notificationTarget(userId, conversation)
-        )));
+        ));
     }
 
     private Map<String, Object> baselineParams(SubscriptionConversationJpaEntity conversation) {

--- a/back/src/test/java/com/back/domain/adapter/out/ai/SpringAiMonitorAdapterTest.java
+++ b/back/src/test/java/com/back/domain/adapter/out/ai/SpringAiMonitorAdapterTest.java
@@ -39,19 +39,8 @@ class SpringAiMonitorAdapterTest {
     void failsExecuteWhenChatClientIsNull() {
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(null, new ObjectMapper(), Integer.MAX_VALUE);
 
-        assertThatThrownBy(() -> adapter.execute(List.of(subscription())))
+        assertThatThrownBy(() -> adapter.execute(subscription()))
                 .isInstanceOf(RuntimeException.class);
-    }
-
-    @Test
-    @DisplayName("구독 목록이 비어 있으면 ChatClient를 호출하지 않는다")
-    void skipsMonitorCallWhenSubscriptionListIsEmpty() {
-        ChatClient chatClient = mock(ChatClient.class);
-        SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
-
-        adapter.execute(List.of());
-
-        verifyNoInteractions(chatClient);
     }
 
     @Test
@@ -62,7 +51,7 @@ class SpringAiMonitorAdapterTest {
                 .thenReturn("처리했습니다.");
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        assertThatThrownBy(() -> adapter.execute(List.of(subscription())))
+        assertThatThrownBy(() -> adapter.execute(subscription()))
                 .isInstanceOf(RuntimeException.class);
     }
 
@@ -76,7 +65,7 @@ class SpringAiMonitorAdapterTest {
                         """);
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
     }
 
     @Test
@@ -92,7 +81,7 @@ class SpringAiMonitorAdapterTest {
                         """);
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
     }
 
     @Test
@@ -113,7 +102,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
     }
 
     @Test
@@ -134,7 +123,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        assertThatThrownBy(() -> adapter.execute(List.of(subscription())))
+        assertThatThrownBy(() -> adapter.execute(subscription()))
                 .isInstanceOf(RuntimeException.class);
     }
 
@@ -161,7 +150,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        assertThatThrownBy(() -> adapter.execute(List.of(subscription())))
+        assertThatThrownBy(() -> adapter.execute(subscription()))
                 .isInstanceOf(RuntimeException.class);
     }
 
@@ -192,7 +181,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -233,7 +222,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(3);
     }
@@ -330,7 +319,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -360,7 +349,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -395,7 +384,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -430,7 +419,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -464,7 +453,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -498,7 +487,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -530,7 +519,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(2);
     }
@@ -566,7 +555,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(3);
     }
@@ -600,7 +589,7 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        adapter.execute(List.of(subscription()));
+        adapter.execute(subscription());
 
         assertThat(calls).hasValue(4);
     }
@@ -615,7 +604,7 @@ class SpringAiMonitorAdapterTest {
                         """);
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        assertThatThrownBy(() -> adapter.execute(List.of(subscription())))
+        assertThatThrownBy(() -> adapter.execute(subscription()))
                 .isInstanceOf(RuntimeException.class);
     }
 
@@ -629,12 +618,12 @@ class SpringAiMonitorAdapterTest {
                         """);
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        assertThatThrownBy(() -> adapter.execute(List.of(subscription())))
+        assertThatThrownBy(() -> adapter.execute(subscription()))
                 .isInstanceOf(RuntimeException.class);
     }
 
     @Test
-    @DisplayName("여러 구독이 병렬로 실행된다")
+    @DisplayName("서비스 레이어처럼 여러 VT가 각각 execute()를 호출하면 병렬로 실행된다")
     void executesSubscriptionsConcurrently() throws InterruptedException {
         int count = 5;
         CountDownLatch allStarted = new CountDownLatch(count);
@@ -648,17 +637,20 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), Integer.MAX_VALUE);
 
-        Thread t = Thread.ofVirtual().start(() -> {
-            try { adapter.execute(subs(count)); } catch (Exception ignored) {}
-        });
+        // 서비스 레이어 VT 동작 시뮬레이션: 각 구독을 별도 VT에서 호출
+        List<Thread> threads = subs(count).stream()
+                .map(sub -> Thread.ofVirtual().start(() -> {
+                    try { adapter.execute(sub); } catch (Exception ignored) {}
+                }))
+                .toList();
 
         assertTrue(allStarted.await(3, TimeUnit.SECONDS), "5개 구독이 동시에 시작되지 않았다");
         release.countDown();
-        t.join(3000);
+        for (Thread t : threads) t.join(3000);
     }
 
     @Test
-    @DisplayName("Semaphore가 동시 실행 수를 제한한다")
+    @DisplayName("Semaphore가 여러 VT의 동시 실행 수를 전역으로 제한한다")
     void semaphoreLimitsConcurrency() throws InterruptedException {
         int limit = 2;
         AtomicInteger concurrent = new AtomicInteger(0);
@@ -675,14 +667,17 @@ class SpringAiMonitorAdapterTest {
                 });
         SpringAiMonitorAdapter adapter = new SpringAiMonitorAdapter(chatClient, new ObjectMapper(), limit);
 
-        Thread t = Thread.ofVirtual().start(() -> {
-            try { adapter.execute(subs(5)); } catch (Exception ignored) {}
-        });
+        // 서비스 레이어 VT 동작 시뮬레이션: 각 구독을 별도 VT에서 호출
+        List<Thread> threads = subs(5).stream()
+                .map(sub -> Thread.ofVirtual().start(() -> {
+                    try { adapter.execute(sub); } catch (Exception ignored) {}
+                }))
+                .toList();
 
         Thread.sleep(200);
         assertThat(maxConcurrent.get()).isLessThanOrEqualTo(limit);
         release.countDown();
-        t.join(3000);
+        for (Thread t : threads) t.join(3000);
     }
 
     private SubscriptionContext subscription() {

--- a/back/src/test/java/com/back/domain/application/service/SubscriptionMonitorServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/SubscriptionMonitorServiceTest.java
@@ -11,9 +11,9 @@ import com.back.domain.model.subscription.SubscriptionMonitoringConfig;
 import com.back.domain.model.user.User;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -148,7 +148,7 @@ class SubscriptionMonitorServiceTest {
     }
 
     private static class CapturingSubscriptionExecutionPort implements RunSubscriptionExecutionPort {
-        private final List<SubscriptionContext> contexts = new ArrayList<>();
+        private final List<SubscriptionContext> contexts = new CopyOnWriteArrayList<>();
         private final List<String> failedSubscriptionIds;
 
         CapturingSubscriptionExecutionPort(String... failedSubscriptionIds) {
@@ -156,21 +156,17 @@ class SubscriptionMonitorServiceTest {
         }
 
         @Override
-        public void execute(List<SubscriptionContext> subscriptions) {
-            contexts.clear();
-            contexts.addAll(subscriptions);
-            boolean hasFailedSubscription = subscriptions.stream()
-                    .map(SubscriptionContext::subscriptionId)
-                    .anyMatch(failedSubscriptionIds::contains);
-            if (hasFailedSubscription) {
+        public void execute(SubscriptionContext subscription) {
+            contexts.add(subscription);
+            if (failedSubscriptionIds.contains(subscription.subscriptionId())) {
                 throw new RuntimeException("execution failed");
             }
         }
     }
 
     private static class CapturingSaveSchedulePort implements SaveSchedulePort {
-        private final List<Schedule> savedSchedules = new ArrayList<>();
-        private Schedule savedSchedule;
+        private final List<Schedule> savedSchedules = new CopyOnWriteArrayList<>();
+        private volatile Schedule savedSchedule;
 
         @Override
         public Schedule save(Schedule schedule) {

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -2143,9 +2143,9 @@ class SubscriptionConversationServiceTest {
         private RuntimeException failure;
 
         @Override
-        public void execute(List<SubscriptionContext> subscriptions) {
+        public void execute(SubscriptionContext subscription) {
             contexts.clear();
-            contexts.addAll(subscriptions);
+            contexts.add(subscription);
             if (failure != null) {
                 throw failure;
             }


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #

**🛠 작업 내역**
execute(List) → execute(SubscriptionContext) 단건 포트로 변경.
병렬화 책임을 서비스 레이어 VT로 일원화하고
어댑터 내부의 이중 executor/CompletableFuture/AtomicBoolean을 제거했다.

변경 내용:
- RunSubscriptionExecutionPort: execute(List) → execute(SubscriptionContext)
- SpringAiMonitorAdapter.execute(): 내부 executor/allOf/cancelled 제거.
  Semaphore 획득·해제만 담당. Semaphore는 bean 필드로 유지해
  서비스 VT 전체에 걸친 전역 동시 Gemini 호출 수를 제한한다.
- SpringAiMonitorAdapter.processSubscription(): AtomicBoolean cancelled 제거.
  AI 실행 로직만 담당.
- SubscriptionMonitorService.runAll(): VT 병렬화는 이미 적용.
  execute() 호출을 List.of(context) → context 단건으로 변경.
- SubscriptionConversationService: 동일 패턴 단건으로 변경.
- 테스트: execute(List.of) → execute(단건), 동시성 테스트를
  멀티 VT 시뮬레이션 방식으로 교체. CopyOnWriteArrayList 적용.

Semaphore와 retry는 역할이 다르다.
Semaphore(proactive)는 thundering herd를 사전에 억제하고,
retry(reactive)는 429 발생 후 복구한다. 둘을 병행 유지한다.
-

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?