### PR TITLE
FIX : 채용 브리핑 MCP 응답 래퍼 파싱 및 source 보강

### DIFF
--- a/back/src/main/java/com/back/domain/adapter/out/ai/NotificationBriefingPayloadFactory.java
+++ b/back/src/main/java/com/back/domain/adapter/out/ai/NotificationBriefingPayloadFactory.java
@@ -42,7 +42,7 @@ final class NotificationBriefingPayloadFactory {
             ObjectNode metadata = objectNode(request, "metadata", objectMapper);
             metadata.put("briefingContractVersion", BRIEFING_CONTRACT_VERSION);
             ObjectNode briefing = compare.get().isRecruitment()
-                    ? recruitmentBriefing(request, compare.get(), objectMapper)
+                    ? recruitmentBriefing(request, compare.get(), data, objectMapper)
                     : realEstateBriefing(request, compare.get(), data, objectMapper);
             metadata.set("briefing", briefing);
             request.set("metadata", metadata);
@@ -102,7 +102,9 @@ final class NotificationBriefingPayloadFactory {
             return Optional.of(new DataEvidence(
                     text(node.path("query"), "region"),
                     text(node.path("query"), "deal_ymd", "dealYmd", "dealPeriod"),
-                    toolNameFromOutput(node, execution.toolName())
+                    toolNameFromOutput(node, execution.toolName()),
+                    // 채용 공고별 URL이 비어도 MCP 도구의 공식 source_url을 provider 검증용 근거로 쓴다.
+                    sourceUrl(execution.output(), objectMapper)
             ));
         }
         return Optional.empty();
@@ -193,9 +195,14 @@ final class NotificationBriefingPayloadFactory {
     private static ObjectNode recruitmentBriefing(
             ObjectNode request,
             CompareEvidence compare,
+            DataEvidence data,
             ObjectMapper objectMapper
     ) {
         ArrayNode sources = recruitmentSources(compare.structured(), objectMapper);
+        // 채용 renderer는 최소 1개 URL을 요구하므로 공고 URL이 없을 때 데이터 도구 URL로 보강한다.
+        if (sources.isEmpty() && !blank(data.sourceUrl())) {
+            addRecruitmentFallbackSource(sources, data, objectMapper);
+        }
         String keyword = firstNonBlank(
                 text(compare.inputParams(), "keyword", "recrut_pbanc_ttl"),
                 text(request.path("metadata").path("briefing").path("watchInfo"), "keyword")
@@ -310,8 +317,20 @@ final class NotificationBriefingPayloadFactory {
         }
     }
 
+    private static void addRecruitmentFallbackSource(
+            ArrayNode sources,
+            DataEvidence data,
+            ObjectMapper objectMapper
+    ) {
+        ObjectNode source = objectMapper.createObjectNode();
+        source.put("label", recruitmentFallbackSourceLabel(data.toolName()));
+        source.put("url", data.sourceUrl());
+        sources.add(source);
+    }
+
     private static Optional<JsonNode> structuredNode(String content, ObjectMapper objectMapper) {
-        return readJson(content, objectMapper).flatMap(NotificationBriefingPayloadFactory::findStructuredNode);
+        return readJson(content, objectMapper)
+                .flatMap(node -> findStructuredNode(node, objectMapper));
     }
 
     private static Optional<JsonNode> toolPayloadNode(String content, ObjectMapper objectMapper) {
@@ -330,7 +349,7 @@ final class NotificationBriefingPayloadFactory {
         }
     }
 
-    private static Optional<JsonNode> findStructuredNode(JsonNode node) {
+    private static Optional<JsonNode> findStructuredNode(JsonNode node, ObjectMapper objectMapper) {
         if (node == null || node.isNull()) {
             return Optional.empty();
         }
@@ -339,23 +358,78 @@ final class NotificationBriefingPayloadFactory {
             if (structured != null && structured.isObject()) {
                 return Optional.of(structured);
             }
+            // Spring AI MCP 응답은 [{"text":"{...}"}]처럼 실제 JSON이 text 안에 한 번 더 들어올 수 있다.
+            JsonNode textNode = node.get("text");
+            if (textNode != null && textNode.isTextual()) {
+                Optional<JsonNode> nested = readJson(textNode.asText(), objectMapper);
+                if (nested.isPresent()) {
+                    Optional<JsonNode> nestedStructured = findStructuredNode(nested.get(), objectMapper);
+                    if (nestedStructured.isPresent()) {
+                        return nestedStructured;
+                    }
+                }
+            }
             if (node.has("baseline_initialized") || node.has("condition_satisfied")) {
                 return Optional.of(node);
             }
             Iterator<JsonNode> elements = node.elements();
             Iterable<JsonNode> iterable = () -> elements;
             return StreamSupport.stream(iterable.spliterator(), false)
-                    .map(NotificationBriefingPayloadFactory::findStructuredNode)
+                    .map(child -> findStructuredNode(child, objectMapper))
                     .flatMap(Optional::stream)
                     .findFirst();
         }
         if (node.isArray()) {
             return StreamSupport.stream(node.spliterator(), false)
-                    .map(NotificationBriefingPayloadFactory::findStructuredNode)
+                    .map(child -> findStructuredNode(child, objectMapper))
                     .flatMap(Optional::stream)
                     .findFirst();
         }
         return Optional.empty();
+    }
+
+    private static String sourceUrl(String content, ObjectMapper objectMapper) {
+        return readJson(content, objectMapper)
+                .map(node -> findText(node, objectMapper, "source_url", "sourceUrl"))
+                .orElse(null);
+    }
+
+    // source_url도 structured와 동일하게 MCP text wrapper 안에 숨을 수 있어 재귀적으로 찾는다.
+    private static String findText(JsonNode node, ObjectMapper objectMapper, String... names) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.isObject()) {
+            String value = text(node, names);
+            if (!blank(value)) {
+                return value;
+            }
+            JsonNode textNode = node.get("text");
+            if (textNode != null && textNode.isTextual()) {
+                Optional<JsonNode> nested = readJson(textNode.asText(), objectMapper);
+                if (nested.isPresent()) {
+                    String nestedValue = findText(nested.get(), objectMapper, names);
+                    if (!blank(nestedValue)) {
+                        return nestedValue;
+                    }
+                }
+            }
+            Iterator<JsonNode> elements = node.elements();
+            Iterable<JsonNode> iterable = () -> elements;
+            return StreamSupport.stream(iterable.spliterator(), false)
+                    .map(child -> findText(child, objectMapper, names))
+                    .filter(valueCandidate -> !blank(valueCandidate))
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (node.isArray()) {
+            return StreamSupport.stream(node.spliterator(), false)
+                    .map(child -> findText(child, objectMapper, names))
+                    .filter(value -> !blank(value))
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
     }
 
     private static ObjectNode objectNode(ObjectNode parent, String field, ObjectMapper objectMapper) {
@@ -427,6 +501,13 @@ final class NotificationBriefingPayloadFactory {
             }
         }
         return hasWorknet ? "공공채용, 워크넷" : "공공채용";
+    }
+
+    private static String recruitmentFallbackSourceLabel(String toolName) {
+        if ("search_worknet_job".equals(toolName)) {
+            return "워크넷 채용정보";
+        }
+        return "공공채용";
     }
 
     private static String recruitmentSummary(JsonNode structured, String keyword) {
@@ -529,6 +610,8 @@ final class NotificationBriefingPayloadFactory {
                 || name.contains("search_offi_rent")
                 || name.contains("search_rh_trade")
                 || name.contains("search_rh_rent")
+                || name.contains("search_public_job")
+                || name.contains("search_worknet_job")
                 || name.contains("get_cached_data");
     }
 
@@ -634,10 +717,10 @@ final class NotificationBriefingPayloadFactory {
         }
     }
 
-    private record DataEvidence(String region, String dealPeriod, String toolName) {
+    private record DataEvidence(String region, String dealPeriod, String toolName, String sourceUrl) {
 
         static DataEvidence empty() {
-            return new DataEvidence(null, null, null);
+            return new DataEvidence(null, null, null, null);
         }
     }
 }

--- a/back/src/test/java/com/back/domain/adapter/out/ai/NotificationBriefingPayloadFactoryTest.java
+++ b/back/src/test/java/com/back/domain/adapter/out/ai/NotificationBriefingPayloadFactoryTest.java
@@ -6,6 +6,7 @@ import com.back.domain.adapter.out.ai.McpToolExecutionRecorder.Execution;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -138,5 +139,143 @@ class NotificationBriefingPayloadFactoryTest {
                 && change.has("current")).isTrue());
         assertThat(briefing.path("sources").get(0).path("label").asText()).isEqualTo("국토연구원 전산직 채용");
         assertThat(briefing.path("sources").get(0).path("url").asText()).isEqualTo("https://example.com/jobs/new");
+    }
+
+    @Test
+    @DisplayName("채용 compare 결과가 MCP text wrapper로 감싸져도 source와 change를 보강한다")
+    void enrichesRecruitmentSendNotificationInputFromMcpTextWrapper() throws Exception {
+        String rawInput = """
+                {
+                  "input": {
+                    "subscriptionId": "sub-job-wrapper",
+                    "notificationChannel": "EMAIL",
+                    "notificationTarget": "user@example.com",
+                    "title": "공공기관 채용 새 공고",
+                    "message": "새로운 채용 공고가 감지되었습니다.",
+                    "metadata": {
+                      "briefingContractVersion": "channel-v1",
+                      "briefing": {
+                        "domain": "recruitment",
+                        "title": "공공기관 채용 새 공고",
+                        "summary": "AI가 만든 요약입니다.",
+                        "changes": [
+                          {"label": "AI 누락 change", "value": "2건"}
+                        ],
+                        "sources": [],
+                        "interpretation": "마감일과 지원 자격을 확인하세요."
+                      }
+                    }
+                  }
+                }
+                """;
+        String comparePayload = """
+                {
+                  "structured": {
+                    "baseline_initialized": false,
+                    "changed": true,
+                    "subscriptionId": "sub-job-wrapper",
+                    "domain": "recruitment",
+                    "baseline_summary": {
+                      "count": 3,
+                      "ongoing_count": 2,
+                      "posting_ids": ["public_job:old"],
+                      "ongoing_posting_ids": ["public_job:old"]
+                    },
+                    "current_summary": {
+                      "count": 5,
+                      "ongoing_count": 4,
+                      "posting_ids": ["public_job:old", "public_job:new-1", "public_job:new-2"],
+                      "ongoing_posting_ids": ["public_job:old", "public_job:new-1", "public_job:new-2"]
+                    },
+                    "diffs": [
+                      {"field": "added_count", "baseline_value": 0, "current_value": 2, "delta": 2, "direction": "increase"},
+                      {"field": "ongoing_added_count", "baseline_value": 0, "current_value": 2, "delta": 2, "direction": "increase"},
+                      {"field": "count", "baseline_value": 3, "current_value": 5, "delta": 2, "change_rate": 66.67, "direction": "increase"}
+                    ],
+                    "briefing_postings_by_source": {
+                      "public_job": [
+                        {"posting_id": "public_job:new-1", "title": "국토연구원 전산직 채용", "url": "https://example.com/jobs/new-1"},
+                        {"posting_id": "public_job:new-2", "title": "한국도로공사 백엔드 채용", "url": "https://example.com/jobs/new-2"}
+                      ],
+                      "worknet_job": []
+                    },
+                    "condition_satisfied": true,
+                    "requires_ai_analysis": true
+                  }
+                }
+                """;
+        List<Execution> executions = List.of(
+                new Execution("compare_subscription_change", """
+                        {"input":{"subscriptionId":"sub-job-wrapper","domain":"recruitment","query":"공공기관 채용 새 공고","params":{"conditionMetric":"COUNT","conditionDirection":"UP","conditionOperator":"GTE","conditionThreshold":"1","conditionUnit":"COUNT","dataToolName":"search_public_job"}}}
+                        """, objectMapper.writeValueAsString(List.of(Map.of("text", comparePayload))), false)
+        );
+
+        String enriched = NotificationBriefingPayloadFactory.enrichSendNotificationInput(
+                rawInput,
+                executions,
+                objectMapper
+        );
+
+        JsonNode briefing = objectMapper.readTree(enriched).path("input").path("metadata").path("briefing");
+
+        assertThat(briefing.path("sources")).hasSize(2);
+        assertThat(briefing.path("sources").get(0).path("label").asText()).isEqualTo("국토연구원 전산직 채용");
+        assertThat(briefing.path("sources").get(0).path("url").asText()).isEqualTo("https://example.com/jobs/new-1");
+        assertThat(briefing.path("changes").findValuesAsText("label"))
+                .contains("신규 공고 수", "신규 진행중 공고 수", "전체 공고 수", "데이터 출처");
+        briefing.path("changes").forEach(change -> assertThat(change.has("label")
+                && change.has("value")
+                && change.has("previous")
+                && change.has("current")).isTrue());
+    }
+
+    @Test
+    @DisplayName("채용 신규 공고 URL이 없으면 데이터 도구 source_url을 briefing source fallback으로 사용한다")
+    void enrichesRecruitmentSourceFromDataToolSourceUrlWhenPostingUrlsAreMissing() throws Exception {
+        String rawInput = """
+                {
+                  "input": {
+                    "subscriptionId": "sub-job-source-fallback",
+                    "notificationChannel": "EMAIL",
+                    "notificationTarget": "user@example.com",
+                    "title": "공공기관 채용 새 공고",
+                    "message": "새로운 채용 공고가 감지되었습니다.",
+                    "metadata": {
+                      "briefingContractVersion": "channel-v1",
+                      "briefing": {
+                        "domain": "recruitment",
+                        "title": "공공기관 채용 새 공고",
+                        "summary": "새로운 채용 공고가 감지되었습니다.",
+                        "interpretation": "마감일과 지원 자격을 확인하세요."
+                      }
+                    }
+                  }
+                }
+                """;
+        List<Execution> executions = List.of(
+                new Execution("search_public_job", """
+                        {"input":{"page_no":1,"num_of_rows":20,"ongoing_yn":"Y"}}
+                        """, """
+                        {"structured":{"summary":{"count":20,"ongoing_count":20},"query":{"page_no":1,"num_of_rows":20,"ongoing_yn":"Y"}},"source_url":"https://apis.data.go.kr/1051000/recruitment/list?serviceKey=***","metadata":{"tool_name":"search_public_job"}}
+                        """, false),
+                new Execution("compare_subscription_change", """
+                        {"input":{"subscriptionId":"sub-job-source-fallback","domain":"recruitment","query":"공공기관 채용 새 공고","params":{"conditionMetric":"COUNT","conditionDirection":"UP","conditionOperator":"GTE","conditionThreshold":"1","conditionUnit":"COUNT","dataToolName":"search_public_job"}}}
+                        """, """
+                        {"structured":{"baseline_initialized":false,"changed":true,"subscriptionId":"sub-job-source-fallback","domain":"recruitment","baseline_summary":{"count":0,"ongoing_count":0,"posting_ids":[],"ongoing_posting_ids":[]},"current_summary":{"count":20,"ongoing_count":20,"posting_ids":["public_job:new"],"ongoing_posting_ids":["public_job:new"]},"diffs":[{"field":"added_count","baseline_value":0,"current_value":20,"delta":20,"direction":"increase"}],"briefing_postings_by_source":{"public_job":[{"posting_id":"public_job:new","title":"URL 없는 공공기관 채용","url":null}],"worknet_job":[]},"condition_satisfied":true,"requires_ai_analysis":true}}
+                        """, false)
+        );
+
+        String enriched = NotificationBriefingPayloadFactory.enrichSendNotificationInput(
+                rawInput,
+                executions,
+                objectMapper
+        );
+
+        JsonNode briefing = objectMapper.readTree(enriched).path("input").path("metadata").path("briefing");
+
+        assertThat(briefing.path("sources")).hasSize(1);
+        assertThat(briefing.path("sources").get(0).path("label").asText()).isEqualTo("공공채용");
+        assertThat(briefing.path("sources").get(0).path("url").asText())
+                .isEqualTo("https://apis.data.go.kr/1051000/recruitment/list?serviceKey=***");
     }
 }


### PR DESCRIPTION
**🔗 Issue 번호**

- Close #179

**🛠 작업 내역**

NotificationBriefingPayloadFactory에서 MCP tool output이 [{"text":"{...json...}"}] 형태로 감싸져도 내부 JSON의 structured를 재파싱하도록 수정

채용 브리핑 sources를 AI 생성값에 의존하지 않고 compare_subscription_change의 briefing_postings_by_source.public_job/worknet_job 기반으로 생성

채용 공고별 URL이 없는 경우 data tool의 source_url을 fallback source로 사용하도록 보강

**✅ 체크리스트**

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?