### PR TITLE
Perf: DB 인덱스 보강 + 커넥션 풀·HTTP 클라이언트 재사용 + MCP 도구 카탈로그 캐싱

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/persistence/hub/AiDataHubJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/hub/AiDataHubJpaEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,7 +24,10 @@ import org.hibernate.annotations.ColumnTransformer;
  */
 @Getter
 @Entity
-@Table(name = "ai_data_hub")
+// findByUserIdAndMcpToolIdOrderByCreatedAtDescIdDesc 로 최근 실행 결과 조회
+@Table(name = "ai_data_hub", indexes = {
+        @Index(name = "idx_ai_data_hub_user_tool_created", columnList = "user_id, mcp_tool_id, created_at")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AiDataHubJpaEntity extends BaseTimeEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/mcp/McpHttpAdapter.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/mcp/McpHttpAdapter.java
@@ -14,6 +14,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +31,12 @@ public class McpHttpAdapter implements ExecuteMcpToolPort {
 
     private final List<McpSyncClient> clients;
     private final ObjectMapper objectMapper;
+
+    // Tool 카탈로그(어떤 client 가 어떤 tool 을 제공하는가)는 런타임 동안 사실상 불변.
+    // 도구 실행 때마다 listTools() 를 왕복하던 것을 첫 호출 1회 스캔으로 캐싱한다.
+    private final Map<String, McpSyncClient> clientByToolName = new ConcurrentHashMap<>();
+    private final ReentrantLock catalogLock = new ReentrantLock();
+    private volatile boolean catalogLoaded = false;
 
     public McpHttpAdapter(List<McpSyncClient> clients, ObjectMapper objectMapper) {
         this.clients = clients;
@@ -55,17 +63,44 @@ public class McpHttpAdapter implements ExecuteMcpToolPort {
     }
 
     private McpSyncClient clientFor(String toolName) {
-        return clients.stream()
-                .filter(client -> hasTool(client, toolName))
-                .findFirst()
-                .orElseThrow(() -> new ApiException(ErrorCode.MCP_REQUEST_FAILED));
+        McpSyncClient cached = clientByToolName.get(toolName);
+        if (cached != null) {
+            return cached;
+        }
+        if (!catalogLoaded) {
+            loadToolCatalogOnce();
+            cached = clientByToolName.get(toolName);
+            if (cached != null) {
+                return cached;
+            }
+        }
+        throw new ApiException(ErrorCode.MCP_REQUEST_FAILED);
     }
 
-    private boolean hasTool(McpSyncClient client, String toolName) {
-        McpSchema.ListToolsResult tools = client.listTools();
-        return tools != null
-                && tools.tools() != null
-                && tools.tools().stream().anyMatch(tool -> toolName.equals(tool.name()));
+    /**
+     * 모든 MCP client 의 listTools() 를 1회씩만 호출해 tool→client 맵을 채운다.
+     * listTools() 가 실패하면 catalogLoaded 를 true 로 올리지 않으므로 다음 호출에서 재시도된다
+     * (서버 기동 직후 MCP 서버가 아직 안 떠 있는 상황 대응).
+     */
+    private void loadToolCatalogOnce() {
+        catalogLock.lock();
+        try {
+            if (catalogLoaded) {
+                return;
+            }
+            for (McpSyncClient client : clients) {
+                McpSchema.ListToolsResult tools = client.listTools();
+                if (tools == null || tools.tools() == null) {
+                    continue;
+                }
+                for (McpSchema.Tool tool : tools.tools()) {
+                    clientByToolName.putIfAbsent(tool.name(), client);
+                }
+            }
+            catalogLoaded = true;
+        } finally {
+            catalogLock.unlock();
+        }
     }
 
     private Map<String, Object> structuredContent(McpSchema.CallToolResult result) {

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationDeliveryJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationDeliveryJpaEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -17,7 +18,11 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "notification_delivery")
+// 디스패처가 5초마다 findDispatchable(status, nextRetryAt) ... order by createdAt 로 폴링
+@Table(name = "notification_delivery", indexes = {
+        @Index(name = "idx_notif_delivery_status_retry", columnList = "status, next_retry_at"),
+        @Index(name = "idx_notif_delivery_created_at", columnList = "created_at")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationDeliveryJpaEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationEndpointJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationEndpointJpaEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "notification_endpoint")
+// findByUserIdAndChannelAndEnabledTrue 로 사용자별 발송 대상 주소 조회
+@Table(name = "notification_endpoint", indexes = {
+        @Index(name = "idx_notif_endpoint_user_channel", columnList = "user_id, channel, enabled")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationEndpointJpaEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationJpaEntity.java
@@ -19,7 +19,11 @@ import java.time.LocalDateTime;
  */
 @Getter
 @Entity
-@Table(name = "notification")
+@Table(name = "notification", indexes = {
+        @Index(name = "idx_notification_schedule", columnList = "schedule_id"),
+        @Index(name = "idx_notification_user", columnList = "user_id"),
+        @Index(name = "idx_notification_ai_data_hub", columnList = "ai_data_hub_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationJpaEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationPreferenceJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/notification/NotificationPreferenceJpaEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "notification_preference")
+// 스케줄러가 구독마다 findBySubscriptionIdAndEnabledTrue 로 조회
+@Table(name = "notification_preference", indexes = {
+        @Index(name = "idx_notif_pref_subscription", columnList = "subscription_id, enabled")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationPreferenceJpaEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/schedule/ScheduleJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/schedule/ScheduleJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,12 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @Entity
-@Table(name = "schedule")
+@Table(name = "schedule", indexes = {
+        // 스케줄러가 매 주기 도는 핵심 쿼리(findDueActiveSubscriptionSchedules) 의 nextRun 필터용
+        @Index(name = "idx_schedule_next_run", columnList = "next_run"),
+        // findFirstBySubscriptionIdOrderByNextRunAsc + FK(sub_id) 조인용
+        @Index(name = "idx_schedule_sub_id_next_run", columnList = "sub_id, next_run")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ScheduleJpaEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/subscription/SubscriptionJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/subscription/SubscriptionJpaEntity.java
@@ -16,7 +16,10 @@ import lombok.NoArgsConstructor;
  */
 @Getter
 @Entity
-@Table(name = "subscription")
+@Table(name = "subscription", indexes = {
+        // findByUserIdAndActiveTrue / findByUserIdAndDomainIdAndActiveTrue 등 사용자별 활성 구독 조회용
+        @Index(name = "idx_subscription_user_domain_active", columnList = "user_id, domain_id, is_active")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubscriptionJpaEntity extends BaseTimeEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/subscriptionconversation/SubscriptionMonitoringConfigJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/subscriptionconversation/SubscriptionMonitoringConfigJpaEntity.java
@@ -6,6 +6,7 @@ import com.back.global.common.UuidGenerator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,7 +14,10 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "subscription_monitoring_config")
+// 스케줄러가 구독마다 findBySubscriptionId 로 조회 → subscription_id 인덱스 필수
+@Table(name = "subscription_monitoring_config", indexes = {
+        @Index(name = "idx_smc_subscription_id", columnList = "subscription_id")
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubscriptionMonitoringConfigJpaEntity extends BaseTimeEntity {
 

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/token/TokenUsageHistoryJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/token/TokenUsageHistoryJpaEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +21,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "token_usage_history")
+@Table(name = "token_usage_history", indexes = {
+        @Index(name = "idx_token_usage_history_user", columnList = "user_id")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/user/UserOAuthConnectionJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/user/UserOAuthConnectionJpaEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,7 +26,8 @@ import lombok.NoArgsConstructor;
         uniqueConstraints = @UniqueConstraint(
                 name = "uk_user_oauth_provider_identity",
                 columnNames = {"provider", "provider_user_id"}
-        )
+        ),
+        indexes = @Index(name = "idx_user_oauth_user", columnList = "user_id")
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserOAuthConnectionJpaEntity extends BaseTimeEntity {

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/user/UserSessionJpaEntity.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/user/UserSessionJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -20,7 +21,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(
         name = "user_sessions",
-        uniqueConstraints = @UniqueConstraint(name = "uk_user_session_token_hash", columnNames = "token_hash")
+        uniqueConstraints = @UniqueConstraint(name = "uk_user_session_token_hash", columnNames = "token_hash"),
+        indexes = @Index(name = "idx_user_session_user", columnList = "user_id")
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSessionJpaEntity extends BaseTimeEntity {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -3,11 +3,25 @@ spring:
     name: back
   profiles:
     default: dev
+  # I/O 바운드(LLM·외부 API) 작업을 가상 스레드로 처리 — 플랫폼 스레드 풀 고갈 없이 대량 동시 호출.
+  # (SpringAiMonitorAdapter 가 이미 수동 가상 스레드를 쓰지만, web/scheduler/@Async 레이어도 일관되게 적용)
+  threads:
+    virtual:
+      enabled: true
+  datasource:
+    hikari:
+      # 가상 스레드로 동시성이 올라가면 기본값 10 으로는 커넥션 고갈 → 환경별 override 가능
+      maximum-pool-size: ${DB_POOL_MAX_SIZE:30}
   jpa:
     open-in-view: false
     properties:
       hibernate:
         format_sql: true
+        # 알림 발송·스케줄 갱신 등 다건 INSERT/UPDATE 를 배치로 묶어 round-trip 절감
+        order_inserts: true
+        order_updates: true
+        jdbc:
+          batch_size: 30
   flyway:
     baseline-on-migrate: true
     baseline-version: 0

--- a/back/src/main/resources/db/migration/V7__add_fk_indexes_mcp_tool.sql
+++ b/back/src/main/resources/db/migration/V7__add_fk_indexes_mcp_tool.sql
@@ -1,0 +1,7 @@
+-- mcp_tool 의 FK 컬럼(server_id, domain_id) 인덱스 추가.
+-- V2에서 테이블을 만들 때 UNIQUE(server_id, name) 만 걸려 있어 server_id 단독·domain_id 조인이 풀스캔이었다.
+-- mcp_tool 은 Flyway 가 생성·관리하는 테이블이므로 인덱스도 마이그레이션으로 둔다.
+-- (그 외 ddl-auto 가 생성하는 테이블의 FK 인덱스는 각 JpaEntity 의 @Table(indexes=...) 로 관리한다.)
+-- IF NOT EXISTS: 테스트 환경(ddl-auto: create-drop) 및 재실행 호환.
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_server_id ON mcp_tool (server_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_tool_domain_id ON mcp_tool (domain_id);

--- a/mcp-server/src/mcp_server/config.py
+++ b/mcp-server/src/mcp_server/config.py
@@ -26,6 +26,18 @@ class Settings(BaseSettings):
     pg_url: str = Field(
         description="MCP 내부 DB 접속 URL (asyncpg 드라이버). default 없음 — .env 미로드 시 ValidationError.",
     )
+    # fetch() 한 번에 세션을 3~4개 순차로 열고 닫는 패턴이라 동시 도구 실행 시 커넥션 압박.
+    # SQLAlchemy 기본(pool_size=5, max_overflow=10) 으로는 부족해질 수 있어 환경변수로 조정 가능.
+    db_pool_size: int = Field(
+        default=10,
+        validation_alias=AliasChoices("MCP_DB_POOL_SIZE", "DB_POOL_SIZE"),
+        description="AsyncEngine 기본 커넥션 풀 크기.",
+    )
+    db_pool_max_overflow: int = Field(
+        default=10,
+        validation_alias=AliasChoices("MCP_DB_POOL_MAX_OVERFLOW", "DB_POOL_MAX_OVERFLOW"),
+        description="AsyncEngine 풀 초과 허용 커넥션 수.",
+    )
 
     langfuse_enabled: bool = Field(default=True)
     langfuse_host: str = Field(default="http://localhost:3000")

--- a/mcp-server/src/mcp_server/db/session.py
+++ b/mcp-server/src/mcp_server/db/session.py
@@ -29,6 +29,9 @@ def get_engine() -> AsyncEngine:
         settings = get_settings()
         _engine = create_async_engine(
             settings.pg_url,
+            pool_size=settings.db_pool_size,
+            max_overflow=settings.db_pool_max_overflow,
+            pool_recycle=1800,  # DB 측 idle timeout 보다 먼저 끊어 stale 커넥션 사용 방지
             pool_pre_ping=True,
             future=True,
         )

--- a/mcp-server/src/mcp_server/server.py
+++ b/mcp-server/src/mcp_server/server.py
@@ -20,6 +20,7 @@ from starlette.responses import JSONResponse
 from mcp_server.config import get_settings
 from mcp_server.db.session import reset_engine
 from mcp_server.observability.tracing import flush_langfuse, get_langfuse
+from mcp_server.sources.api_source_service import aclose_http_client
 
 
 @asynccontextmanager
@@ -29,8 +30,9 @@ async def server_lifespan(_: FastMCP) -> AsyncIterator[None]:
     try:
         yield
     finally:
-        # shutdown: trace 손실 방지 + DB 풀 정리
+        # shutdown: trace 손실 방지 + 공유 HTTP 클라이언트 / DB 풀 정리
         flush_langfuse()
+        await aclose_http_client()
         await reset_engine()
 
 

--- a/mcp-server/src/mcp_server/sources/api_source_service.py
+++ b/mcp-server/src/mcp_server/sources/api_source_service.py
@@ -22,6 +22,29 @@ from mcp_server.db.session import get_session
 from mcp_server.sources.errors import SourceFetchError, SourceNotFoundError
 from mcp_server.sources.result import RawResult
 
+# 공유 httpx 클라이언트 (프로세스당 1개) — 매 fetch() 마다 새로 만들면 커넥션 풀·keep-alive 가
+# 버려져 도메인 도구 호출 1회 = TCP+TLS 핸드셰이크 1회가 된다. lazy singleton 으로 재사용.
+_http_client: httpx.AsyncClient | None = None
+_HTTP_TIMEOUT = 10.0
+
+
+def _get_http_client() -> httpx.AsyncClient:
+    global _http_client
+    if _http_client is None:
+        _http_client = httpx.AsyncClient(
+            timeout=_HTTP_TIMEOUT,
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+        )
+    return _http_client
+
+
+async def aclose_http_client() -> None:
+    """서버 lifespan 종료 시 호출. 열린 커넥션 정리."""
+    global _http_client
+    if _http_client is not None:
+        await _http_client.aclose()
+    _http_client = None
+
 
 async def fetch(
     source_id: int,
@@ -248,11 +271,8 @@ async def _call_external_api(
 ) -> str:
     """url_template + params 로 GET. JSON 응답은 정렬·직렬화, 그 외는 .text 그대로."""
     try:
-        if http_client is None:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                response = await client.get(endpoint, params=params)
-        else:
-            response = await http_client.get(endpoint, params=params)
+        client = http_client if http_client is not None else _get_http_client()
+        response = await client.get(endpoint, params=params)
         response.raise_for_status()
     except httpx.HTTPError as exc:
         raise SourceFetchError(f"API 호출 실패: {endpoint} ({exc})") from exc
@@ -268,6 +288,7 @@ __all__ = [
     "peek_cached_at",
     "peek_cached_content",
     "resolve_source_id_by_tool_name",
+    "aclose_http_client",
     "_PARAM_KEY_FIELDS",
     "_CACHEABLE_TOOLS",
 ]

--- a/mcp-server/tests/test_server.py
+++ b/mcp-server/tests/test_server.py
@@ -33,7 +33,7 @@ async def test_registered_tools_include_search_house_price() -> None:
 
 
 async def test_lifespan_calls_shutdown_hooks(monkeypatch: pytest.MonkeyPatch) -> None:
-    called = {"reset": False, "flush": False}
+    called = {"reset": False, "flush": False, "http_close": False}
 
     async def fake_reset() -> None:
         called["reset"] = True
@@ -41,14 +41,19 @@ async def test_lifespan_calls_shutdown_hooks(monkeypatch: pytest.MonkeyPatch) ->
     def fake_flush() -> None:
         called["flush"] = True
 
+    async def fake_http_close() -> None:
+        called["http_close"] = True
+
     monkeypatch.setattr(server_mod, "reset_engine", fake_reset)
     monkeypatch.setattr(server_mod, "flush_langfuse", fake_flush)
+    monkeypatch.setattr(server_mod, "aclose_http_client", fake_http_close)
 
     async with server_mod.server_lifespan(server_mod.mcp):
         pass
 
     assert called["reset"] is True
     assert called["flush"] is True
+    assert called["http_close"] is True
 
 
 def test_settings_rejects_unknown_transport(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #148 

**🛠 작업 내역**
- 풀스캔으로 돌던 스케줄러/알림 디스패처 폴링 쿼리, 사용자 단위 조회에 인덱스 보강
- MCP 도구 실행마다 하던 `listTools()` 왕복 제거 -> 첫 호출 1회 스캔 후 캐싱
- MCP 서버에서 fetch 마다 새로 만들던 httpx 클라이언트를 프로세스당 1개로 재사용
- 가상 스레드 전역 활성화 + Hikari/SQLAlchemy 커넥션 풀, Hibernate 배치 설정

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?