### PR TITLE
perf : 채팅 응답 지연 개선 (트랜잭션 경계 축소 + baseline 비동기화)

### DIFF
--- a/back/src/main/java/com/back/BackApplication.java
+++ b/back/src/main/java/com/back/BackApplication.java
@@ -2,8 +2,10 @@ package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class BackApplication {
 
     public static void main(String[] args) {

--- a/back/src/main/java/com/back/domain/adapter/in/event/BaselineInitializationListener.java
+++ b/back/src/main/java/com/back/domain/adapter/in/event/BaselineInitializationListener.java
@@ -1,0 +1,38 @@
+package com.back.domain.adapter.in.event;
+
+import com.back.domain.application.event.BaselineInitializationRequested;
+import com.back.domain.application.port.out.RunSubscriptionExecutionPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 구독 확정 트랜잭션 커밋 후 baseline 수집을 비동기로 실행한다.
+ *
+ * HTTP 응답은 즉시 반환되고, 첫 baseline 수집은 가상 스레드에서 백그라운드로 처리된다.
+ * 실패해도 cron 기반 정기 실행이 다음 회차에서 재시도하므로 사용자 흐름을 막지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BaselineInitializationListener {
+
+    private final RunSubscriptionExecutionPort runSubscriptionExecutionPort;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onBaselineInitializationRequested(BaselineInitializationRequested event) {
+        String subscriptionId = event.context().subscriptionId();
+        log.info("[BaselineInitializationListener] baseline 비동기 수집 시작 - subscriptionId={}", subscriptionId);
+        try {
+            runSubscriptionExecutionPort.execute(event.context());
+            log.info("[BaselineInitializationListener] baseline 수집 완료 - subscriptionId={}", subscriptionId);
+        } catch (RuntimeException e) {
+            // baseline 수집은 cron이 이후 회차에서 다시 시도하므로 사용자 흐름을 막지 않는다.
+            log.warn("[BaselineInitializationListener] baseline 수집 실패 - subscriptionId={}", subscriptionId, e);
+        }
+    }
+}

--- a/back/src/main/java/com/back/domain/application/event/BaselineInitializationRequested.java
+++ b/back/src/main/java/com/back/domain/application/event/BaselineInitializationRequested.java
@@ -1,0 +1,13 @@
+package com.back.domain.application.event;
+
+import com.back.domain.application.service.SubscriptionContext;
+
+/**
+ * 구독 확정 직후 baseline 수집을 비동기로 실행하라는 신호.
+ * {@code SubscriptionConversationService.confirm()} 트랜잭션 커밋 후 listener가
+ * {@code runSubscriptionExecutionPort.execute()}를 가상 스레드로 호출한다.
+ *
+ * LLM/MCP 다단계 호출을 HTTP 응답 경로에서 분리하기 위한 도메인 이벤트.
+ */
+public record BaselineInitializationRequested(SubscriptionContext context) {
+}

--- a/back/src/main/java/com/back/domain/application/service/ParseTaskService.java
+++ b/back/src/main/java/com/back/domain/application/service/ParseTaskService.java
@@ -20,16 +20,17 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * [Domain Service] 자연어 파싱 유스케이스 구현
  * 사용자의 자연어 입력을 AI로 파싱하고 멀티턴 대화를 관리합니다.
+ *
+ * 트랜잭션 정책: Vertex AI 호출을 DB 트랜잭션에 묶지 않기 위해 클래스 레벨 @Transactional을 두지 않는다.
+ * 세션 저장은 Spring Data JPA repository의 자체 트랜잭션으로 처리된다.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ParseTaskService implements ParseTaskUseCase {
 
     private final ParseNaturalLanguagePort parseNaturalLanguagePort;

--- a/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
+++ b/back/src/main/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationService.java
@@ -15,7 +15,7 @@ import com.back.domain.application.port.out.FetchInfoDataPort;
 import com.back.domain.application.port.out.LoadDomainPort;
 import com.back.domain.application.port.out.LoadMcpToolPort;
 import com.back.domain.application.port.out.LoadNotificationEndpointPort;
-import com.back.domain.application.port.out.RunSubscriptionExecutionPort;
+import com.back.domain.application.event.BaselineInitializationRequested;
 import com.back.domain.application.result.ParseResult;
 import com.back.domain.application.result.ParsedTask;
 import com.back.domain.application.result.SubscriptionResult;
@@ -44,13 +44,19 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 채팅 응답 경로의 트랜잭션 정책
+ * 클래스 레벨 @Transactional은 의도적으로 두지 않는다.
+ * LLM/MCP 호출이 DB 트랜잭션 내부에서 실행되면 커넥션 풀 장기 점유 + 응답 지연 누적이 발생하기 때문
+ * 다건 DB 쓰기가 원자적이어야 하는 메서드에만 메서드 단위로 @Transactional을 부착한다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class SubscriptionConversationService {
 
     private static final Pattern EMAIL = Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$");
@@ -76,7 +82,7 @@ public class SubscriptionConversationService {
     private final SubscriptionConversationJpaRepository conversationRepository;
     private final SubscriptionMonitoringConfigJpaRepository monitoringConfigRepository;
     private final ObjectMapper objectMapper;
-    private final RunSubscriptionExecutionPort runSubscriptionExecutionPort;
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final FetchInfoDataPort fetchInfoDataPort;
 
     public Response handle(Long userId, String conversationId, String message, ActionRequest action) {
@@ -332,7 +338,8 @@ public class SubscriptionConversationService {
                 ));
     }
 
-    private Response confirm(Long userId, SubscriptionConversationJpaEntity conversation) {
+    @Transactional
+    public Response confirm(Long userId, SubscriptionConversationJpaEntity conversation) {
         if (conversation.getStatus() != SubscriptionConversationStatus.READY_FOR_CONFIRMATION) {
             throw new ApiException(ErrorCode.INVALID_REQUEST);
         }
@@ -380,7 +387,13 @@ public class SubscriptionConversationService {
                 conversation.getDraftIntent(),
                 conversation.getDraftMonitoringParams()
         ));
-        initializeBaseline(userId, conversation, result);
+
+        // baseline 수집은 LLM + MCP 다단계 호출이라 HTTP 응답 경로에서 분리한다.
+        // AFTER_COMMIT 단계의 @Async 리스너가 가상 스레드로 처리한다. 실패 시 cron이 다음 회차에서 재시도.
+        applicationEventPublisher.publishEvent(
+                new BaselineInitializationRequested(buildBaselineContext(userId, conversation, result))
+        );
+
         conversation.updateStatus(SubscriptionConversationStatus.CREATED, "알림을 시작했어요.");
         conversationRepository.save(conversation);
 
@@ -394,13 +407,12 @@ public class SubscriptionConversationService {
         );
     }
 
-    private void initializeBaseline(
+    private SubscriptionContext buildBaselineContext(
             Long userId,
             SubscriptionConversationJpaEntity conversation,
             SubscriptionResult result
     ) {
-        // 구독 확정 응답은 첫 baseline 수집까지 성공해야 실제로 감시가 시작됐다고 본다.
-        runSubscriptionExecutionPort.execute(new SubscriptionContext(
+        return new SubscriptionContext(
                 result.id(),
                 conversation.getDraftDomainName(),
                 result.query(),
@@ -409,7 +421,7 @@ public class SubscriptionConversationService {
                         ? conversation.getDraftNotificationChannel().name()
                         : null,
                 notificationTarget(userId, conversation)
-        ));
+        );
     }
 
     private Map<String, Object> baselineParams(SubscriptionConversationJpaEntity conversation) {

--- a/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
+++ b/back/src/test/java/com/back/domain/application/service/subscriptionconversation/SubscriptionConversationServiceTest.java
@@ -1,7 +1,6 @@
 package com.back.domain.application.service.subscriptionconversation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -17,6 +16,7 @@ import com.back.domain.application.command.CreateSubscriptionCommand;
 import com.back.domain.application.command.GrantTokenCommand;
 import com.back.domain.application.command.ParseTaskCommand;
 import com.back.domain.application.command.UseTokenCommand;
+import com.back.domain.application.event.BaselineInitializationRequested;
 import com.back.domain.application.port.in.CreateSubscriptionUseCase;
 import com.back.domain.application.port.in.ParseTaskUseCase;
 import com.back.domain.application.port.in.TokenManagementUseCase;
@@ -24,7 +24,6 @@ import com.back.domain.application.port.out.LoadDomainPort;
 import com.back.domain.application.port.out.LoadMcpToolPort;
 import com.back.domain.application.port.out.LoadNotificationEndpointPort;
 import com.back.domain.application.port.out.NormalizeSubscriptionDraftPort;
-import com.back.domain.application.port.out.RunSubscriptionExecutionPort;
 import com.back.domain.application.result.ParseResult;
 import com.back.domain.application.result.ParsedTask;
 import com.back.domain.application.result.SubscriptionResult;
@@ -48,6 +47,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 
 @DisplayName("Application: 구독 대화 서비스 테스트")
 class SubscriptionConversationServiceTest {
@@ -61,8 +61,8 @@ class SubscriptionConversationServiceTest {
     private final LoadDomainPort loadDomainPort = new FakeLoadDomainPort();
     private final LoadNotificationEndpointPort loadNotificationEndpointPort =
             (userId, channel) -> Optional.empty();
-    private final FakeRunSubscriptionExecutionPort runSubscriptionExecutionPort =
-            new FakeRunSubscriptionExecutionPort();
+    private final RecordingApplicationEventPublisher applicationEventPublisher =
+            new RecordingApplicationEventPublisher();
 
     @Test
     @DisplayName("새 메시지는 인증 사용자 id로 파싱하고 누락된 채널을 질문한다")
@@ -1636,8 +1636,10 @@ class SubscriptionConversationServiceTest {
                 ArgumentCaptor.forClass(SubscriptionMonitoringConfigJpaEntity.class);
         verify(monitoringConfigRepository).save(captor.capture());
         assertThat(captor.getValue().getToolName()).isEqualTo("search_house_price");
-        assertThat(runSubscriptionExecutionPort.contexts).hasSize(1);
-        SubscriptionContext baselineContext = runSubscriptionExecutionPort.contexts.getFirst();
+        List<BaselineInitializationRequested> baselineEvents =
+                applicationEventPublisher.eventsOfType(BaselineInitializationRequested.class);
+        assertThat(baselineEvents).hasSize(1);
+        SubscriptionContext baselineContext = baselineEvents.getFirst().context();
         assertThat(baselineContext.subscriptionId()).isEqualTo("sub-1");
         assertThat(baselineContext.domain()).isEqualTo("real-estate");
         assertThat(baselineContext.params())
@@ -1649,8 +1651,8 @@ class SubscriptionConversationServiceTest {
     }
 
     @Test
-    @DisplayName("baseline 초기화가 실패하면 구독 확정 성공으로 응답하지 않는다")
-    void confirmDoesNotReportCreatedWhenBaselineInitializationFails() {
+    @DisplayName("baseline 초기화는 비동기 이벤트로 발행되어 confirm 응답을 지연시키지 않는다")
+    void confirmPublishesBaselineEventAndReturnsImmediately() {
         SubscriptionConversationJpaEntity readyConversation = new SubscriptionConversationJpaEntity(1L);
         readyConversation.updateParsedDraft(
                 "parse-1",
@@ -1684,19 +1686,22 @@ class SubscriptionConversationServiceTest {
         LoadNotificationEndpointPort connectedDiscord = (userId, channel) -> channel == NotificationChannel.DISCORD_DM
                 ? Optional.of(new NotificationEndpoint("endpoint-1", userId, channel, "discord-user-1", true))
                 : Optional.empty();
-        runSubscriptionExecutionPort.failure = new RuntimeException("baseline failed");
         SubscriptionConversationService service = service(connectedDiscord);
 
-        assertThatThrownBy(() -> service.handle(
-                        1L,
-                        readyConversation.getId(),
-                        null,
-                        new SubscriptionConversationService.ActionRequest("CONFIRM_SUBSCRIPTION", "confirm")
-                ))
-                .isSameAs(runSubscriptionExecutionPort.failure);
+        // baseline 수집은 AFTER_COMMIT 리스너가 가상 스레드로 처리하므로
+        // confirm()은 baseline 결과와 무관하게 즉시 응답한다 (실패해도 cron이 다음 회차에서 재시도).
+        SubscriptionConversationService.Response response = service.handle(
+                1L,
+                readyConversation.getId(),
+                null,
+                new SubscriptionConversationService.ActionRequest("CONFIRM_SUBSCRIPTION", "confirm")
+        );
 
-        assertThat(readyConversation.getStatus()).isEqualTo(SubscriptionConversationStatus.READY_FOR_CONFIRMATION);
+        assertThat(response.status()).isEqualTo("CREATED");
+        assertThat(readyConversation.getStatus()).isEqualTo(SubscriptionConversationStatus.CREATED);
         verify(monitoringConfigRepository).save(any());
+        assertThat(applicationEventPublisher.eventsOfType(BaselineInitializationRequested.class))
+                .hasSize(1);
     }
 
     @Test
@@ -1848,7 +1853,7 @@ class SubscriptionConversationServiceTest {
                 conversationRepository,
                 monitoringConfigRepository,
                 new ObjectMapper(),
-                runSubscriptionExecutionPort,
+                applicationEventPublisher,
                 (domainName, query) -> Optional.empty()
         );
     }
@@ -2139,17 +2144,19 @@ class SubscriptionConversationServiceTest {
         }
     }
 
-    private static class FakeRunSubscriptionExecutionPort implements RunSubscriptionExecutionPort {
-        private final List<SubscriptionContext> contexts = new ArrayList<>();
-        private RuntimeException failure;
+    private static class RecordingApplicationEventPublisher implements ApplicationEventPublisher {
+        private final List<Object> events = new ArrayList<>();
 
         @Override
-        public void execute(SubscriptionContext subscription) {
-            contexts.clear();
-            contexts.add(subscription);
-            if (failure != null) {
-                throw failure;
-            }
+        public void publishEvent(Object event) {
+            events.add(event);
+        }
+
+        <T> List<T> eventsOfType(Class<T> type) {
+            return events.stream()
+                    .filter(type::isInstance)
+                    .map(type::cast)
+                    .toList();
         }
     }
 


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #163 

**🛠 작업 내역**
채팅 응답 흐름에서 다음 두 가지 병목이 확인됨

원인:
1. SubscriptionConversationService 클래스 레벨 @Transactional - 모든 LLM/MCP 호출이 DB 트랜잭션 내부에서 실행되어 커넥션 풀 장기 점유 + 응답 지연 누적
2. confirm() → initializeBaseline() 동기 대기 - 알림 시작 클릭 시 첫 baseline 수집이 끝날 때까지 HTTP 응답 보류
3. ParseTaskService 클래스 레벨 @Transactional - 자연어 파싱 Vertex AI 호출이 트랜잭션 내에서 실행

작업 요약:
- 사용자가 채팅 메시지 입력 / 알림 시작 클릭 시 응답까지 오래 걸리던 지연을 해소
- LLM/MCP 호출이 DB 트랜잭션 내부에서 실행되던 구조를 트랜잭션 외부로 분리
- baseline 첫 수집을 @TransactionalEventListener(AFTER_COMMIT) + @Async 가상 스레드로 비동기화

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?