### PR TITLE
perf: 알림 디스패치 가상 스레드 병렬화 + 동시 발송 한도 도입

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/notification/NotificationClientProperties.java
+++ b/back/src/main/java/com/back/domain/adapter/out/notification/NotificationClientProperties.java
@@ -9,6 +9,8 @@ public class NotificationClientProperties {
 
     private int maxAttempts = 3;
     private long retryDelaySeconds = 300;
+    // 디스패처 한 틱에서 동시에 발송할 수 있는 알림 수 상한. 외부 채널 rate limit 보호용.
+    private int dispatchConcurrencyLimit = 20;
     private final Telegram telegram = new Telegram();
 
     public int getMaxAttempts() {
@@ -25,6 +27,14 @@ public class NotificationClientProperties {
 
     public void setRetryDelaySeconds(long retryDelaySeconds) {
         this.retryDelaySeconds = retryDelaySeconds;
+    }
+
+    public int getDispatchConcurrencyLimit() {
+        return dispatchConcurrencyLimit;
+    }
+
+    public void setDispatchConcurrencyLimit(int dispatchConcurrencyLimit) {
+        this.dispatchConcurrencyLimit = dispatchConcurrencyLimit;
     }
 
     public Telegram getTelegram() {

--- a/back/src/main/java/com/back/domain/application/service/NotificationDispatcherService.java
+++ b/back/src/main/java/com/back/domain/application/service/NotificationDispatcherService.java
@@ -10,13 +10,13 @@ import com.back.domain.model.notification.NotificationSendResult;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
 public class NotificationDispatcherService {
 
     private static final Logger log = LoggerFactory.getLogger(NotificationDispatcherService.class);
@@ -26,6 +26,24 @@ public class NotificationDispatcherService {
     private final SaveNotificationDeliveryPort saveDeliveryPort;
     private final NotificationClientProperties properties;
     private final MeterRegistry meterRegistry;
+    // 디스패처 전역으로 동시 발송 수를 제한한다. 호출 단위로 new Semaphore()를 만들면
+    // 틱마다 별도 한도가 생겨 외부 제공자 rate limit(예: 텔레그램 글로벌 ~30 msg/s) 보호가 풀린다.
+    private final Semaphore concurrencyGuard;
+
+    public NotificationDispatcherService(
+            LoadDispatchableNotificationDeliveryPort loadDeliveryPort,
+            List<SendNotificationDeliveryPort> senders,
+            SaveNotificationDeliveryPort saveDeliveryPort,
+            NotificationClientProperties properties,
+            MeterRegistry meterRegistry
+    ) {
+        this.loadDeliveryPort = loadDeliveryPort;
+        this.senders = senders;
+        this.saveDeliveryPort = saveDeliveryPort;
+        this.properties = properties;
+        this.meterRegistry = meterRegistry;
+        this.concurrencyGuard = new Semaphore(Math.max(1, properties.getDispatchConcurrencyLimit()));
+    }
 
     public int dispatchPending(LocalDateTime now) {
         List<NotificationDelivery> deliveries = loadDeliveryPort.loadDispatchable(now);
@@ -33,13 +51,29 @@ public class NotificationDispatcherService {
     }
 
     public int dispatch(List<NotificationDelivery> deliveries, LocalDateTime now) {
-        for (NotificationDelivery delivery : deliveries) {
+        // VT per delivery: send()는 BE→MCP→외부 채널로 이어지는 블로킹 I/O다.
+        // try-with-resources의 executor.close()가 모든 VT 완료를 기다리므로 반환 시점 보장은 동일하다.
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (NotificationDelivery delivery : deliveries) {
+                executor.submit(() -> dispatchAndPersist(delivery, now));
+            }
+        }
+        return deliveries.size();
+    }
+
+    private void dispatchAndPersist(NotificationDelivery delivery, LocalDateTime now) {
+        concurrencyGuard.acquireUninterruptibly();
+        try {
             NotificationDelivery dispatched = dispatchOne(delivery, now);
             recordDispatch(dispatched);
             logDispatch(dispatched);
             saveDeliveryPort.save(dispatched);
+        } catch (RuntimeException exception) {
+            // 한 delivery의 실패(예: save 단계 예외)가 같은 틱의 다른 delivery 발송을 막지 않도록 격리한다.
+            log.error("Notification delivery dispatch failed unexpectedly id={}", delivery.id(), exception);
+        } finally {
+            concurrencyGuard.release();
         }
-        return deliveries.size();
     }
 
     private NotificationDelivery dispatchOne(NotificationDelivery delivery, LocalDateTime now) {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -74,6 +74,7 @@ app:
   notification:
     max-attempts: ${APP_NOTIFICATION_MAX_ATTEMPTS:3}
     retry-delay-seconds: ${APP_NOTIFICATION_RETRY_DELAY_SECONDS:300}
+    dispatch-concurrency-limit: ${APP_NOTIFICATION_DISPATCH_CONCURRENCY_LIMIT:20}
     telegram:
       bot-username: ${APP_NOTIFICATION_TELEGRAM_BOT_USERNAME:}
     baseline-promote:

--- a/back/src/test/java/com/back/domain/application/service/NotificationDispatcherServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/NotificationDispatcherServiceTest.java
@@ -12,8 +12,10 @@ import com.back.domain.model.notification.NotificationDeliveryStatus;
 import com.back.domain.model.notification.NotificationSendResult;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -122,8 +124,64 @@ class NotificationDispatcherServiceTest {
         assertThat(saved.failureReason()).contains("No notification sender");
     }
 
+    @Test
+    @DisplayName("Application: 다건 Delivery를 병렬 발송하고 동시 발송 수는 설정 한도를 넘지 않는다")
+    void dispatchesDeliveriesConcurrentlyWithinConfiguredLimit() {
+        LocalDateTime now = LocalDateTime.of(2026, 4, 23, 10, 0);
+        int deliveryCount = 30;
+        int concurrencyLimit = 5;
+        List<NotificationDelivery> pending = IntStream.range(0, deliveryCount)
+                .mapToObj(index -> pendingDelivery("delivery-" + index, 0))
+                .toList();
+        FakeSaveNotificationDeliveryPort savePort = new FakeSaveNotificationDeliveryPort();
+        NotificationClientProperties properties = new NotificationClientProperties();
+        properties.setDispatchConcurrencyLimit(concurrencyLimit);
+
+        AtomicInteger inFlight = new AtomicInteger();
+        AtomicInteger maxObserved = new AtomicInteger();
+        SendNotificationDeliveryPort slowSender = new SendNotificationDeliveryPort() {
+            @Override
+            public boolean supports(NotificationChannel channel) {
+                return true;
+            }
+
+            @Override
+            public NotificationSendResult send(NotificationDelivery delivery) {
+                int current = inFlight.incrementAndGet();
+                maxObserved.accumulateAndGet(current, Math::max);
+                try {
+                    Thread.sleep(20);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                inFlight.decrementAndGet();
+                return NotificationSendResult.success("provider-" + delivery.id());
+            }
+        };
+
+        NotificationDispatcherService service = new NotificationDispatcherService(
+                listLoader(pending),
+                List.of(slowSender),
+                savePort,
+                properties,
+                new SimpleMeterRegistry()
+        );
+
+        int dispatched = service.dispatchPending(now);
+
+        assertThat(dispatched).isEqualTo(deliveryCount);
+        assertThat(savePort.saved).hasSize(deliveryCount);
+        assertThat(savePort.saved)
+                .allSatisfy(saved -> assertThat(saved.status()).isEqualTo(NotificationDeliveryStatus.SENT));
+        assertThat(maxObserved.get()).isBetween(2, concurrencyLimit);
+    }
+
     private static LoadDispatchableNotificationDeliveryPort fixedLoader(NotificationDelivery delivery) {
         return now -> List.of(delivery);
+    }
+
+    private static LoadDispatchableNotificationDeliveryPort listLoader(List<NotificationDelivery> deliveries) {
+        return now -> deliveries;
     }
 
     private static SendNotificationDeliveryPort fixedSender(NotificationSendResult result) {
@@ -141,8 +199,12 @@ class NotificationDispatcherServiceTest {
     }
 
     private static NotificationDelivery pendingDelivery(int attemptCount) {
+        return pendingDelivery("delivery-1", attemptCount);
+    }
+
+    private static NotificationDelivery pendingDelivery(String id, int attemptCount) {
         return new NotificationDelivery(
-                "delivery-1",
+                id,
                 "alert-1",
                 "sub-1",
                 1L,
@@ -162,7 +224,7 @@ class NotificationDispatcherServiceTest {
 
     private static class FakeSaveNotificationDeliveryPort implements SaveNotificationDeliveryPort {
 
-        private final List<NotificationDelivery> saved = new ArrayList<>();
+        private final List<NotificationDelivery> saved = new CopyOnWriteArrayList<>();
 
         @Override
         public NotificationDelivery save(NotificationDelivery delivery) {


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #153 

**🛠 작업 내역**
NotificationDispatcherService.dispatch() 가 PENDING/RETRY 상태 알림을 for 루프로 순차 발송한다. 각 항목마다 sender.send(delivery) 는 BE → MCP send_notification Tool → Telegram/Discord/Email 로 이어지는 블로킹 I/O 이고, 뒤따르는 saveDeliveryPort.save()도 동기

디스패처는 5초 주기로 도는데 fixedDelay 는 이전 실행이 끝나야 다음 틱이 시작된다. 따라서 PENDING 알림이 N건 쌓이면 채널 왕복 지연 × N 이 한 틱에 직렬로 누적돼 알림이 늦게 나감

이미 가상 스레드를 전역 활성화했고 SubscriptionMonitorService.runAll() 이 동일 패턴으로 구독 실행을 병렬화하고 있으므로, 디스패치도 같은 방식으로 병렬화한다. 외부 제공자 rate limit을 고려해 동시 발송 수는 Semaphore 로 제한한다 - SpringAiMonitorAdapter 의 Gemini 호출 가드와 동일

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?