### PR TITLE
Fix: 부동산 info intent 자연어 조회가 결과 없이 LLM 안내문만 노출되는 결함 수정

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/persistence/mcp/FetchInfoDataAdapter.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/mcp/FetchInfoDataAdapter.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -258,8 +259,44 @@ public class FetchInfoDataAdapter implements FetchInfoDataPort {
     }
 
     private String extractRegion(String query) {
+        // 입력 예: "성남시 분당구 아파트 매매 …" → "성남시 분당구" (행정구 포함 다중 토큰)
+        // REGION 정규식은 "OO시/군/구" 단일 토큰만 잡으므로 모든 매치를 모은 뒤
+        // 공백으로만 인접한 매치들을 하나의 region 묶음으로 결합해 최장 묶음을 반환한다.
+        if (query == null || query.isBlank()) {
+            return null;
+        }
         Matcher matcher = REGION.matcher(query);
-        return matcher.find() ? matcher.group(1) : null;
+        List<int[]> matches = new ArrayList<>();
+        while (matcher.find()) {
+            matches.add(new int[]{matcher.start(), matcher.end()});
+        }
+        if (matches.isEmpty()) {
+            return null;
+        }
+        int bestStart = matches.get(0)[0];
+        int bestEnd = matches.get(0)[1];
+        int bestCount = 1;
+        int curStart = bestStart;
+        int curEnd = bestEnd;
+        int curCount = 1;
+        for (int i = 1; i < matches.size(); i++) {
+            int s = matches.get(i)[0];
+            int e = matches.get(i)[1];
+            if (query.substring(curEnd, s).chars().allMatch(Character::isWhitespace)) {
+                curEnd = e;
+                curCount++;
+            } else {
+                curStart = s;
+                curEnd = e;
+                curCount = 1;
+            }
+            if (curCount > bestCount) {
+                bestStart = curStart;
+                bestEnd = curEnd;
+                bestCount = curCount;
+            }
+        }
+        return query.substring(bestStart, bestEnd).replaceAll("\\s+", " ").strip();
     }
 
     private boolean isMolitTool(String toolName) {

--- a/back/src/main/java/com/back/domain/adapter/out/persistence/mcp/McpToolJpaRepository.java
+++ b/back/src/main/java/com/back/domain/adapter/out/persistence/mcp/McpToolJpaRepository.java
@@ -1,14 +1,21 @@
 package com.back.domain.adapter.out.persistence.mcp;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 /**
  * [Persistence Adapter의 도구] MCP 도구(Tool) 정보를 관리하는 JPA 레포지토리
  * 특정 도메인에 종속된 AI 도구의 이름, 설명, 입력 스키마(JSON Schema) 등을 DB에서 조회
+ *
+ * server/domain 연관은 LAZY 인데 어댑터 호출 측이 트랜잭션 밖이라 toDomain() 변환 중
+ * 프록시 초기화가 LazyInitializationException 으로 깨진다. 두 쿼리 모두 @EntityGraph 로
+ * server·domain 을 즉시 함께 로딩한다.
  */
 public interface McpToolJpaRepository extends JpaRepository<McpToolJpaEntity, Long> {
+    @EntityGraph(attributePaths = {"server", "domain"})
     Optional<McpToolJpaEntity> findFirstByDomainId(Long domainId);
 
+    @EntityGraph(attributePaths = {"server", "domain"})
     Optional<McpToolJpaEntity> findFirstByDomainIdAndName(Long domainId, String name);
 }

--- a/back/src/main/java/com/back/domain/application/service/ScheduleExecutionService.java
+++ b/back/src/main/java/com/back/domain/application/service/ScheduleExecutionService.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -424,8 +425,44 @@ public class ScheduleExecutionService implements RunDueSchedulesUseCase {
     }
 
     private String extractRegion(String query) {
-        Matcher matcher = REGION.matcher(query == null ? "" : query);
-        return matcher.find() ? matcher.group(1) : null;
+        // 입력 예: "성남시 분당구 아파트 매매 …" → "성남시 분당구" (행정구 포함 다중 토큰)
+        // REGION 정규식은 "OO시/군/구" 단일 토큰만 잡으므로 모든 매치를 모은 뒤
+        // 공백으로만 인접한 매치들을 하나의 region 묶음으로 결합해 최장 묶음을 반환한다.
+        if (query == null || query.isBlank()) {
+            return null;
+        }
+        Matcher matcher = REGION.matcher(query);
+        List<int[]> matches = new ArrayList<>();
+        while (matcher.find()) {
+            matches.add(new int[]{matcher.start(), matcher.end()});
+        }
+        if (matches.isEmpty()) {
+            return null;
+        }
+        int bestStart = matches.get(0)[0];
+        int bestEnd = matches.get(0)[1];
+        int bestCount = 1;
+        int curStart = bestStart;
+        int curEnd = bestEnd;
+        int curCount = 1;
+        for (int i = 1; i < matches.size(); i++) {
+            int s = matches.get(i)[0];
+            int e = matches.get(i)[1];
+            if (query.substring(curEnd, s).chars().allMatch(Character::isWhitespace)) {
+                curEnd = e;
+                curCount++;
+            } else {
+                curStart = s;
+                curEnd = e;
+                curCount = 1;
+            }
+            if (curCount > bestCount) {
+                bestStart = curStart;
+                bestEnd = curEnd;
+                bestCount = curCount;
+            }
+        }
+        return query.substring(bestStart, bestEnd).replaceAll("\\s+", " ").strip();
     }
 
     private String notificationChannel(String subscriptionId) {

--- a/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
+++ b/back/src/main/java/com/back/domain/application/service/SubscriptionMonitorService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,8 +175,44 @@ public class SubscriptionMonitorService implements RunSubscriptionMonitorUseCase
     }
 
     private String extractRegion(String query) {
-        Matcher matcher = REGION.matcher(query == null ? "" : query);
-        return matcher.find() ? matcher.group(1) : null;
+        // 입력 예: "성남시 분당구 아파트 매매 …" → "성남시 분당구" (행정구 포함 다중 토큰)
+        // REGION 정규식은 "OO시/군/구" 단일 토큰만 잡으므로 모든 매치를 모은 뒤
+        // 공백으로만 인접한 매치들을 하나의 region 묶음으로 결합해 최장 묶음을 반환한다.
+        if (query == null || query.isBlank()) {
+            return null;
+        }
+        Matcher matcher = REGION.matcher(query);
+        List<int[]> matches = new ArrayList<>();
+        while (matcher.find()) {
+            matches.add(new int[]{matcher.start(), matcher.end()});
+        }
+        if (matches.isEmpty()) {
+            return null;
+        }
+        int bestStart = matches.get(0)[0];
+        int bestEnd = matches.get(0)[1];
+        int bestCount = 1;
+        int curStart = bestStart;
+        int curEnd = bestEnd;
+        int curCount = 1;
+        for (int i = 1; i < matches.size(); i++) {
+            int s = matches.get(i)[0];
+            int e = matches.get(i)[1];
+            if (query.substring(curEnd, s).chars().allMatch(Character::isWhitespace)) {
+                curEnd = e;
+                curCount++;
+            } else {
+                curStart = s;
+                curEnd = e;
+                curCount = 1;
+            }
+            if (curCount > bestCount) {
+                bestStart = curStart;
+                bestEnd = curEnd;
+                bestCount = curCount;
+            }
+        }
+        return query.substring(bestStart, bestEnd).replaceAll("\\s+", " ").strip();
     }
 
     private NotificationChannel notificationChannel(String subscriptionId) {

--- a/mcp-server/src/mcp_server/domains/real_estate/region.py
+++ b/mcp-server/src/mcp_server/domains/real_estate/region.py
@@ -111,7 +111,7 @@ def resolve_lawd_cd(query: str) -> str:
                 candidates=_candidates_label(same_sido),
             )
 
-    # (3) 시군구 단독
+    # (3) 시군구 단독 — 정확 일치
     matches = [r for r in rows if r["sigungu"] == normalized]
     if len(matches) == 1:
         return matches[0]["code"]
@@ -119,6 +119,19 @@ def resolve_lawd_cd(query: str) -> str:
         raise RealEstateRegionNotFoundError(
             f"'{normalized}' 동음이의: 시도와 함께 다시 입력하세요 (예: '서울 {normalized}')",
             candidates=_candidates_label(matches),
+        )
+
+    # (3-b) 행정구 endswith 폴백 — 데이터의 sigungu 는 "성남시 분당구" 처럼 한 문자열로
+    # 저장되어 있어 "분당구" 단독 입력은 (3) 의 정확 일치로 잡히지 않는다. 행정구 단독
+    # 입력을 자주 쓰므로 끝일치(공백 경계) 로 후보를 모은다. 1건이면 채택, 2건+ 이면
+    # 동음이의로 후보 안내.
+    tail_matches = [r for r in rows if r["sigungu"].endswith(" " + normalized)]
+    if len(tail_matches) == 1:
+        return tail_matches[0]["code"]
+    if len(tail_matches) > 1:
+        raise RealEstateRegionNotFoundError(
+            f"'{normalized}' 동음이의: 시·도와 함께 다시 입력하세요",
+            candidates=_candidates_label(tail_matches),
         )
 
     raise RealEstateRegionNotFoundError(

--- a/mcp-server/tests/domains/real_estate/test_region.py
+++ b/mcp-server/tests/domains/real_estate/test_region.py
@@ -70,3 +70,19 @@ def test_resolve_raises_when_no_match_at_all():
 def test_resolve_raises_for_empty_input():
     with pytest.raises(RealEstateRegionNotFoundError):
         resolve_lawd_cd("   ")
+
+
+def test_resolve_endswith_fallback_for_administrative_district():
+    """행정구 단독 입력은 '시 행정구' 형태로 저장된 sigungu 에 endswith 매칭."""
+    # 성남시 분당구 → 41135
+    assert resolve_lawd_cd("분당구") == "41135"
+    # 수원시 영통구 → 41117
+    assert resolve_lawd_cd("영통구") == "41117"
+    # 안양시 동안구 → 41173
+    assert resolve_lawd_cd("동안구") == "41173"
+
+
+def test_resolve_exact_match_takes_precedence_over_endswith():
+    """동일 sigungu 가 정확 일치로 잡히면 endswith 폴백을 거치지 않는다.
+    '강남구' 는 '서울특별시 강남구' 의 sigungu 가 '강남구' 단독이므로 (3) 에서 매칭."""
+    assert resolve_lawd_cd("강남구") == "11680"


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #177 

**🛠 작업 내역**
## 증상

```
입력:   "현재 성남시 분당구 아파트 매매 실거래가 조회해줘"
응답:   "부동산 시세에 관심이 있으시군요! 가격 변동을 알림으로 받아보시겠어요?
           '성남시 분당구 아파트 매매 시세 바뀌면 알려줘'라고 말씀하시면 …"
```
→ 실거래 통계가 와야 하는데 LLM 안내문이 그대로 노출.

## 원인 

### 1. 메인 서버 `extractRegion` 이 leftmost 단일 토큰만 추출
`FetchInfoDataAdapter` / `SubscriptionMonitorService` / `ScheduleExecutionService` 세 곳에 중복된 동일 정규식 + `Matcher.find()` 단일 호출 → `"성남시 분당구 …"` 에서 `"성남시"` 만 잡혀 MCP 로 전달.

### 2. MCP `resolve_lawd_cd` 의 "시군구 단독" 정확 일치 한계
`lawd_codes.json` 은 행정구 포함 시군구를 `"성남시 분당구"` 처럼 한 문자열로 저장. (1) 이 고쳐져도 `"분당구"` 단독 입력은 `== "분당구"` 매칭 실패 → `RealEstateRegionNotFoundError`.

### 3. `McpToolPersistenceAdapter` 의 LazyInitializationException - 사용자 가시 결함의 직접 원인
`McpToolJpaEntity.server` / `domain` 이 `FetchType.LAZY`. `loadByDomainIdAndName` 이 Repository 자동 트랜잭션 밖에서 `.map(McpToolJpaEntity::toDomain)` 을 실행하면서 `server.toDomain()` 프록시
  초기화가 `no session` 으로 깨짐. `FetchInfoDataAdapter` 의 `catch(Exception)` 가 예외를 삼키고 `Optional.empty()` 반환 → `infoMessage` 가 LLM 의 `confirmationQuestion` 그대로 노출

## 변경 사항

### 메인 서버 (Java)
- **`extractRegion` 3곳 다중 매치 결합 로직으로 교체**
`REGION` 정규식은 그대로 둔 채 `find()` 반복으로 모든 매치를 수집하고, 사이가 공백뿐인 인접 매치를 한 묶음으로 결합한 뒤 최장 묶음을 반환.
  - `"성남시 분당구 …"` → `"성남시 분당구"`
  - `"서울 강남구 …"` → `"서울 강남구"`
  - `"강남구 …"` → `"강남구"` (단일 그대로)
- **`McpToolJpaRepository` 의 두 finder 에 `@EntityGraph(attributePaths = {"server", "domain"})` 부착**. server·domain 을 즉시 함께 로딩해 LazyInit 제거. `findFirst…` 의 LIMIT 동작은 그대로 유지.

### MCP 서버 (Python)
- **`resolve_lawd_cd` 의 "시군구 단독" 분기 뒤에 endswith 폴백 추가**. `r["sigungu"].endswith(" " + normalized)` 결과 단일이면 채택, 복수면 동음이의 후보 안내(기존 패턴 유지). `"분당구"` 단독 입력으로도 `"성남시 분당구"` 매칭 가능.

### 테스트 (Python)
- `tests/domains/real_estate/test_region.py` 에 신규 케이스 2개 추가
  - 행정구 단독 매칭 (`"분당구"` / `"영통구"` / `"동안구"`)
  - 정확 일치가 endswith 폴백보다 우선

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?