### PR TITLE
fix : prod setting 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -227,9 +227,41 @@ jobs:
             # ── MCP 이미지 Pull + 인프라 기동 ───────────────────
             docker pull "${MCP_IMAGE}:${IMAGE_TAG}"
 
+            # mcp-server 제외하고 인프라 먼저 기동 (DB 초기화 후 MCP 기동)
             docker compose -f ~/app/infra/docker/prod/docker-compose.yml \
               --env-file ~/app/infra/docker/prod/.env \
-              up -d postgres redis minio langfuse-clickhouse langfuse-web langfuse-worker mcp-server
+              up -d postgres redis minio langfuse-clickhouse langfuse-web langfuse-worker
+
+            # postgres 준비 대기 (mcp_dev DB 생성 전)
+            PG_USER_VAL=$(env_value PG_USER)
+            PG_DB_WAIT=0
+            until docker exec prod-postgres pg_isready -U "${PG_USER_VAL}" >/dev/null 2>&1; do
+              if [ "$PG_DB_WAIT" -ge 60 ]; then
+                echo "Postgres 준비 실패 (60s 초과)"; exit 1
+              fi
+              sleep 3; PG_DB_WAIT=$((PG_DB_WAIT + 3))
+            done
+
+            # mcp_dev DB + pgvector 초기화 (멱등 — 이미 존재하면 건너뜀)
+            docker exec prod-postgres psql -U "${PG_USER_VAL}" \
+              -c "SELECT 'CREATE DATABASE mcp_dev' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname='mcp_dev')\gexec"
+            docker exec prod-postgres psql -U "${PG_USER_VAL}" -d mcp_dev \
+              -c "CREATE EXTENSION IF NOT EXISTS vector;"
+            echo "mcp_dev DB 초기화 완료"
+
+            # Alembic 마이그레이션 (멱등 — 이미 적용된 revision은 건너뜀)
+            PG_PASSWORD_VAL=$(env_value PG_PASSWORD)
+            docker run --rm --network prod-net \
+              -e PG_URL="postgresql+asyncpg://${PG_USER_VAL}:${PG_PASSWORD_VAL}@prod-postgres:5432/mcp_dev" \
+              "${MCP_IMAGE}:${IMAGE_TAG}" \
+              alembic upgrade head
+            echo "Alembic 마이그레이션 완료"
+
+            # ── MCP 서버 기동/업데이트 ──────────────────────────
+            docker compose -f ~/app/infra/docker/prod/docker-compose.yml \
+              --env-file ~/app/infra/docker/prod/.env \
+              up -d --force-recreate mcp-server
+            echo "MCP 서버 기동/업데이트 완료"
 
             # ── MCP 헬스체크 ───────────────────────────────────
             echo "MCP 서버 헬스체크 대기..."
@@ -252,15 +284,6 @@ jobs:
               MCP_ELAPSED=$((MCP_ELAPSED + MCP_INTERVAL))
             done
             echo "MCP 서버 정상 확인"
-
-            # ── MCP 서버 배포 ───────────────────────────────────
-            docker compose -f ~/app/infra/docker/prod/docker-compose.yml \
-              --env-file ~/app/infra/docker/prod/.env \
-              pull mcp-server
-            docker compose -f ~/app/infra/docker/prod/docker-compose.yml \
-              --env-file ~/app/infra/docker/prod/.env \
-              up -d --force-recreate mcp-server
-            echo "MCP 서버 기동/업데이트 완료"
 
             # ── Blue/Green 슬롯 판정 ───────────────────────────
             if docker ps --format '{{.Names}}' | grep -q "^be_a$"; then

--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
     // Observability — Langfuse OTLP 연동 (Spring Boot 4.x 신규 스타터)
     implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 
     // 테스트 환경
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -49,6 +49,10 @@ management:
     health:
       probes:
         enabled: true
+  otlp:
+    metrics:
+      export:
+        enabled: false
 
 app:
   frontend:

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -31,6 +31,8 @@ RUN playwright install --with-deps chromium
 # 7. 프로젝트 소스 복사 및 최종 설치
 COPY src/ ./src/
 COPY data/ ./data/
+COPY alembic/ ./alembic/
+COPY alembic.ini ./
 RUN uv sync --frozen --no-dev
 
 # 8. 포트 노출 및 실행


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #

**🛠 작업 내역**
DB 초기화 자동화: 인프라 기동 후 mcp_dev DB와 Vector 확장을 자동 생성하도록 배포 흐름을 개선하고, 서버 실행 시 SQLAlchemy create_all()을 통해 테이블 스키마가 자동 생성되도록 수정했습니다.

모니터링 스택 정규화: micrometer-registry-prometheus 의존성을 추가하여 404 에러를 해결하고, 불필요한 OTLP 메트릭 내보내기(push) 기능을 비활성화하여 연결 에러를 차단했습니다.

인증 및 환경 설정 점검: 스팬 전송 시 발생하는 401 에러의 원인인 LANGFUSE_AUTH_PROD를 추가


-

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?